### PR TITLE
fix(automation): harden blog-autopublish reliability

### DIFF
--- a/.github/workflows/blog-autopublish.yml
+++ b/.github/workflows/blog-autopublish.yml
@@ -24,9 +24,11 @@ jobs:
     env:
       BLOG_AUTOPUBLISH_ENABLED: "true"
       BLOG_AUTOPUBLISH_TOPICS_PATH: docs/blog/automation/topics.json
+      BLOG_AUTOPUBLISH_STATUS_PATH: artifacts/blog-autopublish-status.json
       CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
       AUTOMATION_GH_TOKEN: ${{ secrets.AUTOMATION_GH_TOKEN }}
       CURSOR_MODEL: ${{ vars.CURSOR_MODEL || 'gpt-5.5' }}
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
       NEXT_PUBLIC_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
       NEXT_PUBLIC_APP_URL: http://localhost:3000
@@ -58,8 +60,58 @@ jobs:
             exit 1
           fi
 
-      - name: Generate this week's post with Cursor SDK
+      - name: Generate this week's post with Cursor SDK (attempt 1)
+        id: generate_attempt_1
+        continue-on-error: true
+        timeout-minutes: 12
         run: pnpm run blog:autopublish
+
+      - name: Retry generation once on failure
+        id: generate_attempt_2
+        if: steps.generate_attempt_1.outcome == 'failure'
+        continue-on-error: true
+        timeout-minutes: 12
+        run: pnpm run blog:autopublish
+
+      - name: Write autopublish run summary
+        if: always()
+        env:
+          ATTEMPT_1_OUTCOME: ${{ steps.generate_attempt_1.outcome }}
+          ATTEMPT_2_OUTCOME: ${{ steps.generate_attempt_2.outcome }}
+        run: |
+          node <<'EOF'
+          const fs = require("node:fs");
+          const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+          const statusPath = process.env.BLOG_AUTOPUBLISH_STATUS_PATH || "artifacts/blog-autopublish-status.json";
+          let status = { status: "unknown", message: `Status artifact not found at ${statusPath}` };
+          if (fs.existsSync(statusPath)) {
+            try {
+              status = JSON.parse(fs.readFileSync(statusPath, "utf8"));
+            } catch (error) {
+              status = { status: "unknown", message: `Could not parse status artifact: ${error.message}` };
+            }
+          }
+
+          const lines = [
+            "## Blog Autopublish Summary",
+            "",
+            `- Attempt 1 outcome: ${process.env.ATTEMPT_1_OUTCOME || "unknown"}`,
+            `- Attempt 2 outcome: ${process.env.ATTEMPT_2_OUTCOME || "not-run"}`,
+            `- Status: ${status.status || "unknown"}`,
+            `- Topic: ${status.topic_slug || "-"}`,
+            `- Failure type: ${status.failure_type || "-"}`,
+            `- Message: ${status.message || "-"}`,
+            `- Next action: ${status.next_action || "-"}`,
+            `- Status artifact: \`${statusPath}\``
+          ];
+          fs.appendFileSync(summaryPath, `${lines.join("\n")}\n`);
+          EOF
+
+      - name: Stop workflow if generation failed twice
+        if: steps.generate_attempt_1.outcome == 'failure' && steps.generate_attempt_2.outcome == 'failure'
+        run: |
+          echo "Generation failed on both attempts."
+          exit 1
 
       - name: Verify changed files are build-safe
         run: pnpm run lint && pnpm run typecheck

--- a/docs/BLOG_AUTOPUBLISH_SDK.md
+++ b/docs/BLOG_AUTOPUBLISH_SDK.md
@@ -46,6 +46,7 @@ Workflow: `.github/workflows/blog-autopublish.yml`
 Required GitHub repository secret:
 
 - `CURSOR_API_KEY`: your Cursor API key
+- `AUTOMATION_GH_TOKEN`: PAT used by `create-pull-request` step when org default workflow permission is read-only
 
 Optional GitHub repository variable:
 
@@ -90,3 +91,29 @@ Use `docs/blog/automation/topics.json`:
 - Keep `CURSOR_API_KEY` out of source control.
 - If branch protection blocks direct push to `main`, use manual `push_mode=pr`.
 - For deployment, use your existing main-branch deploy pipeline (e.g. Vercel auto-deploy on push).
+
+## 5) Token scope minimums (`AUTOMATION_GH_TOKEN`)
+
+Recommended minimum repository scopes:
+
+- `repo` (required for branch push + PR creation in private repos)
+- `workflow` (recommended for operational reruns/dispatch visibility)
+
+If your org allows fine-grained PATs, grant:
+
+- **Repository contents**: Read and write
+- **Pull requests**: Read and write
+- **Actions**: Read (write optional for dispatch APIs)
+
+## 6) Failure recovery playbook
+
+The SDK runner writes `artifacts/blog-autopublish-status.json` with `failure_type`.
+
+| failure_type | Typical cause | Operator action |
+|--------------|---------------|-----------------|
+| `auth` | Missing/invalid `CURSOR_API_KEY` or PR token mismatch | Rotate/update repo secrets and rerun workflow |
+| `env` | Required env var missing from workflow mapping | Fix env mapping in workflow and rerun |
+| `sdk_runtime` | SDK runtime dependency issue (`sqlite3`, ripgrep path, runtime agent error) | Reinstall runtime deps / inspect logs / rerun once |
+| `content_validation` | Queue schema/output file mismatch | Fix `docs/blog/automation/topics.json` or output expectations |
+| `unknown` | Uncategorized failure | Check summary + full logs, then rerun with `push_mode=pr` |
+

--- a/scripts/blog-autopublish-sdk.mjs
+++ b/scripts/blog-autopublish-sdk.mjs
@@ -18,6 +18,10 @@ const dryRun = process.env.BLOG_AUTOPUBLISH_DRY_RUN === "true";
 const enabled = process.env.BLOG_AUTOPUBLISH_ENABLED === "true";
 const modelId = process.env.CURSOR_MODEL || "gpt-5.5";
 const apiKey = process.env.CURSOR_API_KEY;
+const statusPath = path.resolve(
+  cwd,
+  process.env.BLOG_AUTOPUBLISH_STATUS_PATH || "artifacts/blog-autopublish-status.json"
+);
 
 function configureRipgrep() {
   if (typeof configureRipgrepPath !== "function") return;
@@ -136,33 +140,117 @@ async function assertOutputFiles(topic) {
   }
 }
 
+function classifyFailure(error) {
+  const message = String(error?.message || error || "");
+  if (message.includes("Missing required environment variable: CURSOR_API_KEY")) return "auth";
+  if (message.includes("Missing required environment variable")) return "env";
+  if (message.includes("Invalid queue format") || message.includes("Missing expected output file")) {
+    return "content_validation";
+  }
+  if (
+    message.includes("sqlite3") ||
+    message.includes("Ripgrep path not configured") ||
+    message.includes("SDK run emitted error event")
+  ) {
+    return "sdk_runtime";
+  }
+  return "unknown";
+}
+
+function nextActionForFailureType(failureType) {
+  if (failureType === "auth") {
+    return "Check CURSOR_API_KEY and AUTOMATION_GH_TOKEN secrets in repository settings.";
+  }
+  if (failureType === "env") {
+    return "Check required env vars and workflow env mapping for autopublish steps.";
+  }
+  if (failureType === "sdk_runtime") {
+    return "Check sdk runtime dependencies (sqlite3 build, ripgrep path) and retry once.";
+  }
+  if (failureType === "content_validation") {
+    return "Review queue schema/output files and rerun after fixing topic payload.";
+  }
+  return "Inspect workflow logs and rerun manually with push_mode=pr.";
+}
+
+async function emitStatus(statusPayload) {
+  await fs.mkdir(path.dirname(statusPath), { recursive: true });
+  await fs.writeFile(statusPath, `${JSON.stringify(statusPayload, null, 2)}\n`, "utf8");
+  console.log(`[blog-autopublish] Status artifact: ${path.relative(cwd, statusPath)}`);
+  console.log(`[blog-autopublish][status] ${JSON.stringify(statusPayload)}`);
+}
+
 async function main() {
   configureRipgrep();
-  if (!enabled && !dryRun) {
-    console.log("[blog-autopublish] BLOG_AUTOPUBLISH_ENABLED is not true. Exiting.");
-    return;
+  const startedAt = new Date().toISOString();
+  let topicSlug = null;
+  try {
+    if (!enabled && !dryRun) {
+      const statusPayload = {
+        status: "skipped",
+        reason: "BLOG_AUTOPUBLISH_ENABLED is not true",
+        started_at_utc: startedAt,
+        ended_at_utc: new Date().toISOString()
+      };
+      await emitStatus(statusPayload);
+      return;
+    }
+
+    const queue = await readTopicsQueue();
+    const index = queue.topics.findIndex((t) => t.status === "pending");
+    if (index < 0) {
+      const statusPayload = {
+        status: "skipped",
+        reason: "No pending topic found",
+        started_at_utc: startedAt,
+        ended_at_utc: new Date().toISOString()
+      };
+      await emitStatus(statusPayload);
+      return;
+    }
+
+    const topic = sanitizeTopic(queue.topics[index]);
+    topicSlug = topic.slug;
+    const prompt = buildPrompt(topic);
+
+    if (dryRun) {
+      console.log("[blog-autopublish] Dry run enabled. Prompt preview:");
+      console.log(prompt);
+      const statusPayload = {
+        status: "dry_run",
+        topic_slug: topic.slug,
+        started_at_utc: startedAt,
+        ended_at_utc: new Date().toISOString()
+      };
+      await emitStatus(statusPayload);
+      return;
+    }
+
+    console.log(`[blog-autopublish] Running SDK agent for topic: ${topic.slug}`);
+    await runAgent(prompt);
+    await assertOutputFiles(topic);
+    console.log(`[blog-autopublish] Completed topic: ${topic.slug}`);
+    const statusPayload = {
+      status: "success",
+      topic_slug: topic.slug,
+      started_at_utc: startedAt,
+      ended_at_utc: new Date().toISOString()
+    };
+    await emitStatus(statusPayload);
+  } catch (error) {
+    const failureType = classifyFailure(error);
+    const statusPayload = {
+      status: "failed",
+      topic_slug: topicSlug,
+      failure_type: failureType,
+      message: String(error?.message || error || "Unknown error"),
+      next_action: nextActionForFailureType(failureType),
+      started_at_utc: startedAt,
+      ended_at_utc: new Date().toISOString()
+    };
+    await emitStatus(statusPayload);
+    throw error;
   }
-
-  const queue = await readTopicsQueue();
-  const index = queue.topics.findIndex((t) => t.status === "pending");
-  if (index < 0) {
-    console.log("[blog-autopublish] No pending topic found. Exiting.");
-    return;
-  }
-
-  const topic = sanitizeTopic(queue.topics[index]);
-  const prompt = buildPrompt(topic);
-
-  if (dryRun) {
-    console.log("[blog-autopublish] Dry run enabled. Prompt preview:");
-    console.log(prompt);
-    return;
-  }
-
-  console.log(`[blog-autopublish] Running SDK agent for topic: ${topic.slug}`);
-  await runAgent(prompt);
-  await assertOutputFiles(topic);
-  console.log(`[blog-autopublish] Completed topic: ${topic.slug}`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- add deterministic failure taxonomy (`auth|env|sdk_runtime|content_validation|unknown`) in the SDK runner
- emit machine-readable status artifact and include next-action hints for operators
- harden workflow with generation timeout, one retry, and run summary output under org read-only workflow-permission constraints

## Test plan
- pnpm run lint
- pnpm run typecheck
- BLOG_AUTOPUBLISH_ENABLED=true BLOG_AUTOPUBLISH_DRY_RUN=true pnpm run blog:autopublish
- Simulate missing CURSOR_API_KEY and verify failure classification in status artifact

Made with [Cursor](https://cursor.com)