### PR TITLE
feat(studio): estimated Runway credits before scene render

### DIFF
--- a/.github/DESIGN.md
+++ b/.github/DESIGN.md
@@ -35,6 +35,8 @@ Epic: [#1 — Studio · Scene render · cost & UX](https://github.com/plancy-dev
 | Explorations | [#9](https://github.com/plancy-dev/elevate/issues/9) | TBD (optional) |
 | DESIGN.md ↔ Figma links | [#10](https://github.com/plancy-dev/elevate/issues/10) | Close #10 when the TBD cells above are filled and verified |
 
+**Product (code, separate from Figma frames):** estimated Runway credits before scene render — [#12](https://github.com/plancy-dev/elevate/issues/12).
+
 ## GitHub workflow (this repo)
 
 - **Milestones:** `Scene render · P0` … `Scene render · P3` — group issues by delivery phase.

--- a/messages/en.json
+++ b/messages/en.json
@@ -1540,6 +1540,8 @@
       "pipelineScenePlanLlmNeedScript": "Save script text in the Draft step first.",
       "pipelineSceneBudgetSoftWarning": "Planned total duration is {seconds}s (high). Proceed if intentional.",
       "pipelineSceneBrandGuideOn": "Project brand guide will be merged into Runway visual prompts.",
+      "pipelineSceneEstimatedCredits": "Estimated Runway credits (before render): ~{credits}",
+      "pipelineSceneEstimatedCreditsDisclaimer": "Illustrative only — actual usage and billing are shown in your Runway account.",
       "pipelineSceneRunwayVideoModelLabel": "Runway video model",
       "pipelineSceneRunwayVideoModelHint": "Used for each scene clip when you run Scene render. Veo models use HD aspect presets; duration follows your scene plan (Veo 3 / 3.1 use 4, 6, or 8 seconds).",
       "pipelineSceneRunwayModelGen45": "Gen-4.5",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1532,6 +1532,8 @@
       "pipelineScenePlanLlmNeedScript": "先に下書きステップでスクリプトを保存してください。",
       "pipelineSceneBudgetSoftWarning": "計画された合計時間は {seconds} 秒です（高め）。意図的な場合のみ続行してください。",
       "pipelineSceneBrandGuideOn": "プロジェクトのブランドガイドが Runway のビジュアルプロンプトにマージされます。",
+      "pipelineSceneEstimatedCredits": "推定 Runway クレジット（レンダー前）: 約 {credits}",
+      "pipelineSceneEstimatedCreditsDisclaimer": "目安です。実際の利用・請求は Runway アカウントでご確認ください。",
       "pipelineSceneRunwayVideoModelLabel": "Runway 動画モデル",
       "pipelineSceneRunwayVideoModelHint": "シーンレンダー実行時に各クリップで使われます。Veo は HD のアスペクトプリセットを使い、長さはシーン計画に従います（Veo 3 / 3.1 は 4・6・8 秒）。",
       "pipelineSceneRunwayModelGen45": "Gen-4.5",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1540,6 +1540,8 @@
       "pipelineScenePlanLlmNeedScript": "먼저 초안 단계에서 스크립트를 저장하세요.",
       "pipelineSceneBudgetSoftWarning": "계획된 총 길이가 {seconds}초입니다(높음). 의도한 경우에만 진행하세요.",
       "pipelineSceneBrandGuideOn": "프로젝트 브랜드 가이드가 Runway 비주얼 프롬프트에 합쳐집니다.",
+      "pipelineSceneEstimatedCredits": "예상 Runway 크레딧(렌더 전): ~{credits}",
+      "pipelineSceneEstimatedCreditsDisclaimer": "참고용 추정치이며, 실제 사용량·과금은 Runway 계정에서 확인하세요.",
       "pipelineSceneRunwayVideoModelLabel": "Runway 비디오 모델",
       "pipelineSceneRunwayVideoModelHint": "씬 렌더 실행 시 각 클립에 사용됩니다. Veo 모델은 HD 비율 프리셋을 쓰며, 길이는 씬 계획을 따릅니다(Veo 3 / 3.1은 4·6·8초).",
       "pipelineSceneRunwayModelGen45": "Gen-4.5",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -1532,6 +1532,8 @@
       "pipelineScenePlanLlmNeedScript": "请先在初稿步骤保存脚本。",
       "pipelineSceneBudgetSoftWarning": "计划总时长为 {seconds} 秒（偏高）。请确认后再继续。",
       "pipelineSceneBrandGuideOn": "项目品牌指南将合并到 Runway 视觉提示词中。",
+      "pipelineSceneEstimatedCredits": "预估 Runway 点数（渲染前）：约 {credits}",
+      "pipelineSceneEstimatedCreditsDisclaimer": "仅供参考；实际用量与计费以 Runway 账户为准。",
       "pipelineSceneRunwayVideoModelLabel": "Runway 视频模型",
       "pipelineSceneRunwayVideoModelHint": "运行场景渲染时用于每个片段。Veo 模型使用高清比例预设；时长遵循场景计划（Veo 3 / 3.1 为 4、6 或 8 秒）。",
       "pipelineSceneRunwayModelGen45": "Gen-4.5",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -1532,6 +1532,8 @@
       "pipelineScenePlanLlmNeedScript": "請先在初稿步驟儲存腳本。",
       "pipelineSceneBudgetSoftWarning": "計畫總長度為 {seconds} 秒（偏高）。請確認後再繼續。",
       "pipelineSceneBrandGuideOn": "專案品牌指南將合併到 Runway 視覺提示詞中。",
+      "pipelineSceneEstimatedCredits": "預估 Runway 點數（算繪前）：約 {credits}",
+      "pipelineSceneEstimatedCreditsDisclaimer": "僅供參考；實際用量與計費以 Runway 帳戶為準。",
       "pipelineSceneRunwayVideoModelLabel": "Runway 影片模型",
       "pipelineSceneRunwayVideoModelHint": "執行場景算繪時用於每個片段。Veo 模型使用 HD 比例預設；長度依場景計畫（Veo 3 / 3.1 為 4、6 或 8 秒）。",
       "pipelineSceneRunwayModelGen45": "Gen-4.5",

--- a/src/components/dashboard/scene-render-pipeline-step.tsx
+++ b/src/components/dashboard/scene-render-pipeline-step.tsx
@@ -19,6 +19,8 @@ import {
   parseRunwaySceneModelId,
   type RunwayTextToVideoModelId,
 } from "@/lib/studio-integrations/providers/runway/runway-scene-models";
+import { estimateSceneRenderCredits } from "@/lib/studio-integrations/providers/runway/runway-scene-credits-estimate";
+import { parseSceneRows } from "@/lib/studio-productions/scene-rows-json";
 import { Button } from "@/components/ui/button";
 import { toast } from "@/lib/ui/app-toast";
 import { cn } from "@/lib/utils";
@@ -30,13 +32,6 @@ const RUNWAY_MODEL_LABEL_KEYS: Record<RunwayTextToVideoModelId, string> = {
   "veo3.1": "pipelineSceneRunwayModelVeo31",
   "veo3.1_fast": "pipelineSceneRunwayModelVeo31Fast",
   veo3: "pipelineSceneRunwayModelVeo3",
-};
-
-type SceneRow = {
-  index: number;
-  narration: string;
-  visualPrompt: string;
-  durationSeconds: number;
 };
 
 type PerIndex = Record<number, "queued" | "running" | "ok" | "error">;
@@ -60,38 +55,6 @@ async function mapPool<T, R>(
     }),
   );
   return results;
-}
-
-function parseSceneRows(payload: string): SceneRow[] | null {
-  try {
-    const raw = JSON.parse(payload) as unknown;
-    if (!Array.isArray(raw)) return null;
-    const out: SceneRow[] = [];
-    for (const item of raw) {
-      if (typeof item !== "object" || item === null) return null;
-      const o = item as Record<string, unknown>;
-      const index = typeof o.index === "number" && Number.isFinite(o.index) ? o.index : -1;
-      const narration = typeof o.narration === "string" ? o.narration : "";
-      const visualPrompt =
-        typeof o.visualPrompt === "string"
-          ? o.visualPrompt
-          : typeof o.visual_prompt === "string"
-            ? o.visual_prompt
-            : "";
-      const dur =
-        typeof o.durationSeconds === "number"
-          ? o.durationSeconds
-          : typeof o.duration_seconds === "number"
-            ? o.duration_seconds
-            : 5;
-      if (index < 0 || !narration.trim() || !visualPrompt.trim()) return null;
-      out.push({ index, narration, visualPrompt, durationSeconds: dur });
-    }
-    out.sort((a, b) => a.index - b.index);
-    return out;
-  } catch {
-    return null;
-  }
 }
 
 export function SceneRenderPipelineStep({
@@ -169,6 +132,16 @@ export function SceneRenderPipelineStep({
     () => Object.values(rowStatus).some((s) => s === "error"),
     [rowStatus],
   );
+
+  const parsedSceneRowsForEstimate = useMemo(
+    () => parseSceneRows(scenesJsonControlled),
+    [scenesJsonControlled],
+  );
+
+  const estimatedRunwayCredits = useMemo(() => {
+    if (!parsedSceneRowsForEstimate?.length) return null;
+    return estimateSceneRenderCredits(runwayModel, parsedSceneRowsForEstimate);
+  }, [parsedSceneRowsForEstimate, runwayModel]);
 
   const selectedPlanModelLabel = useMemo(
     () =>
@@ -456,6 +429,16 @@ export function SceneRenderPipelineStep({
         <p className="mt-1.5 text-[10px] text-text-tertiary leading-relaxed pl-7">
           {t("pipelineSceneBrandGuideOn")}
         </p>
+      ) : null}
+      {!disabled && estimatedRunwayCredits != null ? (
+        <div className="mt-1.5 space-y-0.5 pl-7">
+          <p className="text-[11px] font-medium text-text-secondary leading-snug">
+            {t("pipelineSceneEstimatedCredits", { credits: estimatedRunwayCredits })}
+          </p>
+          <p className="text-[10px] text-text-tertiary leading-relaxed">
+            {t("pipelineSceneEstimatedCreditsDisclaimer")}
+          </p>
+        </div>
       ) : null}
 
       {!disabled ? (

--- a/src/lib/studio-integrations/providers/runway/runway-scene-credits-estimate.ts
+++ b/src/lib/studio-integrations/providers/runway/runway-scene-credits-estimate.ts
@@ -1,0 +1,31 @@
+/**
+ * Illustrative Runway **credits per second** by text-to-video model for UI estimates only.
+ * Runway may change pricing; actual usage appears in the Runway dashboard — do not treat as billing truth.
+ */
+import type { RunwayTextToVideoModelId } from "@/lib/studio-integrations/providers/runway/runway-scene-models";
+import type { SceneRow } from "@/lib/studio-productions/scene-rows-json";
+
+/** Rough relative cost for UX preview (credits × seconds ≈ order of magnitude). */
+export const RUNWAY_SCENE_CREDITS_PER_SECOND_ESTIMATE: Record<RunwayTextToVideoModelId, number> =
+  {
+    "gen4.5": 5,
+    "veo3.1": 8,
+    "veo3.1_fast": 6,
+    veo3: 7,
+  };
+
+/**
+ * Sum of (per-second rate × scene duration) for all scenes — integer credits, rounded up per scene.
+ */
+export function estimateSceneRenderCredits(
+  modelId: RunwayTextToVideoModelId,
+  scenes: Pick<SceneRow, "durationSeconds">[],
+): number {
+  const rate = RUNWAY_SCENE_CREDITS_PER_SECOND_ESTIMATE[modelId];
+  let total = 0;
+  for (const s of scenes) {
+    const sec = Math.max(0, Number(s.durationSeconds) || 0);
+    total += Math.ceil(sec * rate);
+  }
+  return total;
+}

--- a/src/lib/studio-productions/scene-rows-json.ts
+++ b/src/lib/studio-productions/scene-rows-json.ts
@@ -1,0 +1,42 @@
+/**
+ * Client-safe parse of episode scene plan JSON (same shape as server `resolveEpisodeScenes`).
+ */
+
+export type SceneRow = {
+  index: number;
+  narration: string;
+  visualPrompt: string;
+  durationSeconds: number;
+};
+
+export function parseSceneRows(payload: string): SceneRow[] | null {
+  try {
+    const raw = JSON.parse(payload) as unknown;
+    if (!Array.isArray(raw)) return null;
+    const out: SceneRow[] = [];
+    for (const item of raw) {
+      if (typeof item !== "object" || item === null) return null;
+      const o = item as Record<string, unknown>;
+      const index = typeof o.index === "number" && Number.isFinite(o.index) ? o.index : -1;
+      const narration = typeof o.narration === "string" ? o.narration : "";
+      const visualPrompt =
+        typeof o.visualPrompt === "string"
+          ? o.visualPrompt
+          : typeof o.visual_prompt === "string"
+            ? o.visual_prompt
+            : "";
+      const dur =
+        typeof o.durationSeconds === "number"
+          ? o.durationSeconds
+          : typeof o.duration_seconds === "number"
+            ? o.duration_seconds
+            : 5;
+      if (index < 0 || !narration.trim() || !visualPrompt.trim()) return null;
+      out.push({ index, narration, visualPrompt, durationSeconds: dur });
+    }
+    out.sort((a, b) => a.index - b.index);
+    return out;
+  } catch {
+    return null;
+  }
+}

--- a/tests/unit/runway-scene-credits-estimate.test.ts
+++ b/tests/unit/runway-scene-credits-estimate.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  estimateSceneRenderCredits,
+  RUNWAY_SCENE_CREDITS_PER_SECOND_ESTIMATE,
+} from "@/lib/studio-integrations/providers/runway/runway-scene-credits-estimate";
+
+describe("estimateSceneRenderCredits", () => {
+  it("sums ceil(duration * rate) per scene for gen4.5", () => {
+    const rate = RUNWAY_SCENE_CREDITS_PER_SECOND_ESTIMATE["gen4.5"];
+    const scenes = [{ durationSeconds: 4 }, { durationSeconds: 6 }];
+    const expected = Math.ceil(4 * rate) + Math.ceil(6 * rate);
+    expect(estimateSceneRenderCredits("gen4.5", scenes)).toBe(expected);
+  });
+
+  it("returns 0 for empty scenes", () => {
+    expect(estimateSceneRenderCredits("veo3.1", [])).toBe(0);
+  });
+
+  it("treats invalid duration as 0", () => {
+    expect(estimateSceneRenderCredits("veo3", [{ durationSeconds: NaN }])).toBe(0);
+  });
+});

--- a/tests/unit/scene-rows-json.test.ts
+++ b/tests/unit/scene-rows-json.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { parseSceneRows } from "@/lib/studio-productions/scene-rows-json";
+
+describe("parseSceneRows", () => {
+  it("parses valid array with snake_case duration", () => {
+    const j = JSON.stringify([
+      {
+        index: 0,
+        narration: "a",
+        visual_prompt: "b",
+        duration_seconds: 8,
+      },
+    ]);
+    const rows = parseSceneRows(j);
+    expect(rows).toHaveLength(1);
+    expect(rows![0].durationSeconds).toBe(8);
+  });
+
+  it("returns null for invalid json", () => {
+    expect(parseSceneRows("not json")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Show **estimated Runway credits** on the scene render pipeline step when `scenes_json` parses and Runway is enabled (before run).
- **Illustrative** per-second rates per model in `runway-scene-credits-estimate.ts` + disclaimer copy (i18n).
- Extract `parseSceneRows` to `scene-rows-json.ts` for reuse and tests.

## Closes
Closes #12

## Refs
Refs #1

Made with [Cursor](https://cursor.com)