### PR TITLE
docs: Figma backlog tracking in DESIGN.md

### DIFF
--- a/.github/DESIGN.md
+++ b/.github/DESIGN.md
@@ -14,9 +14,26 @@ Single place for **Figma** links and design↔engineering workflow for the Studi
 
 - **P0 Cost** — 비용 요약 카드, 예상 크레딧, 면책 문구
 - **P1 Scene table** — 씬 테이블 밀도, 씬별 예상 비용
+- **P2 Preflight** — 실행 전 확인, 부분 렌더, 실패 안내
+- **P3 Format and budget** — 포맷 프리셋, 예산 가드
 - **Explorations** — 실험·대안 레이아웃
 
 > Tip: Link a specific frame in GitHub issues with *Share → Copy link* on the frame (URL will include `node-id=`).
+
+## Figma backlog (GitHub)
+
+Epic: [#1 — Studio · Scene render · cost & UX](https://github.com/plancy-dev/elevate/issues/1).  
+아래 이슈에 **문장형 수락 기준**이 있으며, 완료 시 본 표의 **대표 프레임** 열을 프레임 URL(`node-id=` 포함)로 갱신한다. 전체 동기화·검수는 [#10](https://github.com/plancy-dev/elevate/issues/10).
+
+| Phase | GitHub issue | Representative frame (update when issue closes) |
+|-------|----------------|--------------------------------------------------|
+| Foundation — pages & cover | [#4](https://github.com/plancy-dev/elevate/issues/4) | TBD |
+| P0 Cost | [#5](https://github.com/plancy-dev/elevate/issues/5) | TBD |
+| P1 Scene table | [#6](https://github.com/plancy-dev/elevate/issues/6) | TBD |
+| P2 Preflight | [#7](https://github.com/plancy-dev/elevate/issues/7) | TBD |
+| P3 Format & budget | [#8](https://github.com/plancy-dev/elevate/issues/8) | TBD |
+| Explorations | [#9](https://github.com/plancy-dev/elevate/issues/9) | TBD (optional) |
+| DESIGN.md ↔ Figma links | [#10](https://github.com/plancy-dev/elevate/issues/10) | Close #10 when the TBD cells above are filled and verified |
 
 ## GitHub workflow (this repo)
 


### PR DESCRIPTION
## Summary
Adds **Figma backlog (GitHub)** section to [`.github/DESIGN.md`](.github/DESIGN.md): links to issues [#4](https://github.com/plancy-dev/elevate/issues/4)–[#10](https://github.com/plancy-dev/elevate/issues/10), expands recommended **Pages** (P2, P3), and a **Representative frame** column (TBD until design issues close).

## Refs
Refs #10  
Refs #1

## Note
[#10](https://github.com/plancy-dev/elevate/issues/10) remains **open** until P0–P3 frame URLs from [#5](https://github.com/plancy-dev/elevate/issues/5)–[#8](https://github.com/plancy-dev/elevate/issues/8) are pasted into the table and verified.

Made with [Cursor](https://cursor.com)