### PR TITLE
feat(blog): add Lemon subscription tiers with premium access gating

### DIFF
--- a/docs/features/INIT-blog-subscription-lemon-phase1.md
+++ b/docs/features/INIT-blog-subscription-lemon-phase1.md
@@ -1,0 +1,95 @@
+# INIT — Blog Subscription (Lemon Squeezy, Phase 1)
+
+## 요청 요약
+
+Elevate에 기존 단일 구독/권한 모델을 유지한 채, 블로그 전용 3티어 구독(`free`, `monthly`, `annual`)을 도입한다. 결제는 Lemon Squeezy hosted checkout + webhook 기반으로 동기화하며, 프리미엄 글은 프리뷰 컷오프 + CTA 페이월 UI를 적용한다.
+
+## 제품/결제 고정값 (사용자 제공 SoT)
+
+- Monthly: Product `1010143`, Variant `1585015`, `$5.99/month`
+- Annual: Product `1010154`, Variant `1585028`, `$47.99/year`
+- Checkout URL pattern:
+  - `https://elevate.lemonsqueezy.com/checkout/buy/{variant_id}?checkout[email]={user_email}`
+
+## 현재 코드베이스 매핑 (앵커)
+
+### 이미 존재
+
+- Lemon webhook 엔드포인트: `src/app/api/webhooks/lemonsqueezy/route.ts`
+- Lemon webhook 처리기(현재 order_created 1회성 구매 중심): `src/lib/payments/lemon-squeezy-webhook.ts`
+- 공통 결제 API/checkout 생성기: `src/lib/payments/lemon-squeezy-api.ts`
+- 기존 권한 모델:
+  - 조직 단위 entitlement: `organization_content_entitlements`
+  - 접근 판정: `src/lib/content/ebook-access.ts`
+- 블로그 렌더링 엔트리: `src/app/[locale]/(marketing)/blog/[slug]/page.tsx`
+- 블로그 메타 파서: `src/lib/blog/posts.ts`
+
+### 아직 없음 (이번 작업 대상)
+
+- 사용자 구독 상태 스키마 (`subscription_tier`, `subscription_status`, LS subscription id, variant id, current period end)
+- Lemon `subscription_*` 이벤트 처리 경로
+- 블로그 포스트 `is_premium` 메타/플래그
+- 프리미엄 프리뷰 컷오프 + reusable paywall CTA 컴포넌트
+- 블로그 구독형 pricing/subscription 관리 화면
+- Lemon checkout에 이메일 prefill 강제 규칙을 공통 유틸로 고정
+
+## 복잡도 판단
+
+**L4**
+
+- 파일 수: 10+ (DB migration, webhook, auth-bound subscription resolver, blog renderer, CTA UI, pricing page, i18n)
+- 설계 결정: 다수 (기존 org-plan/entitlement와 신규 user subscription tier 공존 모델)
+- DB 변경: 있음 (새 테이블 또는 `profiles` 확장 + enum/status 모델)
+
+## 설계 핵심 결정 (INIT 잠정안, PLAN에서 확정)
+
+1. **권한 모델 분리**
+   - 기존 `organization_content_entitlements`는 전자책/카탈로그 구매 경로 유지.
+   - 블로그 구독은 사용자 단위 `blog_subscriptions` (가칭)로 분리.
+   - 이유: 이후 콘텐츠 타입별 규칙 확장(블로그/전자책/제품 기능)을 위해 결합도 축소.
+
+2. **웹훅 이벤트 수용**
+   - 처리 대상: `subscription_created`, `subscription_updated`, `subscription_cancelled`, `subscription_expired`.
+   - 이벤트 payload의 variant id를 내부 tier로 매핑:
+     - `1585015` -> `monthly`
+     - `1585028` -> `annual`
+
+3. **접근 판정 계층**
+   - 블로그 렌더링은 "전체 공개 vs 프리미엄"만 판단.
+   - 실제 구독 판정은 별도 도메인 서비스(`lib/subscriptions/*`)가 담당.
+   - 렌더링 레이어는 boolean contract만 받도록 유지.
+
+4. **프리뷰 컷오프 정책**
+   - 기본 35% 컷오프 (요구사항 30~40% 중앙값).
+   - 컷오프/CTA/blur는 reusable component로 분리하여 향후 콘텐츠 타입 재사용.
+
+5. **영문 카피 고정**
+   - 사용자-facing 텍스트는 영어만 사용.
+   - 기존 i18n 구조와의 충돌은 PLAN에서 "영문 고정 문자열 vs i18n 키" 선택.
+
+## 리스크 및 선제 대응
+
+- **리스크 A: 기존 org plan(`starter/professional/enterprise`)과 신규 blog tier 충돌**
+  - 대응: blog access는 org plan 무시, 신규 subscription source of truth로 단일화.
+- **리스크 B: Lemon webhook payload 신뢰성(이메일 매칭 실패/중복 이벤트)**
+  - 대응: LS subscription id 기준 멱등 업데이트, 이메일은 fallback만 사용.
+- **리스크 C: 프리미엄 글 렌더링 성능/UX 저하**
+  - 대응: 서버에서 컷오프 문자열 계산 + 클라이언트는 표시만 수행.
+- **리스크 D: 추후 ebook/제품 게이팅과의 얽힘**
+  - 대응: 정책 엔진 함수명을 `canReadPremiumBlogPost`로 분리해 확장 지점 명확화.
+
+## PLAN 진입용 구현 단위 (다음 단계)
+
+1. DB 스키마 + 타입 갱신
+2. Lemon subscription webhook 확장 + idempotency
+3. subscription status 조회 서비스 + auth 연계
+4. blog `is_premium` 메타 지원 + 프리뷰 컷오프 유틸
+5. paywall CTA 컴포넌트 구현 (monthly/annual checkout 링크 + sign-in)
+6. pricing/subscription page 개편 + manage subscription 링크
+7. QA (typecheck/lint/unit + blog premium access integration smoke)
+
+## 완료 기준 (INIT)
+
+- 요구사항이 현재 코드 구조와 어디서 연결/확장되는지 명확히 맵핑됨
+- 복잡도/리스크/다음 모드(PLAN) 진입 기준이 고정됨
+- 구현 범위와 비범위가 분리됨

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,34 +2,20 @@
 
 ## 현재 페이즈 (활성)
 
-**IMPLEMENT (2026-04-28) — Design System v3 "Editor's Desk" (편집자의 책상), S7 완료**
+**INIT (2026-04-28) — Blog Subscription (Lemon Squeezy, Phase 1)**
 
-**브랜치:** `feat/editors-desk-v3` (main에서 분기, 별도 PR 단위)
-**SoT:** [`docs/features/INIT-editors-desk-design-system.md`](../docs/features/INIT-editors-desk-design-system.md) · [`ADR-011`](../docs/adr/ADR-011-design-system-v3-editors-desk.md) (Accepted) · [`PLAN S0-S2`](../docs/features/PLAN-editors-desk-s0-s1-s2.md) · [`TOC IA`](../docs/design/v3-creative/toc-ia-mapping.md)
+**브랜치:** `main` (직전 Editors Desk v3 PR #21 merge 완료 상태)  
+**SoT:** [`docs/features/INIT-blog-subscription-lemon-phase1.md`](../docs/features/INIT-blog-subscription-lemon-phase1.md)
 
-**복잡도:** **L4** — 디자인 토큰 전면 교체(ink/paper/vermilion) + 3서체(Fraunces/Geist/JetBrains Mono) + UI 프리미티브 10개 재작성 + 앱 쉘 교체(Sidebar→TOC, Masthead) + 시그니처 **Columnar Timeline** 신규 + Studio Phase 2 fullscreen editor 표면 sweep + 마케팅·어드민·인증 전 라우트. **스키마/서버 액션/마이그레이션 변경 없음**(순수 표현 계층).
+**복잡도:** **L4** — DB 구독 스키마 + Lemon subscription webhook 확장 + 블로그 프리미엄 접근제어 + paywall CTA + pricing/manage UX를 기존 결제 인프라 위에 증설.
 
-**이전 시도(2026-04-24):** 동일 작업이 한 차례 진행되었으나 main에 머지되지 않은 채 사라졌고, ADR-010 번호는 별도 주제(`ADR-010-fullscreen-timeline-editor`)에 재배정됨. 본 재시작은 **ADR-011**을 사용하고, Q1-Q9 결정은 그대로 가져가며 Q10(`src/components/desk/` 경로 — `dashboard/editor/`와 어휘 충돌 회피)을 추가.
+**핵심 목표:**
+- 기존 단일 구독/권한 구조를 재작성하지 않고 확장
+- 블로그 전용 3티어(`free`, `monthly`, `annual`) 도입
+- Lemon Variant 고정 매핑 (`1585015`/`1585028`)
+- 프리미엄 포스트 preview cutoff + CTA reusable 컴포넌트
 
-**확정 결정 (Q1-Q10):**
-- **Q1** v2 문서 즉시 archive → `memory-bank/archive/design-v2/` (S0)
-- **Q2** 마케팅 오렌지 폐기 (버밀리언 유일 크로매틱)
-- **Q3** Framer Motion 경로 제한 — `src/components/desk/**` + 지정된 micro-interaction 경로만
-- **Q4** Tailwind 완전 교체 — S0는 v2 토큰 shim으로 빌드 보호; S6에서 namespace lock
-- **Q5** 다크 테마 Phase 2 (S7)
-- **Q6** TOC IA Option A (Editorial metaphor): I. Studio / II. Scripts / III. Library / IV. House / V. Settings
-- **Q7** CJK 폴백 — Noto Serif KR/JP/SC/TC + 시스템 산세리프
-- **Q8** Fraunces display-lg 1 weight만 preload + `display=swap`
-- **Q9** ColumnTimeline 데이터 — 기존 `resolve-episode-scenes.ts` + `studio-productions.ts` 재사용; 스키마 무변경
-- **Q10** `src/components/desk/` 경로 (Studio Phase 2의 `src/components/dashboard/editor/`와 어휘 충돌 회피)
-
-**슬라이스 순서:** S0 (Tokens+Fonts+Archive, L2) → S1 (Primitives, L3) → S2 (Shell TOC/Masthead/CommandBar, L3) → **S3 (Columnar Timeline 시그니처, L3)** → **S4 (Scene/Publish + Phase 2 sweep, L3)** → **S5 (Marketing+Auth, L3)** → **S6 (Admin+Billing + namespace lock, L2)** → **S7 (Dark, 선택, L2)**. 각 슬라이스 = 1 commit, 전체 = 1 PR.
-
-**완료된 이번 단계 (S7):** 다크 테마 토글 경로를 v3 토큰과 완전 동기화. `src/styles/tokens.css`에서 다크 오버라이드를 `.dark` + `[data-theme="dark"]` + `:root.dark`로 통합하고 `color-scheme: dark`를 적용. `src/app/globals.css`의 semantic dark alias도 동일 선택자 집합으로 정렬해 시스템/수동 토글 모두 일관 동작.
-
-**검증:** `pnpm -s tsc --noEmit` + `pnpm -s eslint src --max-warnings=0` + `pnpm -s vitest run tests/unit/auth-errors.test.ts tests/unit/editor-dsl.test.ts` 통과.
-
-**다음 단계:** Editor's Desk v3 슬라이스(S0-S7) 구현 완료. 필요 시 최종 QA/ship 단계(수동 다크 스모크 + PR 정리)로 전환.
+**다음 단계:** **PLAN** (데이터 모델 확정 -> webhook/event lifecycle 설계 -> UI 접근제어 계약 확정).
 
 **04-24 학습(반드시 회피):**
 - L1: PostCSS 8.4.31 + Turbopack은 CSS 주석의 em-dash(`U+2014`)에 `Unknown word` 에러 → tokens.css/globals.css 주석 ASCII-only.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -25,6 +25,7 @@
 
 | Area | Status |
 |------|--------|
+| Blog subscription Phase 1 (Lemon monthly/annual + premium paywall) | **INIT prepared 2026-04-28** — [`docs/features/INIT-blog-subscription-lemon-phase1.md`](../docs/features/INIT-blog-subscription-lemon-phase1.md), next: PLAN |
 | Content catalog, entitlements, Toss PoC, Library | Shipped (see `tasks.md` Phase B) |
 | Library detail, Lemon billing entry, purchase history, admin catalog edits (`020`–`021`) | Shipped 2026-04 — [`archive/work-history/archive-dashboard-billing-library-lemon-2026-04.md`](archive/work-history/archive-dashboard-billing-library-lemon-2026-04.md) |
 | Prompt Studio placeholder + beta allowlist | Shipped |
@@ -46,4 +47,4 @@
 
 ---
 
-마지막 구조 갱신: 2026-04-28 (S6 완료 반영)
+마지막 구조 갱신: 2026-04-28 (Blog subscription INIT 반영)

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -56,6 +56,21 @@
 
 ---
 
+## INIT — Blog Subscription (Lemon, Phase 1) — 활성
+
+**SoT:** [`docs/features/INIT-blog-subscription-lemon-phase1.md`](../docs/features/INIT-blog-subscription-lemon-phase1.md)  
+**복잡도:** **L4** — 구독 스키마/웹훅/블로그 접근제어/페이월 UI/가격 페이지 동시 변경.
+
+### 체크리스트
+
+- [ ] **PLAN 문서화:** DB shape(`free|monthly|annual`, status, LS subscription id, period end) + 기존 entitlement/org plan과 공존 규칙
+- [ ] **Webhook 확장:** `subscription_created|updated|cancelled|expired` 처리 + variant->tier 매핑 (`1585015`, `1585028`) + 멱등성
+- [ ] **접근제어:** 블로그 `is_premium` + preview cutoff(30~40%) + reusable paywall CTA
+- [ ] **Pricing/Manage:** 3티어 표 + checkout prefill(`checkout[email]`) + 구독자 상태/관리 링크
+- [ ] **검증:** type/lint/unit + 프리미엄 글 접근 스모크 + webhook 시나리오
+
+---
+
 ## AI 피벗 — Phase A (문서·랜딩·도구)
 
 | # | 항목 | 상태 |

--- a/src/app/[locale]/(marketing)/blog/[slug]/page.tsx
+++ b/src/app/[locale]/(marketing)/blog/[slug]/page.tsx
@@ -15,6 +15,15 @@ import {
 import { getSiteUrl } from "@/lib/seo/site-url";
 import { BlogPostViewedCapture } from "@/components/blog/blog-post-viewed-capture";
 import { BlogShareLinkButton } from "@/components/blog/blog-share-link-button";
+import { BlogPaywallCta } from "@/components/blog/blog-paywall-cta";
+import { createClient } from "@/lib/supabase/server";
+import {
+  buildBlogSubscriptionCheckoutUrl,
+  canReadPremiumBlogPost,
+  getBlogSubscriptionByUserId,
+  LEMON_ANNUAL_VARIANT_ID,
+  LEMON_MONTHLY_VARIANT_ID,
+} from "@/lib/subscriptions/blog-subscription";
 
 type Props = { params: Promise<{ locale: string; slug: string }> };
 
@@ -85,6 +94,23 @@ export default async function BlogPostPage({ params }: Props) {
   if (!post) notFound();
 
   const t = await getTranslations("Blog");
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const subscription = await getBlogSubscriptionByUserId(supabase, user?.id ?? null);
+  const access = canReadPremiumBlogPost({
+    isPremium: post.meta.isPremium,
+    subscription,
+  });
+  const monthlyCheckoutUrl = buildBlogSubscriptionCheckoutUrl({
+    variantId: LEMON_MONTHLY_VARIANT_ID,
+    email: user?.email,
+  });
+  const annualCheckoutUrl = buildBlogSubscriptionCheckoutUrl({
+    variantId: LEMON_ANNUAL_VARIANT_ID,
+    email: user?.email,
+  });
   const base = getSiteUrl();
   const pathname = getPathname({
     locale,
@@ -147,9 +173,27 @@ export default async function BlogPostPage({ params }: Props) {
           title={post.meta.title}
         />
 
-        <div className="mt-10 prose-blog">
-          <MDXRemote source={post.body} components={blogMdxComponents} />
-        </div>
+        {access.canReadFull ? (
+          <div className="mt-10 prose-blog">
+            <MDXRemote source={post.body} components={blogMdxComponents} />
+          </div>
+        ) : (
+          <>
+            <div className="relative mt-10">
+              <div className="prose-blog max-h-136 overflow-hidden">
+                <MDXRemote source={post.body} components={blogMdxComponents} />
+              </div>
+              <div
+                aria-hidden
+                className="pointer-events-none absolute inset-x-0 bottom-0 h-40 bg-linear-to-t from-paper-50 via-paper-50/95 to-transparent"
+              />
+            </div>
+            <BlogPaywallCta
+              monthlyCheckoutUrl={monthlyCheckoutUrl}
+              annualCheckoutUrl={annualCheckoutUrl}
+            />
+          </>
+        )}
 
         <div className="mt-14 border-t border-ink-100 pt-8">
           <Link

--- a/src/app/[locale]/(marketing)/pricing/page.tsx
+++ b/src/app/[locale]/(marketing)/pricing/page.tsx
@@ -1,36 +1,14 @@
-import NextLink from "next/link";
 import type { Metadata } from "next";
 import { setRequestLocale } from "next-intl/server";
 import { getTranslations } from "next-intl/server";
-import { Link } from "@/i18n/navigation";
-import { Check, ArrowRight, Minus } from "lucide-react";
-import { Button } from "@/components/ui/button";
-
-type Plan = {
-  key: "starter" | "professional" | "enterprise";
-  name: string;
-  price: string;
-  period: string;
-  description: string;
-  cta: string;
-  highlight: boolean;
-};
-
-type FeatureRow =
-  | {
-      kind: "text";
-      label: string;
-      starter: string;
-      professional: string;
-      enterprise: string;
-    }
-  | {
-      kind: "check";
-      label: string;
-      starter: boolean;
-      professional: boolean;
-      enterprise: boolean;
-    };
+import NextLink from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import {
+  buildBlogSubscriptionCheckoutUrl,
+  getBlogSubscriptionByUserId,
+  LEMON_ANNUAL_VARIANT_ID,
+  LEMON_MONTHLY_VARIANT_ID,
+} from "@/lib/subscriptions/blog-subscription";
 
 type Props = { params: Promise<{ locale: string }> };
 
@@ -40,160 +18,166 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return { title: tMeta("pageTitles.pricing") };
 }
 
-function FeatureCell({ value }: { value: boolean | string }) {
-  if (typeof value === "string") {
-    return (
-      <span className="text-[length:var(--elevate-prose-body-size)] text-ink-900">
-        {value}
-      </span>
-    );
-  }
-  return value ? (
-    <Check className="h-4 w-4 text-vermilion-600" />
-  ) : (
-    <Minus className="h-4 w-4 text-ink-500" />
-  );
-}
-
 export default async function PricingPage({ params }: Props) {
   const { locale } = await params;
   setRequestLocale(locale);
-  const t = await getTranslations("Pricing");
-  const plans = t.raw("plans") as Plan[];
-  const featureRows = t.raw("featureRows") as FeatureRow[];
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const subscription = await getBlogSubscriptionByUserId(supabase, user?.id ?? null);
+
+  const monthlyCheckoutUrl = buildBlogSubscriptionCheckoutUrl({
+    variantId: LEMON_MONTHLY_VARIANT_ID,
+    email: user?.email,
+  });
+  const annualCheckoutUrl = buildBlogSubscriptionCheckoutUrl({
+    variantId: LEMON_ANNUAL_VARIANT_ID,
+    email: user?.email,
+  });
+
+  const showManageLink = Boolean(subscription.manageSubscriptionUrl);
+  const showActiveState =
+    subscription.status === "active" &&
+    (subscription.tier === "monthly" || subscription.tier === "annual");
 
   return (
     <div className="border-t border-ink-100">
       <section className="elevate-marketing-shell py-14 text-center sm:py-16">
         <h1 className="text-[length:var(--elevate-marketing-home-hero-size)] font-semibold leading-[1.1] tracking-[-0.02em] text-ink-900">
-          {t("heroTitle")}
+          Choose your plan
         </h1>
         <p className="mx-auto mt-4 max-w-xl text-[length:var(--elevate-marketing-lead-size)] leading-[var(--elevate-prose-body-leading)] text-ink-700">
-          {t("heroSub")}
+          Weekly practical AI tips for everyday users, from quick previews to full archive access.
         </p>
       </section>
 
       <section className="elevate-marketing-shell pb-14 sm:pb-16">
         <div className="grid gap-px overflow-hidden border border-ink-100 bg-ink-100 md:grid-cols-3">
-          {plans.map((plan) => (
-            <div
-              key={plan.key}
-              className={`flex flex-col border-t-2 p-8 ${plan.highlight ? "border-t-vermilion-600 bg-vermilion-50" : "border-t-transparent bg-paper-100"}`}
-            >
-              <span className="mb-4 font-mono text-[10px] uppercase tracking-[0.08em] text-ink-500">
-                {plan.highlight ? t("mostPopular") : plan.name}
-              </span>
-              <h2 className="text-[length:var(--elevate-marketing-lead-size)] font-semibold text-ink-900">
-                {plan.name}
-              </h2>
-              <div className="mt-3 flex items-baseline gap-1">
-                <span className="text-4xl font-semibold tracking-tight text-ink-900">
-                  {plan.price}
-                </span>
-                {plan.period && (
-                  <span className="text-sm text-ink-500">
-                    {plan.period}
-                  </span>
-                )}
-              </div>
-              <p className="mt-3 flex-1 text-[length:var(--elevate-prose-body-size)] leading-[var(--elevate-prose-body-leading)] text-ink-500">
-                {plan.description}
-              </p>
-              <div className="mt-6">
-                {plan.key === "enterprise" ? (
-                  <Link href="/contact">
-                    <Button
-                      variant="tertiary"
-                      size="lg"
-                      className="w-full"
-                    >
-                      {plan.cta}
-                      <ArrowRight className="h-4 w-4" />
-                    </Button>
-                  </Link>
-                ) : (
-                  <NextLink href="/signup">
-                    <Button
-                      variant={plan.highlight ? "primary" : "tertiary"}
-                      size="lg"
-                      className="w-full"
-                    >
-                      {plan.cta}
-                      <ArrowRight className="h-4 w-4" />
-                    </Button>
-                  </NextLink>
-                )}
-              </div>
+          <article className="bg-paper-100 p-8">
+            <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-ink-500">Free</p>
+            <h2 className="mt-2 text-[length:var(--elevate-marketing-lead-size)] font-semibold text-ink-900">
+              $0
+            </h2>
+            <p className="mt-3 text-[length:var(--elevate-prose-body-size)] leading-[var(--elevate-prose-body-leading)] text-ink-700">
+              Preview access and saved reading list.
+            </p>
+            <ul className="mt-4 space-y-2 text-sm text-ink-700">
+              <li>- Read the first 30-40% of premium posts</li>
+              <li>- Save bookmarks and reading history</li>
+            </ul>
+            <div className="mt-6">
+              <NextLink
+                href="/signup"
+                className="inline-flex items-center justify-center border border-ink-100 bg-paper-50 px-4 py-2.5 text-sm font-medium text-ink-900 transition-colors duration-80 ease-(--ease-editorial) hover:bg-paper-0"
+              >
+                Create free account
+              </NextLink>
             </div>
-          ))}
+          </article>
+
+          <article className="bg-paper-100 p-8">
+            <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-ink-500">Monthly</p>
+            <h2 className="mt-2 text-[length:var(--elevate-marketing-lead-size)] font-semibold text-ink-900">
+              $5.99 / month
+            </h2>
+            <p className="mt-3 text-[length:var(--elevate-prose-body-size)] leading-[var(--elevate-prose-body-leading)] text-ink-700">
+              Full access to all posts and the full archive.
+            </p>
+            <ul className="mt-4 space-y-2 text-sm text-ink-700">
+              <li>- Unlimited access to premium articles</li>
+              <li>- Full archive access</li>
+            </ul>
+            <div className="mt-6">
+              <a
+                href={monthlyCheckoutUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center border border-ink-900 bg-ink-900 px-4 py-2.5 text-sm font-medium text-paper-50 transition-colors duration-80 ease-(--ease-editorial) hover:bg-ink-700"
+              >
+                Subscribe Monthly - $5.99/mo
+              </a>
+            </div>
+          </article>
+
+          <article className="border-t-2 border-t-vermilion-600 bg-vermilion-50 p-8">
+            <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-vermilion-600">
+              Annual
+            </p>
+            <h2 className="mt-2 text-[length:var(--elevate-marketing-lead-size)] font-semibold text-ink-900">
+              $47.99 / year
+            </h2>
+            <p className="mt-3 text-[length:var(--elevate-prose-body-size)] leading-[var(--elevate-prose-body-leading)] text-ink-700">
+              Full access plus the best value for long-term readers.
+            </p>
+            <ul className="mt-4 space-y-2 text-sm text-ink-700">
+              <li>- Unlimited access to premium articles</li>
+              <li>- Full archive access</li>
+              <li>- Save 33% compared to monthly billing</li>
+            </ul>
+            <div className="mt-6">
+              <a
+                href={annualCheckoutUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center border border-vermilion-600 bg-vermilion-600 px-4 py-2.5 text-sm font-medium text-paper-50 transition-colors duration-80 ease-(--ease-editorial) hover:bg-vermilion-700"
+              >
+                Subscribe Annually - $47.99/yr (Save 33%)
+              </a>
+            </div>
+          </article>
         </div>
       </section>
 
       <section className="elevate-marketing-shell pb-16 sm:pb-20">
-        <h2 className="mb-8 text-center text-[length:var(--elevate-marketing-section-title-size)] font-semibold tracking-[-0.02em] text-ink-900">
-          {t("compareTitle")}
+        <h2 className="mb-6 text-center text-[length:var(--elevate-marketing-section-title-size)] font-semibold tracking-[-0.02em] text-ink-900">
+          Subscription status
         </h2>
-
-        <div className="overflow-x-auto border border-ink-100 bg-paper-100">
-          <div className="sticky top-0 z-10 grid grid-cols-[1fr_140px_140px_140px] gap-0 border-b border-ink-100 bg-paper-50">
-            <div className="px-5 py-3 font-mono text-[10px] uppercase tracking-[0.08em] text-ink-500">
-              {t("featureColumn")}
-            </div>
-            {plans.map((plan) => (
-              <div
-                key={plan.key}
-                className={`border-l border-ink-100 px-5 py-3 text-center font-mono text-[10px] uppercase tracking-[0.08em] ${plan.highlight ? "bg-vermilion-50 text-vermilion-600" : "text-ink-500"}`}
-              >
-                {plan.name}
-              </div>
-            ))}
-          </div>
-
-          {featureRows.map((row, i) => (
-            <div
-              key={row.label}
-              className={`elevate-interactive-subtle grid grid-cols-[1fr_140px_140px_140px] gap-0 hover:bg-paper-50 focus-within:bg-paper-50 ${i < featureRows.length - 1 ? "border-b border-ink-100" : ""}`}
-            >
-              <div className="px-5 py-3 text-[length:var(--elevate-prose-body-size)] text-ink-700">
-                {row.label}
-              </div>
-              {(["starter", "professional", "enterprise"] as const).map(
-                (col) => (
-                  <div
-                    key={col}
-                    className={`flex items-center justify-center border-l border-ink-100 px-5 py-3 ${col === "professional" ? "bg-vermilion-50/50" : ""}`}
-                  >
-                    <FeatureCell value={row[col]} />
-                  </div>
-                ),
-              )}
-            </div>
-          ))}
-        </div>
-      </section>
-
-      <section className="border-t border-ink-100 bg-paper-100">
-        <div className="elevate-marketing-shell py-14 text-center sm:py-16">
-          <h2 className="text-[length:var(--elevate-marketing-section-title-size)] font-semibold tracking-[-0.02em] text-ink-900">
-            {t("faqTitle")}
-          </h2>
-          <p className="mx-auto mt-2 max-w-md text-[length:var(--elevate-prose-body-size)] leading-[var(--elevate-prose-body-leading)] text-ink-500">
-            {t("faqSub")}
-          </p>
-          <div className="mt-6 flex flex-wrap justify-center gap-3">
-            <NextLink href="/signup">
-              <Button variant="primary" size="lg">
-                {t("faqSignUp")}
-                <ArrowRight className="h-4 w-4" />
-              </Button>
-            </NextLink>
-            <Link href="/contact">
-              <Button variant="tertiary" size="lg">
-                {t("faqCta")}
-                <ArrowRight className="h-4 w-4" />
-              </Button>
-            </Link>
-          </div>
+        <div className="mx-auto max-w-xl border border-ink-100 bg-paper-100 p-6">
+          {showActiveState ? (
+            <>
+              <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-vermilion-600">
+                Active plan
+              </p>
+              <p className="mt-2 text-lg font-semibold text-ink-900">
+                {subscription.tier === "annual" ? "Annual Subscriber" : "Monthly Subscriber"}
+              </p>
+              <p className="mt-2 text-sm text-ink-700">
+                Status: {subscription.status}
+                {subscription.currentPeriodEnd
+                  ? ` · Current period ends ${new Date(subscription.currentPeriodEnd).toLocaleDateString("en-US")}`
+                  : ""}
+              </p>
+              {showManageLink ? (
+                <a
+                  href={subscription.manageSubscriptionUrl ?? "#"}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-4 inline-flex text-sm font-medium text-vermilion-600 underline-offset-2 hover:underline"
+                >
+                  Manage Subscription
+                </a>
+              ) : null}
+            </>
+          ) : (
+            <>
+              <p className="font-mono text-[10px] uppercase tracking-[0.08em] text-ink-500">
+                Current plan
+              </p>
+              <p className="mt-2 text-lg font-semibold text-ink-900">Free</p>
+              <p className="mt-2 text-sm text-ink-700">
+                Upgrade to monthly or annual for full access to all posts and archive.
+              </p>
+              {!user ? (
+                <NextLink
+                  href="/login"
+                  className="mt-4 inline-flex text-sm font-medium text-vermilion-600 underline-offset-2 hover:underline"
+                >
+                  Sign in to continue
+                </NextLink>
+              ) : null}
+            </>
+          )}
         </div>
       </section>
     </div>

--- a/src/app/api/webhooks/lemonsqueezy/route.ts
+++ b/src/app/api/webhooks/lemonsqueezy/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getLemonWebhookEventName } from "@/lib/payments/lemon-squeezy-request";
 import { verifyLemonSqueezySignature } from "@/lib/payments/lemon-squeezy-signature";
 import { processLemonSqueezyOrderWebhook } from "@/lib/payments/lemon-squeezy-webhook";
+import { processLemonSqueezySubscriptionWebhook } from "@/lib/payments/lemon-squeezy-subscription-webhook";
 import { createAdminClient } from "@/lib/supabase/admin";
 
 /**
@@ -48,6 +49,12 @@ export async function POST(req: Request) {
 
   const admin = createAdminClient();
   await processLemonSqueezyOrderWebhook(admin, parsed, eventName);
+  await processLemonSqueezySubscriptionWebhook({
+    admin,
+    body: parsed,
+    eventName,
+    rawBody,
+  });
 
   return NextResponse.json({ received: true });
 }

--- a/src/components/blog/blog-paywall-cta.tsx
+++ b/src/components/blog/blog-paywall-cta.tsx
@@ -1,0 +1,52 @@
+import NextLink from "next/link";
+
+type BlogPaywallCtaProps = {
+  monthlyCheckoutUrl: string;
+  annualCheckoutUrl: string;
+};
+
+export function BlogPaywallCta({
+  monthlyCheckoutUrl,
+  annualCheckoutUrl,
+}: BlogPaywallCtaProps) {
+  return (
+    <section className="relative mt-8 border border-ink-100 bg-paper-50 p-6 sm:p-7">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 -top-16 h-16 bg-linear-to-t from-paper-50 to-transparent"
+      />
+      <h2 className="text-xl font-semibold tracking-[-0.01em] text-ink-900">
+        Unlock the full article
+      </h2>
+      <p className="mt-2 max-w-2xl text-sm leading-relaxed text-ink-700">
+        Join Elevate and get weekly AI tips - no technical background required.
+      </p>
+      <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+        <a
+          href={monthlyCheckoutUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center justify-center border border-ink-900 bg-ink-900 px-4 py-2.5 text-sm font-medium text-paper-50 transition-colors duration-80 ease-(--ease-editorial) hover:bg-ink-700"
+        >
+          Subscribe Monthly - $5.99/mo
+        </a>
+        <a
+          href={annualCheckoutUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center justify-center border border-vermilion-600 bg-vermilion-600 px-4 py-2.5 text-sm font-medium text-paper-50 transition-colors duration-80 ease-(--ease-editorial) hover:bg-vermilion-700"
+        >
+          Subscribe Annually - $47.99/yr (Save 33%)
+        </a>
+      </div>
+      <div className="mt-4">
+        <NextLink
+          href="/login"
+          className="text-sm font-medium text-vermilion-600 underline-offset-2 hover:underline"
+        >
+          Already a subscriber? Sign in
+        </NextLink>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/blog/posts.ts
+++ b/src/lib/blog/posts.ts
@@ -12,6 +12,7 @@ export type BlogPostMeta = {
   title: string;
   description: string;
   date: string;
+  isPremium: boolean;
   /** Absolute path from site root for OG/Twitter preview, e.g. `/blog/my-slug/hero.jpg`. Must live under `public/`. */
   ogImage?: string;
 };
@@ -38,8 +39,9 @@ function parseFrontmatter(
     typeof data.date === "string"
       ? data.date
       : new Date().toISOString().slice(0, 10);
+  const isPremium = data.is_premium === true;
   const ogImage = parseOgImage(data.ogImage);
-  return { title, description, date, ...(ogImage ? { ogImage } : {}) };
+  return { title, description, date, isPremium, ...(ogImage ? { ogImage } : {}) };
 }
 
 function listMdxFiles(dir: string): string[] {

--- a/src/lib/payments/lemon-squeezy-subscription-webhook.ts
+++ b/src/lib/payments/lemon-squeezy-subscription-webhook.ts
@@ -1,0 +1,198 @@
+import crypto from "node:crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database.types";
+import {
+  mapVariantIdToBlogTier,
+  type BlogSubscriptionTier,
+  type BlogSubscriptionStatus,
+} from "@/lib/subscriptions/blog-subscription";
+
+type AdminClient = SupabaseClient<Database>;
+
+const HANDLED_EVENTS = new Set([
+  "subscription_created",
+  "subscription_updated",
+  "subscription_cancelled",
+  "subscription_expired",
+]);
+
+type JsonRecord = Record<string, unknown>;
+
+function asRecord(v: unknown): JsonRecord | null {
+  if (v && typeof v === "object" && !Array.isArray(v)) {
+    return v as JsonRecord;
+  }
+  return null;
+}
+
+function asString(v: unknown): string | null {
+  if (typeof v !== "string") return null;
+  const t = v.trim();
+  return t.length > 0 ? t : null;
+}
+
+function asNumber(v: unknown): number | null {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string") {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function extractPayload(body: unknown): {
+  subscriptionId: string | null;
+  variantId: number | null;
+  userEmail: string | null;
+  manageUrl: string | null;
+  periodEnd: string | null;
+} {
+  const root = asRecord(body);
+  const data = asRecord(root?.data);
+  const attributes = asRecord(data?.attributes);
+  const urls = asRecord(attributes?.urls);
+  const userEmailRaw =
+    asString(attributes?.user_email) ??
+    asString(attributes?.customer_email) ??
+    asString(attributes?.email);
+  return {
+    subscriptionId: asString(data?.id),
+    variantId: asNumber(attributes?.variant_id),
+    userEmail: userEmailRaw?.toLowerCase() ?? null,
+    manageUrl:
+      asString(urls?.customer_portal) ??
+      asString(urls?.update_payment_method) ??
+      null,
+    periodEnd:
+      asString(attributes?.renews_at) ??
+      asString(attributes?.ends_at) ??
+      asString(attributes?.trial_ends_at) ??
+      null,
+  };
+}
+
+function deriveStatus(eventName: string): BlogSubscriptionStatus {
+  if (eventName === "subscription_cancelled") return "cancelled";
+  if (eventName === "subscription_expired") return "expired";
+  return "active";
+}
+
+export function deriveSubscriptionState(args: {
+  eventName: string;
+  variantTier: Extract<BlogSubscriptionTier, "monthly" | "annual"> | null;
+  existingTier: BlogSubscriptionTier | null;
+}): { tier: BlogSubscriptionTier; status: BlogSubscriptionStatus } {
+  const status = deriveStatus(args.eventName);
+  if (status === "expired") {
+    return { tier: "free", status };
+  }
+  const fallbackTier =
+    args.existingTier === "annual"
+      ? "annual"
+      : args.existingTier === "monthly"
+        ? "monthly"
+        : "monthly";
+  return { tier: args.variantTier ?? fallbackTier, status };
+}
+
+async function resolveUserIdByEmail(
+  admin: AdminClient,
+  userEmail: string | null,
+): Promise<string | null> {
+  if (!userEmail) return null;
+  const { data } = await admin
+    .from("profiles")
+    .select("id")
+    .eq("email", userEmail)
+    .limit(1)
+    .maybeSingle();
+  return data?.id ?? null;
+}
+
+async function insertWebhookEventIfNew(args: {
+  admin: AdminClient;
+  eventId: string;
+  eventName: string;
+  subscriptionId: string | null;
+  body: unknown;
+}): Promise<boolean> {
+  const { error } = await args.admin
+    .from("user_blog_subscription_webhook_events")
+    .insert({
+      event_id: args.eventId,
+      event_name: args.eventName,
+      lemon_squeezy_subscription_id: args.subscriptionId,
+      payload: (args.body ?? {}) as Database["public"]["Tables"]["user_blog_subscription_webhook_events"]["Insert"]["payload"],
+    });
+  if (!error) return true;
+  if (error.code === "23505") return false;
+  throw error;
+}
+
+export type LemonSubscriptionWebhookResult =
+  | { kind: "noop" }
+  | { kind: "skipped"; reason: string }
+  | { kind: "processed" };
+
+export async function processLemonSqueezySubscriptionWebhook(args: {
+  admin: AdminClient;
+  body: unknown;
+  eventName: string;
+  rawBody: string;
+}): Promise<LemonSubscriptionWebhookResult> {
+  if (!HANDLED_EVENTS.has(args.eventName)) {
+    return { kind: "noop" };
+  }
+
+  const payload = extractPayload(args.body);
+  const eventId = crypto
+    .createHash("sha256")
+    .update(`${args.eventName}:${args.rawBody}`)
+    .digest("hex");
+
+  const inserted = await insertWebhookEventIfNew({
+    admin: args.admin,
+    eventId,
+    eventName: args.eventName,
+    subscriptionId: payload.subscriptionId,
+    body: args.body,
+  });
+  if (!inserted) return { kind: "noop" };
+
+  const tierFromVariant = mapVariantIdToBlogTier(payload.variantId);
+  const userId = await resolveUserIdByEmail(args.admin, payload.userEmail);
+  if (!userId) {
+    return { kind: "skipped", reason: "unknown_user" };
+  }
+
+  const { data: existing } = await args.admin
+    .from("user_blog_subscriptions")
+    .select("subscription_tier")
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  const next = deriveSubscriptionState({
+    eventName: args.eventName,
+    variantTier: tierFromVariant,
+    existingTier: existing?.subscription_tier ?? null,
+  });
+
+  const upsertPayload: Database["public"]["Tables"]["user_blog_subscriptions"]["Insert"] = {
+    user_id: userId,
+    subscription_tier: next.tier,
+    subscription_status: next.status,
+    lemon_squeezy_subscription_id: payload.subscriptionId,
+    lemon_squeezy_variant_id: payload.variantId,
+    current_period_end: payload.periodEnd,
+    manage_subscription_url: payload.manageUrl,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { error } = await args.admin
+    .from("user_blog_subscriptions")
+    .upsert(upsertPayload, { onConflict: "user_id" });
+  if (error) {
+    return { kind: "skipped", reason: "upsert_failed" };
+  }
+  return { kind: "processed" };
+}

--- a/src/lib/subscriptions/blog-subscription.ts
+++ b/src/lib/subscriptions/blog-subscription.ts
@@ -1,0 +1,115 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database.types";
+
+export const LEMON_MONTHLY_VARIANT_ID = 1585015;
+export const LEMON_ANNUAL_VARIANT_ID = 1585028;
+
+export type BlogSubscriptionTier = Database["public"]["Enums"]["blog_subscription_tier"];
+export type BlogSubscriptionStatus = Database["public"]["Enums"]["blog_subscription_status"];
+
+export type BlogSubscriptionRow =
+  Database["public"]["Tables"]["user_blog_subscriptions"]["Row"];
+
+export type BlogSubscriptionSnapshot = {
+  tier: BlogSubscriptionTier;
+  status: BlogSubscriptionStatus | null;
+  currentPeriodEnd: string | null;
+  manageSubscriptionUrl: string | null;
+  lemonSubscriptionId: string | null;
+  lemonVariantId: number | null;
+};
+
+export type BlogAccessDecision = {
+  canReadFull: boolean;
+  tier: BlogSubscriptionTier;
+  previewRatio: number;
+};
+
+const DEFAULT_PREVIEW_RATIO = 0.35;
+
+export function mapVariantIdToBlogTier(
+  variantId: number | string | null | undefined,
+): Extract<BlogSubscriptionTier, "monthly" | "annual"> | null {
+  const n =
+    typeof variantId === "number"
+      ? variantId
+      : typeof variantId === "string"
+        ? Number(variantId)
+        : NaN;
+  if (!Number.isFinite(n)) return null;
+  if (n === LEMON_MONTHLY_VARIANT_ID) return "monthly";
+  if (n === LEMON_ANNUAL_VARIANT_ID) return "annual";
+  return null;
+}
+
+export function buildBlogSubscriptionCheckoutUrl(args: {
+  variantId: number;
+  email?: string | null;
+}): string {
+  const base = `https://elevate.lemonsqueezy.com/checkout/buy/${args.variantId}`;
+  const email = args.email?.trim();
+  if (!email) return base;
+  const params = new URLSearchParams();
+  params.set("checkout[email]", email);
+  return `${base}?${params.toString()}`;
+}
+
+export async function getBlogSubscriptionByUserId(
+  supabase: SupabaseClient<Database>,
+  userId: string | null,
+): Promise<BlogSubscriptionSnapshot> {
+  if (!userId) {
+    return {
+      tier: "free",
+      status: null,
+      currentPeriodEnd: null,
+      manageSubscriptionUrl: null,
+      lemonSubscriptionId: null,
+      lemonVariantId: null,
+    };
+  }
+  const { data } = await supabase
+    .from("user_blog_subscriptions")
+    .select(
+      "subscription_tier, subscription_status, current_period_end, manage_subscription_url, lemon_squeezy_subscription_id, lemon_squeezy_variant_id",
+    )
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (!data) {
+    return {
+      tier: "free",
+      status: null,
+      currentPeriodEnd: null,
+      manageSubscriptionUrl: null,
+      lemonSubscriptionId: null,
+      lemonVariantId: null,
+    };
+  }
+
+  return {
+    tier: data.subscription_tier,
+    status: data.subscription_status,
+    currentPeriodEnd: data.current_period_end,
+    manageSubscriptionUrl: data.manage_subscription_url,
+    lemonSubscriptionId: data.lemon_squeezy_subscription_id,
+    lemonVariantId: data.lemon_squeezy_variant_id,
+  };
+}
+
+export function canReadPremiumBlogPost(args: {
+  isPremium: boolean;
+  subscription: BlogSubscriptionSnapshot;
+}): BlogAccessDecision {
+  if (!args.isPremium) {
+    return { canReadFull: true, tier: args.subscription.tier, previewRatio: 1 };
+  }
+  const paidTier =
+    args.subscription.tier === "monthly" || args.subscription.tier === "annual";
+  const active = args.subscription.status === "active";
+  return {
+    canReadFull: paidTier && active,
+    tier: paidTier && active ? args.subscription.tier : "free",
+    previewRatio: DEFAULT_PREVIEW_RATIO,
+  };
+}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1583,6 +1583,74 @@ export type Database = {
           },
         ]
       }
+      user_blog_subscription_webhook_events: {
+        Row: {
+          event_id: string
+          event_name: string
+          lemon_squeezy_subscription_id: string | null
+          payload: Json
+          processed_at: string
+        }
+        Insert: {
+          event_id: string
+          event_name: string
+          lemon_squeezy_subscription_id?: string | null
+          payload?: Json
+          processed_at?: string
+        }
+        Update: {
+          event_id?: string
+          event_name?: string
+          lemon_squeezy_subscription_id?: string | null
+          payload?: Json
+          processed_at?: string
+        }
+        Relationships: []
+      }
+      user_blog_subscriptions: {
+        Row: {
+          created_at: string
+          current_period_end: string | null
+          lemon_squeezy_subscription_id: string | null
+          lemon_squeezy_variant_id: number | null
+          manage_subscription_url: string | null
+          subscription_status: Database["public"]["Enums"]["blog_subscription_status"] | null
+          subscription_tier: Database["public"]["Enums"]["blog_subscription_tier"]
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          current_period_end?: string | null
+          lemon_squeezy_subscription_id?: string | null
+          lemon_squeezy_variant_id?: number | null
+          manage_subscription_url?: string | null
+          subscription_status?: Database["public"]["Enums"]["blog_subscription_status"] | null
+          subscription_tier?: Database["public"]["Enums"]["blog_subscription_tier"]
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          current_period_end?: string | null
+          lemon_squeezy_subscription_id?: string | null
+          lemon_squeezy_variant_id?: number | null
+          manage_subscription_url?: string | null
+          subscription_status?: Database["public"]["Enums"]["blog_subscription_status"] | null
+          subscription_tier?: Database["public"]["Enums"]["blog_subscription_tier"]
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_blog_subscriptions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       toss_payment_intents: {
         Row: {
           amount_krw: number
@@ -1744,6 +1812,8 @@ export type Database = {
       }
     }
     Enums: {
+      blog_subscription_status: "active" | "cancelled" | "expired" | "past_due"
+      blog_subscription_tier: "free" | "monthly" | "annual"
       event_status:
         | "draft"
         | "planning"
@@ -1890,6 +1960,8 @@ export type CompositeTypes<
 export const Constants = {
   public: {
     Enums: {
+      blog_subscription_status: ["active", "cancelled", "expired", "past_due"],
+      blog_subscription_tier: ["free", "monthly", "annual"],
       event_status: [
         "draft",
         "planning",

--- a/supabase/migrations/045_user_blog_subscriptions.sql
+++ b/supabase/migrations/045_user_blog_subscriptions.sql
@@ -1,0 +1,68 @@
+-- Blog subscription state (user-level) for Lemon Squeezy recurring plans.
+-- Phase 1 scope: blog premium access only (free/monthly/annual).
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_type
+    where typname = 'blog_subscription_tier'
+      and typnamespace = 'public'::regnamespace
+  ) then
+    create type public.blog_subscription_tier as enum ('free', 'monthly', 'annual');
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_type
+    where typname = 'blog_subscription_status'
+      and typnamespace = 'public'::regnamespace
+  ) then
+    create type public.blog_subscription_status as enum ('active', 'cancelled', 'expired', 'past_due');
+  end if;
+end $$;
+
+create table if not exists public.user_blog_subscriptions (
+  user_id uuid primary key references public.profiles (id) on delete cascade,
+  subscription_tier public.blog_subscription_tier not null default 'free',
+  subscription_status public.blog_subscription_status,
+  lemon_squeezy_subscription_id text unique,
+  lemon_squeezy_variant_id bigint,
+  current_period_end timestamptz,
+  manage_subscription_url text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.user_blog_subscription_webhook_events (
+  event_id text primary key,
+  lemon_squeezy_subscription_id text,
+  event_name text not null,
+  payload jsonb not null default '{}'::jsonb,
+  processed_at timestamptz not null default now()
+);
+
+create index if not exists idx_user_blog_subscriptions_lemon_subscription_id
+  on public.user_blog_subscriptions (lemon_squeezy_subscription_id);
+
+create index if not exists idx_user_blog_subscriptions_tier_status
+  on public.user_blog_subscriptions (subscription_tier, subscription_status);
+
+alter table public.user_blog_subscriptions enable row level security;
+alter table public.user_blog_subscription_webhook_events enable row level security;
+
+drop policy if exists user_blog_subscriptions_select_own on public.user_blog_subscriptions;
+create policy user_blog_subscriptions_select_own
+  on public.user_blog_subscriptions
+  for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+comment on table public.user_blog_subscriptions is
+  'User-level blog subscription state for Lemon Squeezy monthly/annual plans.';
+
+comment on table public.user_blog_subscription_webhook_events is
+  'Idempotency ledger for Lemon Squeezy subscription webhooks.';

--- a/tests/unit/blog-subscription.test.ts
+++ b/tests/unit/blog-subscription.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBlogSubscriptionCheckoutUrl,
+  canReadPremiumBlogPost,
+  LEMON_ANNUAL_VARIANT_ID,
+  LEMON_MONTHLY_VARIANT_ID,
+  mapVariantIdToBlogTier,
+} from "@/lib/subscriptions/blog-subscription";
+
+describe("mapVariantIdToBlogTier", () => {
+  it("maps fixed Lemon variant ids to monthly/annual", () => {
+    expect(mapVariantIdToBlogTier(LEMON_MONTHLY_VARIANT_ID)).toBe("monthly");
+    expect(mapVariantIdToBlogTier(String(LEMON_ANNUAL_VARIANT_ID))).toBe("annual");
+  });
+
+  it("returns null for unknown variants", () => {
+    expect(mapVariantIdToBlogTier(9999999)).toBeNull();
+    expect(mapVariantIdToBlogTier(null)).toBeNull();
+  });
+});
+
+describe("buildBlogSubscriptionCheckoutUrl", () => {
+  it("adds checkout[email] when email is provided", () => {
+    const url = buildBlogSubscriptionCheckoutUrl({
+      variantId: LEMON_MONTHLY_VARIANT_ID,
+      email: "user@example.com",
+    });
+    expect(url).toContain(`/checkout/buy/${LEMON_MONTHLY_VARIANT_ID}`);
+    expect(url).toContain("checkout%5Bemail%5D=user%40example.com");
+  });
+
+  it("returns plain hosted checkout url for guest users", () => {
+    const url = buildBlogSubscriptionCheckoutUrl({
+      variantId: LEMON_ANNUAL_VARIANT_ID,
+      email: null,
+    });
+    expect(url).toBe(`https://elevate.lemonsqueezy.com/checkout/buy/${LEMON_ANNUAL_VARIANT_ID}`);
+  });
+});
+
+describe("canReadPremiumBlogPost", () => {
+  it("always allows non-premium posts", () => {
+    const decision = canReadPremiumBlogPost({
+      isPremium: false,
+      subscription: {
+        tier: "free",
+        status: null,
+        currentPeriodEnd: null,
+        manageSubscriptionUrl: null,
+        lemonSubscriptionId: null,
+        lemonVariantId: null,
+      },
+    });
+    expect(decision.canReadFull).toBe(true);
+  });
+
+  it("requires active monthly/annual for premium posts", () => {
+    const monthlyActive = canReadPremiumBlogPost({
+      isPremium: true,
+      subscription: {
+        tier: "monthly",
+        status: "active",
+        currentPeriodEnd: null,
+        manageSubscriptionUrl: null,
+        lemonSubscriptionId: null,
+        lemonVariantId: null,
+      },
+    });
+    const annualExpired = canReadPremiumBlogPost({
+      isPremium: true,
+      subscription: {
+        tier: "annual",
+        status: "expired",
+        currentPeriodEnd: null,
+        manageSubscriptionUrl: null,
+        lemonSubscriptionId: null,
+        lemonVariantId: null,
+      },
+    });
+    expect(monthlyActive.canReadFull).toBe(true);
+    expect(annualExpired.canReadFull).toBe(false);
+  });
+});

--- a/tests/unit/lemon-subscription-webhook.test.ts
+++ b/tests/unit/lemon-subscription-webhook.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { deriveSubscriptionState } from "@/lib/payments/lemon-squeezy-subscription-webhook";
+
+describe("deriveSubscriptionState", () => {
+  it("sets free tier on subscription_expired", () => {
+    const next = deriveSubscriptionState({
+      eventName: "subscription_expired",
+      variantTier: "annual",
+      existingTier: "annual",
+    });
+    expect(next).toEqual({
+      tier: "free",
+      status: "expired",
+    });
+  });
+
+  it("keeps paid tier for cancelled/past events when variant is missing", () => {
+    const cancelled = deriveSubscriptionState({
+      eventName: "subscription_cancelled",
+      variantTier: null,
+      existingTier: "monthly",
+    });
+    const updated = deriveSubscriptionState({
+      eventName: "subscription_updated",
+      variantTier: null,
+      existingTier: "annual",
+    });
+    expect(cancelled).toEqual({
+      tier: "monthly",
+      status: "cancelled",
+    });
+    expect(updated).toEqual({
+      tier: "annual",
+      status: "active",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add user-level blog subscription persistence (`free`/`monthly`/`annual`) with webhook idempotency ledger and generated DB types
- extend Lemon webhook handling for subscription lifecycle events, mapped from fixed monthly/annual variant ids, while preserving existing one-time order entitlement flow
- implement premium blog access gating (frontmatter `is_premium`, paywall CTA, checkout email prefill) and update pricing UI to the new free/monthly/annual subscription model

## Commit grouping
- `feat(schema): add user blog subscription persistence model`
- `feat(webhook): process Lemon subscription lifecycle events`
- `feat(ui): add premium blog gating and subscription pricing UX`
- `test(subscription): cover tier mapping and webhook state transitions`
- `docs(memory): capture blog subscription phase1 init context`

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test`

Made with [Cursor](https://cursor.com)