### PR TITLE
feat(studio): validate artifact metadata with zod schemas

### DIFF
--- a/docs/features/STUDIO_ARTIFACT_METADATA.md
+++ b/docs/features/STUDIO_ARTIFACT_METADATA.md
@@ -1,0 +1,31 @@
+# Studio Artifact Metadata Schemas
+
+`studio_production_artifacts.metadata` is intentionally flexible JSONB, but we now
+validate and normalize known shapes with zod at server-action write paths.
+
+Source of truth: `src/lib/studio-productions/artifact-metadata-schemas.ts`.
+
+## Role groups
+
+| Artifact roles | Schema |
+| --- | --- |
+| `hook`, `title`, `script`, `script_draft`, `prompt`, `settings`, `packaging_draft`, `social_captions`, `title_suggestion`, `compliance_note`, `reference_source` | `LlmMetadataSchema` |
+| `scene_keyframe_candidate`, `scene_keyframe_first`, `scene_keyframe_last`, `thumbnail` | `ImageGenMetadataSchema` |
+| `scene_clip` | `RunwayI2VMetadataSchema` |
+| `tts_audio` | `ElevenLabsTtsMetadataSchema` |
+| `assembled_video`, `render_output` | `FfmpegAssemblyMetadataSchema` |
+| `subtitle_srt`, `subtitle_vtt` | `SubtitleMetadataSchema` |
+
+## Compatibility policy
+
+- Validation mode is **lenient-first**:
+  - unknown keys are preserved (`.passthrough()`)
+  - numeric strings are coerced where meaningful
+  - parse failures fall back to original object instead of hard-failing writes
+- This keeps existing production rows compatible while enabling gradual tightening.
+
+## Lemon idempotency note
+
+`lemon_squeezy_processed_orders.ls_order_identifier` is already the table
+`PRIMARY KEY` (`018_lemon_squeezy_processed_orders.sql`), so no additional UNIQUE
+migration is required for order-level idempotency.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -19,6 +19,7 @@
 **품질 게이트:** `pnpm typecheck` · `pnpm lint` · `pnpm test`(325) · `pnpm test:e2e tests/e2e/auth-*` green. live-phase* 는 Buffer 채널 prerequisite 외에는 결정적 동작.
 
 **PR-1 (데이터 정합성) 진행 메모 · 2026-04-27:** Supabase 로컬 마이그레이션 번호 충돌(`013`/`014`)은 최신 생성 파일을 `042`/`043`으로 renumber 처리. `studio_org_provider_connections.provider` CHECK는 `025`·`030`·`038`·`040`에서 이미 확장되어 현재 코드 기준 enum 드리프트 이슈는 해소됨.
+**PR-3 (메타 검증) 진행 메모 · 2026-04-27:** `artifact-metadata-schemas.ts`에 role별 zod 스키마/디스패처를 도입해 `scene_clip`·`tts_audio`·`subtitle_srt`·`assembled_video`·`social_captions`·`scene_keyframe_*` write 경로에 느슨한 정규화를 적용했다. Lemon 주문 멱등성은 `018`의 `ls_order_identifier PRIMARY KEY`로 이미 충족됨을 확인.
 
 **다음 후보:**
 

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -428,6 +428,7 @@
 | P1 | **시각 언어 v2** — [`docs/design/VISUAL_LANGUAGE_V2.md`](../docs/design/VISUAL_LANGUAGE_V2.md) 롤아웃 · [`PLAN_VISUAL_LANGUAGE_V2_ROLLOUT.md`](../docs/design/PLAN_VISUAL_LANGUAGE_V2_ROLLOUT.md) | ✅ PR-1–5 + 문서/PR-6(부분) 반영(2026-04); 스테이징 스크린샷·감사 리포트 갱신은 선택 |
 | P1 | **대시보드 단일 표면 UX** — [`docs/design/DASHBOARD_UX_PRINCIPLES.md`](../docs/design/DASHBOARD_UX_PRINCIPLES.md) | ✅ 개요·라이브러리·설정·스튜디오·프로덕션 목록 등(2026-04); 팀·빌링 등은 동일 패턴으로 확장 가능 |
 | P1 | **PROJECT_OVERVIEW §9 권고 1·2 (데이터 정합성)** — 마이그레이션 번호 충돌 + provider CHECK 드리프트 점검 | ✅ `013/014` 충돌 파일을 `042/043`으로 renumber, provider CHECK는 `025/030/038/040`로 이미 확장됨 |
+| P1 | **PROJECT_OVERVIEW §9 권고 5·6 (메타 검증)** — artifact metadata zod + Lemon 멱등성 확인 | ✅ role별 zod 느슨한 검증 도입(`artifact-metadata-schemas.ts`), Lemon `ls_order_identifier`는 `018`에서 PK로 이미 멱등성 충족 |
 | P1 | PostHog 대시보드(퍼널 시각화) | 이벤트: `elevate_funnel_*`, `elevate_waitlist_*`, `elevate_marketing_cta_click`, `elevate_blog_post_viewed` — [`docs/POSTHOG_FUNNELS.md`](../docs/POSTHOG_FUNNELS.md) 참고 후 UI에서 구성 |
 | P1 | E2E CI — PR에 `run-e2e` 라벨 또는 수동 workflow | `e2e.yml` |
 | P2 | **대시보드 접근 게이트** — `profiles.dashboard_access` · [`src/lib/auth/dashboard-access.ts`](../src/lib/auth/dashboard-access.ts) · `/access-pending` · PKCE 콜백 정리 | ✅ (2026-04) 마이그레이션 `037` + 서버 `SUPABASE_SERVICE_ROLE_KEY`; REFLECT [`archive/work-history/reflect-dashboard-access-pkce-2026-04.md`](archive/work-history/reflect-dashboard-access-pkce-2026-04.md) |

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "react-dom": "19.2.4",
     "resend": "^6.10.0",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@playwright/test':
         specifier: ^1.58.2

--- a/src/actions/studio-scene-i2v.ts
+++ b/src/actions/studio-scene-i2v.ts
@@ -20,6 +20,7 @@ import { parseSceneKeyframeMetadata } from "@/lib/studio-productions/scene-keyfr
 import { scenePlanRowsFromPipelinePrefs } from "@/lib/studio-productions/episode-scene-plan-dto";
 import { resolveEpisodeFormat, FORMAT_SPECS } from "@/lib/studio-productions/episode-format";
 import { STUDIO_CONTENT_TEXT_MAX } from "@/lib/studio-productions/constants";
+import { normalizeArtifactMetadataForWrite } from "@/lib/studio-productions/artifact-metadata-schemas";
 import { logAudit } from "@/lib/audit/log";
 import { AuditAction, AuditEntityType } from "@/lib/audit/constants";
 import type { Json } from "@/types/database.types";
@@ -193,7 +194,7 @@ export async function renderSceneWithI2V(
       tool_platform: "runway",
       content_text: content,
       external_url: primaryUrl.length > 0 ? primaryUrl : null,
-      metadata: {
+      metadata: normalizeArtifactMetadataForWrite("scene_clip", {
         source: "runway_i2v",
         runway_task_id: result.task_id,
         output_urls: result.output_urls,
@@ -205,7 +206,7 @@ export async function renderSceneWithI2V(
         first_frame_url: firstUrl,
         last_frame_url: cap.supportsLastFrame ? lastUrl : null,
         prompt_used: promptText,
-      } as Json,
+      } as Json),
       sort_order: nextOrder,
     })
     .select("id")

--- a/src/actions/studio-scene-images.ts
+++ b/src/actions/studio-scene-images.ts
@@ -35,6 +35,7 @@ import { scenePlanRowsFromPipelinePrefs } from "@/lib/studio-productions/episode
 import { resolveEpisodeFormat, FORMAT_SPECS } from "@/lib/studio-productions/episode-format";
 import { isSceneKeyframeRole } from "@/lib/studio-productions/artifact-roles";
 import { STUDIO_CONTENT_TEXT_MAX } from "@/lib/studio-productions/constants";
+import { normalizeArtifactMetadataForWrite } from "@/lib/studio-productions/artifact-metadata-schemas";
 import { logAudit } from "@/lib/audit/log";
 import { AuditAction, AuditEntityType } from "@/lib/audit/constants";
 import type { Database, Json } from "@/types/database.types";
@@ -249,7 +250,10 @@ export async function generateSceneKeyframes(
         tool_platform: provider,
         content_text: `scene ${sceneIndex}: keyframe candidate`,
         external_url: upload.publicUrl,
-        metadata: serializeSceneKeyframeMetadata(meta) as Json,
+        metadata: normalizeArtifactMetadataForWrite(
+          "scene_keyframe_candidate",
+          serializeSceneKeyframeMetadata(meta) as Json,
+        ),
         sort_order: sort,
       })
       .select("id")

--- a/src/actions/studio-scene-render.ts
+++ b/src/actions/studio-scene-render.ts
@@ -25,6 +25,7 @@ import { generateScenesWithLlm } from "@/lib/studio-productions/scene-llm-planne
 import { resolveOrgLlmCredentialForDraftModel } from "@/lib/studio-productions/episode-llm";
 import { DEFAULT_PACKAGING_DRAFT_MODEL_ID } from "@/lib/studio-productions/episode-llm-models";
 import { resolveEpisodeFormat, FORMAT_SPECS } from "@/lib/studio-productions/episode-format";
+import { normalizeArtifactMetadataForWrite } from "@/lib/studio-productions/artifact-metadata-schemas";
 import { logAudit } from "@/lib/audit/log";
 import { AuditAction, AuditEntityType } from "@/lib/audit/constants";
 import type { Json } from "@/types/database.types";
@@ -177,7 +178,7 @@ async function renderOneScene(params: {
       tool_platform: "runway",
       content_text: scene.narration.slice(0, 500),
       external_url: result.output_urls[0] ?? null,
-      metadata,
+      metadata: normalizeArtifactMetadataForWrite("scene_clip", metadata as Json),
       sort_order: scene.index,
     })
     .select("id")

--- a/src/actions/studio-social-captions.ts
+++ b/src/actions/studio-social-captions.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/studio-productions/social-captions";
 import { draftTripleFromArtifactTimestamps } from "@/lib/studio-productions/resolve-episode-draft-artifacts";
 import { STUDIO_CONTENT_TEXT_MAX } from "@/lib/studio-productions/constants";
+import { normalizeArtifactMetadataForWrite } from "@/lib/studio-productions/artifact-metadata-schemas";
 import { logAudit } from "@/lib/audit/log";
 import { AuditAction, AuditEntityType } from "@/lib/audit/constants";
 import type { Json } from "@/types/database.types";
@@ -190,7 +191,10 @@ export async function generateSocialCaptions(
       .from("studio_production_artifacts")
       .update({
         content_text: contentText,
-        metadata: meta as Json,
+        metadata: normalizeArtifactMetadataForWrite(
+          "social_captions",
+          meta as Json,
+        ),
         tool_platform: cred.provider,
       })
       .eq("id", existing.id);
@@ -201,7 +205,7 @@ export async function generateSocialCaptions(
       artifact_role: "social_captions",
       tool_platform: cred.provider,
       content_text: contentText,
-      metadata: meta as Json,
+      metadata: normalizeArtifactMetadataForWrite("social_captions", meta as Json),
       sort_order: 55,
     });
   }
@@ -274,7 +278,10 @@ export async function saveSocialCaptionsManual(
       .from("studio_production_artifacts")
       .update({
         content_text: contentText,
-        metadata: meta as Json,
+        metadata: normalizeArtifactMetadataForWrite(
+          "social_captions",
+          meta as Json,
+        ),
         tool_platform: "elevate",
       })
       .eq("id", existing.id);
@@ -286,7 +293,7 @@ export async function saveSocialCaptionsManual(
       artifact_role: "social_captions",
       tool_platform: "elevate",
       content_text: contentText,
-      metadata: meta as Json,
+      metadata: normalizeArtifactMetadataForWrite("social_captions", meta as Json),
       sort_order: 55,
     });
     if (error) return { error: ActionErrorCode.dbError };

--- a/src/actions/studio-tts.ts
+++ b/src/actions/studio-tts.ts
@@ -14,6 +14,10 @@ import {
   type TtsSegment,
 } from "@/lib/studio-productions/tts-chunked-pipeline";
 import { resolveVoiceIdFromPreset } from "@/lib/studio-productions/elevenlabs-tts-presets";
+import {
+  normalizeArtifactMetadataForWrite,
+  parseArtifactMetadata,
+} from "@/lib/studio-productions/artifact-metadata-schemas";
 import { logAudit } from "@/lib/audit/log";
 import { AuditAction, AuditEntityType } from "@/lib/audit/constants";
 import type { Json } from "@/types/database.types";
@@ -234,7 +238,7 @@ export async function generateTtsFromScript(
       tool_platform: "elevenlabs",
       content_text: contentText,
       external_url: dataUri,
-      metadata,
+      metadata: normalizeArtifactMetadataForWrite("tts_audio", metadata as Json),
     })
     .select("id")
     .single();
@@ -287,7 +291,10 @@ export async function generateSubtitlesFromAudio(
     .order("created_at", { ascending: false })
     .limit(1);
 
-  const ttsMetadata = ttsRows?.[0]?.metadata as Record<string, unknown> | null;
+  const ttsMetadata = parseArtifactMetadata(
+    "tts_audio",
+    (ttsRows?.[0]?.metadata ?? null) as Json | null,
+  ) as Record<string, unknown> | null;
   const savedSegments = ttsMetadata?.segments as
     | Array<{ i: number; t: string; s: number; e: number }>
     | undefined;
@@ -319,7 +326,10 @@ export async function generateSubtitlesFromAudio(
         artifact_role: "subtitle_srt",
         tool_platform: "elevenlabs_segments",
         content_text: vttContent,
-        metadata,
+        metadata: normalizeArtifactMetadataForWrite(
+          "subtitle_srt",
+          metadata as Json,
+        ),
       })
       .select("id")
       .single();
@@ -391,7 +401,7 @@ export async function generateSubtitlesFromAudio(
       artifact_role: "subtitle_srt",
       tool_platform: "openai_whisper",
       content_text: srtContent,
-      metadata,
+      metadata: normalizeArtifactMetadataForWrite("subtitle_srt", metadata as Json),
     })
     .select("id")
     .single();

--- a/src/actions/studio-video-assembly-status.ts
+++ b/src/actions/studio-video-assembly-status.ts
@@ -2,6 +2,8 @@
 
 import { getOrgMemberContext } from "@/lib/auth/require-org-editor";
 import { createClient } from "@/lib/supabase/server";
+import { parseArtifactMetadata } from "@/lib/studio-productions/artifact-metadata-schemas";
+import type { Json } from "@/types/database.types";
 
 export type VideoAssemblyJobStatusState = {
   status: "pending" | "processing" | "completed" | "failed" | "unknown";
@@ -42,7 +44,10 @@ export async function getVideoAssemblyJobStatus(
         .select("metadata")
         .eq("id", row.output_artifact_id)
         .maybeSingle();
-      const meta = art?.metadata;
+      const meta = parseArtifactMetadata(
+        "assembled_video",
+        (art?.metadata ?? null) as Json | null,
+      );
       if (meta && typeof meta === "object" && meta !== null && "duration_seconds" in meta) {
         const ds = (meta as { duration_seconds?: unknown }).duration_seconds;
         durationSeconds = typeof ds === "number" ? ds : null;

--- a/src/actions/studio-video-assembly.ts
+++ b/src/actions/studio-video-assembly.ts
@@ -19,6 +19,7 @@ import {
   type VideoAssemblyJobInput,
 } from "@/lib/studio-productions/video-assembly-job-input";
 import { mergeVideoAssemblyJobInput, scenesJsonFromEpisodePipelinePrefs } from "@/lib/studio-productions/build-video-assembly-input";
+import { normalizeArtifactMetadataForWrite } from "@/lib/studio-productions/artifact-metadata-schemas";
 import {
   assembleVideoPerScene,
   perSceneJobClipsToSpecs,
@@ -216,7 +217,10 @@ export async function assembleEpisodeVideo(
       tool_platform: "ffmpeg",
       content_text: `Assembled ${assemblyClipCount} clips, ${result.durationSeconds.toFixed(1)}s`,
       external_url: externalUrl,
-      metadata,
+      metadata: normalizeArtifactMetadataForWrite(
+        "assembled_video",
+        metadata as Json,
+      ),
     })
     .select("id")
     .single();

--- a/src/lib/studio-productions/artifact-metadata-schemas.ts
+++ b/src/lib/studio-productions/artifact-metadata-schemas.ts
@@ -1,0 +1,136 @@
+import { z } from "zod";
+import type { Json } from "@/types/database.types";
+
+const NumberFromUnknownSchema = z.preprocess((v) => {
+  if (typeof v === "string" && v.trim() !== "") {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : v;
+  }
+  return v;
+}, z.number().finite());
+
+const StringArraySchema = z.array(z.string()).catch([]);
+
+export const BaseArtifactMetadataSchema = z
+  .object({
+    source: z.string().optional(),
+    provider: z.string().optional(),
+    model: z.string().optional(),
+    generated_at: z.string().optional(),
+  })
+  .passthrough();
+
+export const LlmMetadataSchema = BaseArtifactMetadataSchema.extend({
+  prompt_used: z.string().optional(),
+  saved_at: z.string().optional(),
+}).passthrough();
+
+export const ImageGenMetadataSchema = BaseArtifactMetadataSchema.extend({
+  scene_index: NumberFromUnknownSchema.optional(),
+  prompt_used: z.string().optional(),
+  width: NumberFromUnknownSchema.optional(),
+  height: NumberFromUnknownSchema.optional(),
+  seed: NumberFromUnknownSchema.optional(),
+  storage_path: z.string().optional(),
+  mime_type: z.string().optional(),
+}).passthrough();
+
+export const RunwayI2VMetadataSchema = BaseArtifactMetadataSchema.extend({
+  source: z.string().optional(),
+  runway_task_id: z.string().optional(),
+  output_urls: StringArraySchema.optional(),
+  scene_index: NumberFromUnknownSchema.optional(),
+  target_duration_sec: NumberFromUnknownSchema.optional(),
+  duration_seconds: NumberFromUnknownSchema.optional(),
+  first_frame_url: z.string().optional(),
+  last_frame_url: z.string().nullable().optional(),
+}).passthrough();
+
+export const ElevenLabsTtsMetadataSchema = BaseArtifactMetadataSchema.extend({
+  mode: z.string().optional(),
+  voice_id: z.string().optional(),
+  voice_preset: z.string().optional(),
+  model_id: z.string().optional(),
+  language: z.string().optional(),
+  chunk_count: NumberFromUnknownSchema.optional(),
+  total_duration_ms: NumberFromUnknownSchema.optional(),
+}).passthrough();
+
+export const FfmpegAssemblyMetadataSchema = BaseArtifactMetadataSchema.extend({
+  source: z.string().optional(),
+  clip_count: NumberFromUnknownSchema.optional(),
+  duration_seconds: NumberFromUnknownSchema.optional(),
+  resolution: z.string().optional(),
+  codec: z.string().optional(),
+  content_storage_bucket: z.string().optional(),
+  content_storage_path: z.string().optional(),
+}).passthrough();
+
+export const SubtitleMetadataSchema = BaseArtifactMetadataSchema.extend({
+  format: z.string().optional(),
+  segment_count: NumberFromUnknownSchema.optional(),
+  model: z.string().optional(),
+}).passthrough();
+
+function toJsonObject(value: unknown): Record<string, Json> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, Json>;
+}
+
+function safeNormalize(
+  schema: z.ZodTypeAny,
+  raw: Json | null | undefined,
+): Record<string, Json> | null {
+  const obj = toJsonObject(raw);
+  if (!obj) return null;
+  const parsed = schema.safeParse(obj);
+  if (!parsed.success) {
+    return obj;
+  }
+  return parsed.data as Record<string, Json>;
+}
+
+export function parseArtifactMetadata(
+  artifactRole: string,
+  raw: Json | null | undefined,
+): Record<string, Json> | null {
+  switch (artifactRole) {
+    case "hook":
+    case "title":
+    case "script":
+    case "script_draft":
+    case "prompt":
+    case "settings":
+    case "packaging_draft":
+    case "social_captions":
+    case "title_suggestion":
+    case "compliance_note":
+    case "reference_source":
+      return safeNormalize(LlmMetadataSchema, raw);
+    case "scene_keyframe_candidate":
+    case "scene_keyframe_first":
+    case "scene_keyframe_last":
+    case "thumbnail":
+      return safeNormalize(ImageGenMetadataSchema, raw);
+    case "scene_clip":
+      return safeNormalize(RunwayI2VMetadataSchema, raw);
+    case "tts_audio":
+      return safeNormalize(ElevenLabsTtsMetadataSchema, raw);
+    case "assembled_video":
+    case "render_output":
+      return safeNormalize(FfmpegAssemblyMetadataSchema, raw);
+    case "subtitle_srt":
+    case "subtitle_vtt":
+      return safeNormalize(SubtitleMetadataSchema, raw);
+    default:
+      return toJsonObject(raw);
+  }
+}
+
+export function normalizeArtifactMetadataForWrite(
+  artifactRole: string,
+  raw: Json | null | undefined,
+): Json | null {
+  const normalized = parseArtifactMetadata(artifactRole, raw);
+  return normalized ?? null;
+}

--- a/src/lib/studio-productions/process-video-assembly-job.ts
+++ b/src/lib/studio-productions/process-video-assembly-job.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/studio-productions/video-assembly-job-input";
 import { AuditAction, AuditEntityType } from "@/lib/audit/constants";
 import { getContentStorageBucket } from "@/lib/env/content-storage";
+import { normalizeArtifactMetadataForWrite } from "@/lib/studio-productions/artifact-metadata-schemas";
 import type { Database, Json } from "@/types/database.types";
 
 type JobRow = Database["public"]["Tables"]["studio_video_assembly_jobs"]["Row"];
@@ -146,7 +147,10 @@ export async function processVideoAssemblyJob(
       tool_platform: "ffmpeg",
       content_text: `Assembled ${clipCount} clips, ${result.durationSeconds.toFixed(1)}s`,
       external_url: publicUrl,
-      metadata,
+      metadata: normalizeArtifactMetadataForWrite(
+        "assembled_video",
+        metadata as Json,
+      ),
     })
     .select("id")
     .single();

--- a/src/lib/studio-productions/resolve-episode-scenes.ts
+++ b/src/lib/studio-productions/resolve-episode-scenes.ts
@@ -13,6 +13,7 @@ import {
 import {
   validateAndParseScenesJsonArray,
 } from "@/lib/studio-productions/scenes-json-validate";
+import { parseArtifactMetadata } from "@/lib/studio-productions/artifact-metadata-schemas";
 
 export type ResolveEpisodeScenesInput = {
   supabase: SupabaseClient<Database>;
@@ -50,7 +51,11 @@ export async function resolveEpisodeScenes(
     .order("created_at", { ascending: false })
     .limit(1);
 
-  const ttsTimings = parseTtsSegmentTimings(ttsRows?.[0]?.metadata);
+  const ttsMetadata = parseArtifactMetadata(
+    "tts_audio",
+    (ttsRows?.[0]?.metadata ?? null) as Database["public"]["Tables"]["studio_production_artifacts"]["Row"]["metadata"] | null,
+  );
+  const ttsTimings = parseTtsSegmentTimings(ttsMetadata);
   const scenesFromTts =
     scriptText && ttsTimings
       ? buildScenesFromTtsTimings(scriptText, ttsTimings)

--- a/tests/unit/artifact-metadata-schemas.test.ts
+++ b/tests/unit/artifact-metadata-schemas.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeArtifactMetadataForWrite,
+  parseArtifactMetadata,
+} from "@/lib/studio-productions/artifact-metadata-schemas";
+
+describe("artifact-metadata-schemas", () => {
+  it("coerces numeric strings for known scene_clip keys", () => {
+    const parsed = parseArtifactMetadata("scene_clip", {
+      source: "runway_i2v",
+      scene_index: "3",
+      duration_seconds: "8",
+      target_duration_sec: "8",
+    });
+    expect(parsed?.scene_index).toBe(3);
+    expect(parsed?.duration_seconds).toBe(8);
+    expect(parsed?.target_duration_sec).toBe(8);
+  });
+
+  it("keeps unknown keys via passthrough", () => {
+    const parsed = parseArtifactMetadata("tts_audio", {
+      source: "elevenlabs",
+      custom_field: "keep-me",
+    });
+    expect(parsed?.custom_field).toBe("keep-me");
+  });
+
+  it("returns null for non-object metadata", () => {
+    expect(normalizeArtifactMetadataForWrite("subtitle_srt", null)).toBeNull();
+    expect(normalizeArtifactMetadataForWrite("subtitle_srt", "bad" as never)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add role-based zod schemas for `studio_production_artifacts.metadata` in `artifact-metadata-schemas.ts` with lenient-first behavior (`passthrough`, numeric coercion, fallback to original object).
- Apply metadata normalization/parsing on key write/read paths (`scene_render`, `scene_i2v`, `scene_images`, `tts/subtitle`, `social_captions`, `assembled_video`, status/scene resolution paths) and add schema unit tests.
- Document role mapping and compatibility policy in `docs/features/STUDIO_ARTIFACT_METADATA.md`, and record that Lemon idempotency is already guaranteed by `ls_order_identifier` primary key in migration `018`.

## Test plan
- [x] `pnpm verify`
- [ ] Smoke in staging with existing episodes: read/write scene clips, tts/subtitle, social captions, and assembled video metadata.

Made with [Cursor](https://cursor.com)