### PR TITLE
fix(studio): add Runway I2V credit preflight and stale job recovery

### DIFF
--- a/docs/VIDEO_ASSEMBLY_WORKER.md
+++ b/docs/VIDEO_ASSEMBLY_WORKER.md
@@ -12,11 +12,13 @@ Vercel (Next.js) and this worker **do not call each other over HTTP**. They shar
 | `SUPABASE_SERVICE_ROLE_KEY` | Yes | Server-only; worker uses RPC + storage + inserts. |
 | `CONTENT_STORAGE_BUCKET` | Yes | Same bucket name as Next.js; objects under `studio-assembled/...`. |
 | `WORKER_POLL_IDLE_MS` | No | Idle delay when no job (default `2500`). |
+| `WORKER_STALE_JOB_MINUTES` | No | Reclaim threshold for stuck `processing` jobs (default `30`). |
+| `WORKER_STALE_RECOVERY_EVERY_LOOPS` | No | How often stale recovery runs in poll loop (default `10`). |
 | `PORT` | Fly.io only | Set automatically on Fly; enables `GET /health` for platform checks. |
 | `VIDEO_ASSEMBLY_SUBTITLE_FONT` | No | libass `Fontname` for SRT burn-in (default `Noto Sans CJK KR`). Must match a font family installed on the host. |
 | `VIDEO_ASSEMBLY_SUBTITLE_FONTSDIR` | No | Optional extra directory passed to FFmpeg `subtitles=...:fontsdir=...` if fontconfig cannot find the font. |
 
-Apply migrations **`034`** (jobs table + RLS + claim RPC) and **`035`** (Realtime broadcast for dashboard progress) to your Supabase project before relying on production assembly. The dashboard uses Realtime for job updates and falls back to slower HTTP polling if Realtime is unavailable.
+Apply migrations **`034`** (jobs table + RLS + claim RPC), **`035`** (Realtime broadcast), and **`044`** (stale recovery + retry fields) before relying on production assembly. The dashboard uses Realtime for job updates and falls back to slower HTTP polling if Realtime is unavailable.
 
 ## Incident triage (runbook)
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -19,6 +19,7 @@
 **품질 게이트:** `pnpm typecheck` · `pnpm lint` · `pnpm test`(325) · `pnpm test:e2e tests/e2e/auth-*` green. live-phase* 는 Buffer 채널 prerequisite 외에는 결정적 동작.
 
 **PR-1 (데이터 정합성) 진행 메모 · 2026-04-27:** Supabase 로컬 마이그레이션 번호 충돌(`013`/`014`)은 최신 생성 파일을 `042`/`043`으로 renumber 처리. `studio_org_provider_connections.provider` CHECK는 `025`·`030`·`038`·`040`에서 이미 확장되어 현재 코드 기준 enum 드리프트 이슈는 해소됨.
+**PR-2 (Studio 견고성) 진행 메모 · 2026-04-27:** Runway I2V는 `organization.retrieve()` 기반 크레딧 preflight를 추가했고, `studio_video_assembly_jobs`는 `044` 마이그레이션으로 stale recovery RPC/`retry_count`를 도입해 워커 시작·주기 실행 시 stuck `processing` 잡을 자동 회수한다.
 
 **다음 후보:**
 

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -428,6 +428,7 @@
 | P1 | **시각 언어 v2** — [`docs/design/VISUAL_LANGUAGE_V2.md`](../docs/design/VISUAL_LANGUAGE_V2.md) 롤아웃 · [`PLAN_VISUAL_LANGUAGE_V2_ROLLOUT.md`](../docs/design/PLAN_VISUAL_LANGUAGE_V2_ROLLOUT.md) | ✅ PR-1–5 + 문서/PR-6(부분) 반영(2026-04); 스테이징 스크린샷·감사 리포트 갱신은 선택 |
 | P1 | **대시보드 단일 표면 UX** — [`docs/design/DASHBOARD_UX_PRINCIPLES.md`](../docs/design/DASHBOARD_UX_PRINCIPLES.md) | ✅ 개요·라이브러리·설정·스튜디오·프로덕션 목록 등(2026-04); 팀·빌링 등은 동일 패턴으로 확장 가능 |
 | P1 | **PROJECT_OVERVIEW §9 권고 1·2 (데이터 정합성)** — 마이그레이션 번호 충돌 + provider CHECK 드리프트 점검 | ✅ `013/014` 충돌 파일을 `042/043`으로 renumber, provider CHECK는 `025/030/038/040`로 이미 확장됨 |
+| P1 | **PROJECT_OVERVIEW §9 권고 3·4 (Studio 견고성)** — Runway 크레딧 사전검증 + stale assembly job 회수 | ✅ Runway `organization.retrieve()` preflight + `044` stale recovery RPC(`retry_count`/`max_retries`) + 워커 주기 회수 |
 | P1 | PostHog 대시보드(퍼널 시각화) | 이벤트: `elevate_funnel_*`, `elevate_waitlist_*`, `elevate_marketing_cta_click`, `elevate_blog_post_viewed` — [`docs/POSTHOG_FUNNELS.md`](../docs/POSTHOG_FUNNELS.md) 참고 후 UI에서 구성 |
 | P1 | E2E CI — PR에 `run-e2e` 라벨 또는 수동 workflow | `e2e.yml` |
 | P2 | **대시보드 접근 게이트** — `profiles.dashboard_access` · [`src/lib/auth/dashboard-access.ts`](../src/lib/auth/dashboard-access.ts) · `/access-pending` · PKCE 콜백 정리 | ✅ (2026-04) 마이그레이션 `037` + 서버 `SUPABASE_SERVICE_ROLE_KEY`; REFLECT [`archive/work-history/reflect-dashboard-access-pkce-2026-04.md`](archive/work-history/reflect-dashboard-access-pkce-2026-04.md) |

--- a/src/actions/studio-scene-i2v.ts
+++ b/src/actions/studio-scene-i2v.ts
@@ -14,6 +14,8 @@ import {
   RUNWAY_I2V_MODELS,
   parseRunwayI2VModelId,
 } from "@/lib/studio-integrations/providers/runway/runway-i2v-models";
+import { checkRunwayCredits } from "@/lib/studio-integrations/providers/runway/runway-credits";
+import { estimateRunwayI2VCreditsForDuration } from "@/lib/studio-integrations/providers/runway/runway-i2v-credits-estimate";
 import { parseCharacterBible } from "@/lib/studio-productions/character-bible";
 import { buildSceneI2VPrompt } from "@/lib/studio-productions/scene-i2v-prompt";
 import { parseSceneKeyframeMetadata } from "@/lib/studio-productions/scene-keyframe-metadata";
@@ -143,6 +145,17 @@ export async function renderSceneWithI2V(
     endStateHint: endStateHint || undefined,
     modelSupportsLastFrame: cap.supportsLastFrame,
   });
+
+  // Prefer deterministic org credit preflight over fragile message matching.
+  // If preflight API fails, keep generation path + runtime fallback classification.
+  const estimatedCredits = estimateRunwayI2VCreditsForDuration(
+    model,
+    sceneRow.durationSeconds,
+  );
+  const creditCheck = await checkRunwayCredits(apiKey, estimatedCredits);
+  if (!creditCheck.ok && creditCheck.code === "insufficient_credits") {
+    return { error: ActionErrorCode.studioRunwayInsufficientCredits };
+  }
 
   const result = await runRunwayImageToVideo(apiKey, {
     promptText,

--- a/src/lib/studio-integrations/providers/runway/runway-credits.ts
+++ b/src/lib/studio-integrations/providers/runway/runway-credits.ts
@@ -1,0 +1,54 @@
+import "server-only";
+
+import RunwayML from "@runwayml/sdk";
+import { RUNWAY_API_VERSION } from "@/lib/studio-integrations/runway-verify";
+
+export type RunwayCreditCheckResult =
+  | { ok: true; creditBalance: number }
+  | {
+      ok: false;
+      code: "missing_key" | "insufficient_credits" | "api_error";
+      message?: string;
+      creditBalance?: number;
+    };
+
+/**
+ * Runway org credit preflight via `organization.retrieve()`.
+ * Falls back to runtime task errors if this call fails.
+ */
+export async function checkRunwayCredits(
+  apiKey: string,
+  estimatedCost: number,
+): Promise<RunwayCreditCheckResult> {
+  const key = apiKey.replace(/\s+/g, "").trim();
+  if (!key) return { ok: false, code: "missing_key", message: "missing_key" };
+
+  const client = new RunwayML({
+    apiKey: key,
+    runwayVersion: RUNWAY_API_VERSION,
+    maxRetries: 1,
+  });
+
+  try {
+    const org = await client.organization.retrieve();
+    const balance =
+      typeof org.creditBalance === "number" && Number.isFinite(org.creditBalance)
+        ? org.creditBalance
+        : NaN;
+    if (!Number.isFinite(balance)) {
+      return { ok: false, code: "api_error", message: "invalid_credit_balance" };
+    }
+    if (balance < estimatedCost) {
+      return {
+        ok: false,
+        code: "insufficient_credits",
+        message: `credit_balance=${balance}, estimated_cost=${estimatedCost}`,
+        creditBalance: balance,
+      };
+    }
+    return { ok: true, creditBalance: balance };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, code: "api_error", message: msg };
+  }
+}

--- a/src/lib/studio-integrations/providers/runway/runway-i2v-credits-estimate.ts
+++ b/src/lib/studio-integrations/providers/runway/runway-i2v-credits-estimate.ts
@@ -1,0 +1,26 @@
+import type { RunwayI2VModelId } from "./runway-i2v-models";
+
+/**
+ * Illustrative credits/sec estimates for I2V preflight checks.
+ * Keep these conservative and calibrate against Runway billing docs/dashboard.
+ */
+export const RUNWAY_I2V_CREDITS_PER_SECOND_ESTIMATE: Record<
+  RunwayI2VModelId,
+  number
+> = {
+  "veo3.1": 8,
+  "veo3.1_fast": 6,
+  gen3a_turbo: 5,
+  "gen4.5": 5,
+  gen4_turbo: 5,
+  veo3: 7,
+};
+
+export function estimateRunwayI2VCreditsForDuration(
+  modelId: RunwayI2VModelId,
+  durationSeconds: number,
+): number {
+  const rate = RUNWAY_I2V_CREDITS_PER_SECOND_ESTIMATE[modelId];
+  const sec = Math.max(0, Number(durationSeconds) || 0);
+  return Math.ceil(sec * rate);
+}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1446,8 +1446,11 @@ export type Database = {
           error_message: string | null
           id: string
           input: Json
+          max_retries: number
           organization_id: string
           output_artifact_id: string | null
+          processing_started_at: string | null
+          retry_count: number
           started_at: string | null
           status: string
           updated_at: string
@@ -1460,8 +1463,11 @@ export type Database = {
           error_message?: string | null
           id?: string
           input?: Json
+          max_retries?: number
           organization_id: string
           output_artifact_id?: string | null
+          processing_started_at?: string | null
+          retry_count?: number
           started_at?: string | null
           status: string
           updated_at?: string
@@ -1474,8 +1480,11 @@ export type Database = {
           error_message?: string | null
           id?: string
           input?: Json
+          max_retries?: number
           organization_id?: string
           output_artifact_id?: string | null
+          processing_started_at?: string | null
+          retry_count?: number
           started_at?: string | null
           status?: string
           updated_at?: string
@@ -1720,6 +1729,13 @@ export type Database = {
       claim_studio_video_assembly_job: {
         Args: Record<PropertyKey, never>
         Returns: Database["public"]["Tables"]["studio_video_assembly_jobs"]["Row"][]
+      }
+      reset_stale_studio_video_assembly_jobs: {
+        Args: { stale_before?: unknown }
+        Returns: {
+          failed_count: number
+          requeued_count: number
+        }[]
       }
       user_organization_id: { Args: never; Returns: string }
       user_role: {

--- a/supabase/migrations/044_studio_video_assembly_stale_recovery.sql
+++ b/supabase/migrations/044_studio_video_assembly_stale_recovery.sql
@@ -1,0 +1,104 @@
+-- Recover stale processing rows in studio_video_assembly_jobs.
+-- Worker crash safety: requeue old processing jobs, fail after max retries.
+
+alter table public.studio_video_assembly_jobs
+  add column if not exists retry_count int not null default 0;
+
+alter table public.studio_video_assembly_jobs
+  add column if not exists max_retries int not null default 3;
+
+alter table public.studio_video_assembly_jobs
+  add column if not exists processing_started_at timestamptz null;
+
+update public.studio_video_assembly_jobs
+set processing_started_at = started_at
+where processing_started_at is null
+  and started_at is not null;
+
+create or replace function public.claim_studio_video_assembly_job()
+returns setof public.studio_video_assembly_jobs
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  rid uuid;
+begin
+  select j.id into rid
+  from public.studio_video_assembly_jobs j
+  where j.status = 'pending'
+  order by j.created_at asc
+  for update skip locked
+  limit 1;
+
+  if rid is null then
+    return;
+  end if;
+
+  update public.studio_video_assembly_jobs
+  set
+    status = 'processing',
+    started_at = now(),
+    processing_started_at = now(),
+    updated_at = now()
+  where id = rid;
+
+  return query
+  select * from public.studio_video_assembly_jobs where id = rid;
+end;
+$$;
+
+create or replace function public.reset_stale_studio_video_assembly_jobs(
+  stale_before interval default interval '30 minutes'
+)
+returns table(requeued_count int, failed_count int)
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  return query
+  with stale as (
+    select
+      j.id,
+      j.retry_count,
+      j.max_retries
+    from public.studio_video_assembly_jobs j
+    where j.status = 'processing'
+      and coalesce(j.processing_started_at, j.started_at, j.updated_at)
+        < now() - stale_before
+    for update skip locked
+  ),
+  upd as (
+    update public.studio_video_assembly_jobs j
+    set
+      retry_count = j.retry_count + 1,
+      status = case
+        when (j.retry_count + 1) >= j.max_retries then 'failed'
+        else 'pending'
+      end,
+      error_message = case
+        when (j.retry_count + 1) >= j.max_retries
+          then concat_ws(' | ', nullif(j.error_message, ''), 'stale_timeout_max_retries')
+        else concat_ws(' | ', nullif(j.error_message, ''), 'stale_timeout_requeued')
+      end,
+      started_at = null,
+      processing_started_at = null,
+      completed_at = case
+        when (j.retry_count + 1) >= j.max_retries then now()
+        else null
+      end,
+      updated_at = now()
+    from stale s
+    where j.id = s.id
+    returning j.status
+  )
+  select
+    count(*) filter (where status = 'pending')::int as requeued_count,
+    count(*) filter (where status = 'failed')::int as failed_count
+  from upd;
+end;
+$$;
+
+revoke all on function public.reset_stale_studio_video_assembly_jobs(interval) from public;
+grant execute on function public.reset_stale_studio_video_assembly_jobs(interval) to service_role;

--- a/tests/unit/runway-i2v-credits-estimate.test.ts
+++ b/tests/unit/runway-i2v-credits-estimate.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import {
+  RUNWAY_I2V_CREDITS_PER_SECOND_ESTIMATE,
+  estimateRunwayI2VCreditsForDuration,
+} from "@/lib/studio-integrations/providers/runway/runway-i2v-credits-estimate";
+
+describe("estimateRunwayI2VCreditsForDuration", () => {
+  it("uses ceil(duration * rate)", () => {
+    const rate = RUNWAY_I2V_CREDITS_PER_SECOND_ESTIMATE["veo3.1"];
+    expect(estimateRunwayI2VCreditsForDuration("veo3.1", 6)).toBe(
+      Math.ceil(6 * rate),
+    );
+  });
+
+  it("returns 0 for invalid duration", () => {
+    expect(estimateRunwayI2VCreditsForDuration("gen4.5", NaN)).toBe(0);
+  });
+});

--- a/tests/unit/video-assembly-stale-recovery.test.ts
+++ b/tests/unit/video-assembly-stale-recovery.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { resetStaleVideoAssemblyJobs } from "../../workers/video-assembly/stale-recovery";
+
+describe("resetStaleVideoAssemblyJobs", () => {
+  it("maps rpc summary counts", async () => {
+    const rpc = vi.fn(async () => ({
+      data: [{ requeued_count: 2, failed_count: 1 }],
+      error: null,
+    }));
+    const summary = await resetStaleVideoAssemblyJobs(
+      { rpc } as unknown as Parameters<typeof resetStaleVideoAssemblyJobs>[0],
+      30,
+    );
+
+    expect(rpc).toHaveBeenCalledWith("reset_stale_studio_video_assembly_jobs", {
+      stale_before: "30 minutes",
+    });
+    expect(summary).toEqual({ requeuedCount: 2, failedCount: 1 });
+  });
+
+  it("throws when rpc fails", async () => {
+    const rpc = vi.fn(async () => ({
+      data: null,
+      error: { message: "boom" },
+    }));
+    await expect(
+      resetStaleVideoAssemblyJobs(
+        { rpc } as unknown as Parameters<typeof resetStaleVideoAssemblyJobs>[0],
+        30,
+      ),
+    ).rejects.toEqual({ message: "boom" });
+  });
+});

--- a/workers/video-assembly/run.ts
+++ b/workers/video-assembly/run.ts
@@ -14,6 +14,7 @@ import http from "node:http";
 
 import { createAdminClient } from "@/lib/supabase/admin";
 import { processVideoAssemblyJob } from "@/lib/studio-productions/process-video-assembly-job";
+import { resetStaleVideoAssemblyJobs } from "./stale-recovery";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
@@ -48,6 +49,36 @@ function pollMs(): number {
   return Number.isFinite(n) && n >= 200 ? n : 2500;
 }
 
+function staleMinutes(): number {
+  const raw = process.env.WORKER_STALE_JOB_MINUTES?.trim();
+  const n = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) && n >= 1 ? n : 30;
+}
+
+function staleRecoveryEveryLoops(): number {
+  const raw = process.env.WORKER_STALE_RECOVERY_EVERY_LOOPS?.trim();
+  const n = raw ? Number.parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) && n >= 1 ? n : 10;
+}
+
+async function maybeRecoverStaleJobs(
+  admin: ReturnType<typeof createAdminClient>,
+  staleMin: number,
+  reason: "startup" | "interval",
+): Promise<void> {
+  try {
+    const summary = await resetStaleVideoAssemblyJobs(admin, staleMin);
+    if (summary.requeuedCount > 0 || summary.failedCount > 0) {
+      console.info(
+        `[assembly-worker] stale-recovery(${reason}) requeued=${summary.requeuedCount} failed=${summary.failedCount}`,
+      );
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.warn(`[assembly-worker] stale-recovery(${reason}) failed:`, msg);
+  }
+}
+
 async function failJobCrash(
   admin: ReturnType<typeof createAdminClient>,
   jobId: string,
@@ -67,9 +98,22 @@ async function failJobCrash(
 async function runPollLoop(): Promise<void> {
   const admin = createAdminClient();
   const idle = pollMs();
+  const staleMin = staleMinutes();
+  const recoveryEvery = staleRecoveryEveryLoops();
   console.info(`[assembly-worker] poll loop started (idle ${idle}ms)`);
+  console.info(
+    `[assembly-worker] stale recovery: threshold=${staleMin}m every=${recoveryEvery} loops`,
+  );
+
+  await maybeRecoverStaleJobs(admin, staleMin, "startup");
+  let loop = 0;
 
   for (;;) {
+    loop += 1;
+    if (loop % recoveryEvery === 0) {
+      await maybeRecoverStaleJobs(admin, staleMin, "interval");
+    }
+
     const { data: rows, error } = await admin.rpc("claim_studio_video_assembly_job");
     if (error) {
       console.error("[assembly-worker] claim error:", error.message);

--- a/workers/video-assembly/stale-recovery.ts
+++ b/workers/video-assembly/stale-recovery.ts
@@ -1,0 +1,31 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database.types";
+
+export type StaleRecoverySummary = {
+  requeuedCount: number;
+  failedCount: number;
+};
+
+type ResetRpcRow = {
+  requeued_count?: number | null;
+  failed_count?: number | null;
+};
+
+export async function resetStaleVideoAssemblyJobs(
+  admin: SupabaseClient<Database>,
+  staleMinutes: number,
+): Promise<StaleRecoverySummary> {
+  const { data, error } = await admin.rpc(
+    "reset_stale_studio_video_assembly_jobs",
+    {
+      stale_before: `${Math.max(1, Math.floor(staleMinutes))} minutes`,
+    },
+  );
+  if (error) throw error;
+
+  const row = (Array.isArray(data) ? data[0] : null) as ResetRpcRow | null;
+  return {
+    requeuedCount: Number(row?.requeued_count ?? 0),
+    failedCount: Number(row?.failed_count ?? 0),
+  };
+}


### PR DESCRIPTION
## Summary
- Add deterministic Runway I2V credit preflight (`organization.retrieve()`) before generation, with estimated per-scene credits based on model + duration while keeping runtime error-classification fallback.
- Add migration `044_studio_video_assembly_stale_recovery.sql` to introduce `retry_count`/`max_retries`/`processing_started_at`, update claim RPC, and add `reset_stale_studio_video_assembly_jobs(interval)` recovery RPC.
- Update assembly worker to run stale recovery on startup and periodically during polling, with unit tests and worker runbook env documentation.

## Test plan
- [x] `pnpm verify`
- [ ] Apply migration `044` in target Supabase project.
- [ ] End-to-end smoke: enqueue assembly job -> kill worker while processing -> restart worker -> verify stale job is requeued or failed after max retries.

Made with [Cursor](https://cursor.com)