### PR TITLE
feat(blog): add deterministic EN/KO quality gate

### DIFF
--- a/.github/workflows/blog-autopublish.yml
+++ b/.github/workflows/blog-autopublish.yml
@@ -25,6 +25,7 @@ jobs:
       BLOG_AUTOPUBLISH_ENABLED: "true"
       BLOG_AUTOPUBLISH_TOPICS_PATH: docs/blog/automation/topics.json
       BLOG_AUTOPUBLISH_STATUS_PATH: artifacts/blog-autopublish-status.json
+      BLOG_QUALITY_GATE_STATUS_PATH: artifacts/blog-quality-gate.json
       CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
       AUTOMATION_GH_TOKEN: ${{ secrets.AUTOMATION_GH_TOKEN }}
       CURSOR_MODEL: ${{ vars.CURSOR_MODEL || 'gpt-5.5' }}
@@ -112,6 +113,53 @@ jobs:
         run: |
           echo "Generation failed on both attempts."
           exit 1
+
+      - name: Run blog quality gate
+        id: quality_gate
+        run: pnpm run blog:quality-gate
+
+      - name: Write quality gate summary
+        if: always()
+        run: |
+          node <<'EOF'
+          const fs = require("node:fs");
+          const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+          const gatePath = process.env.BLOG_QUALITY_GATE_STATUS_PATH || "artifacts/blog-quality-gate.json";
+          let payload = { status: "unknown", hard_errors: [], soft_warnings: [] };
+          if (fs.existsSync(gatePath)) {
+            try {
+              payload = JSON.parse(fs.readFileSync(gatePath, "utf8"));
+            } catch (error) {
+              payload = { status: "unknown", hard_errors: [{ file: "-", message: error.message }], soft_warnings: [] };
+            }
+          }
+
+          const lines = [
+            "## Blog Quality Gate",
+            "",
+            `- Status: ${payload.status || "unknown"}`,
+            `- Checked files: ${(payload.checked_files || []).join(", ") || "-"}`,
+            `- Hard errors: ${(payload.hard_errors || []).length}`,
+            `- Soft warnings: ${(payload.soft_warnings || []).length}`,
+            `- Gate artifact: \`${gatePath}\``
+          ];
+
+          if ((payload.hard_errors || []).length > 0) {
+            lines.push("", "### Hard errors");
+            for (const err of payload.hard_errors.slice(0, 10)) {
+              lines.push(`- ${err.file}: ${err.message}`);
+            }
+          }
+
+          if ((payload.soft_warnings || []).length > 0) {
+            lines.push("", "### Soft warnings");
+            for (const warn of payload.soft_warnings.slice(0, 10)) {
+              lines.push(`- ${warn.file}: ${warn.message}`);
+            }
+          }
+
+          fs.appendFileSync(summaryPath, `${lines.join("\n")}\n`);
+          EOF
 
       - name: Verify changed files are build-safe
         run: pnpm run lint && pnpm run typecheck

--- a/.github/workflows/blog-autopublish.yml
+++ b/.github/workflows/blog-autopublish.yml
@@ -24,9 +24,11 @@ jobs:
     env:
       BLOG_AUTOPUBLISH_ENABLED: "true"
       BLOG_AUTOPUBLISH_TOPICS_PATH: docs/blog/automation/topics.json
+      BLOG_AUTOPUBLISH_STATUS_PATH: artifacts/blog-autopublish-status.json
       CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
       AUTOMATION_GH_TOKEN: ${{ secrets.AUTOMATION_GH_TOKEN }}
       CURSOR_MODEL: ${{ vars.CURSOR_MODEL || 'gpt-5.5' }}
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
       NEXT_PUBLIC_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
       NEXT_PUBLIC_APP_URL: http://localhost:3000
@@ -58,8 +60,58 @@ jobs:
             exit 1
           fi
 
-      - name: Generate this week's post with Cursor SDK
+      - name: Generate this week's post with Cursor SDK (attempt 1)
+        id: generate_attempt_1
+        continue-on-error: true
+        timeout-minutes: 12
         run: pnpm run blog:autopublish
+
+      - name: Retry generation once on failure
+        id: generate_attempt_2
+        if: steps.generate_attempt_1.outcome == 'failure'
+        continue-on-error: true
+        timeout-minutes: 12
+        run: pnpm run blog:autopublish
+
+      - name: Write autopublish run summary
+        if: always()
+        env:
+          ATTEMPT_1_OUTCOME: ${{ steps.generate_attempt_1.outcome }}
+          ATTEMPT_2_OUTCOME: ${{ steps.generate_attempt_2.outcome }}
+        run: |
+          node <<'EOF'
+          const fs = require("node:fs");
+          const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+          const statusPath = process.env.BLOG_AUTOPUBLISH_STATUS_PATH || "artifacts/blog-autopublish-status.json";
+          let status = { status: "unknown", message: `Status artifact not found at ${statusPath}` };
+          if (fs.existsSync(statusPath)) {
+            try {
+              status = JSON.parse(fs.readFileSync(statusPath, "utf8"));
+            } catch (error) {
+              status = { status: "unknown", message: `Could not parse status artifact: ${error.message}` };
+            }
+          }
+
+          const lines = [
+            "## Blog Autopublish Summary",
+            "",
+            `- Attempt 1 outcome: ${process.env.ATTEMPT_1_OUTCOME || "unknown"}`,
+            `- Attempt 2 outcome: ${process.env.ATTEMPT_2_OUTCOME || "not-run"}`,
+            `- Status: ${status.status || "unknown"}`,
+            `- Topic: ${status.topic_slug || "-"}`,
+            `- Failure type: ${status.failure_type || "-"}`,
+            `- Message: ${status.message || "-"}`,
+            `- Next action: ${status.next_action || "-"}`,
+            `- Status artifact: \`${statusPath}\``
+          ];
+          fs.appendFileSync(summaryPath, `${lines.join("\n")}\n`);
+          EOF
+
+      - name: Stop workflow if generation failed twice
+        if: steps.generate_attempt_1.outcome == 'failure' && steps.generate_attempt_2.outcome == 'failure'
+        run: |
+          echo "Generation failed on both attempts."
+          exit 1
 
       - name: Verify changed files are build-safe
         run: pnpm run lint && pnpm run typecheck

--- a/docs/BLOG_AUTOPUBLISH_SDK.md
+++ b/docs/BLOG_AUTOPUBLISH_SDK.md
@@ -124,7 +124,9 @@ Workflow runs `pnpm run blog:quality-gate` after generation.
 - Hard fail (blocks commit/PR):
   - missing frontmatter required keys
   - locale/slug/date structural mismatches
-  - invalid internal CTA/link constraints (`/#waitlist`, `/ko#waitlist`)
+  - invalid internal CTA/link constraints:
+    - public posts require waitlist CTA (`/#waitlist`, `/ko#waitlist`)
+    - member/premium posts require at least one internal action link
 - Soft fail (non-blocking warning in run summary):
   - repetitive AI boilerplate phrase detection
 

--- a/docs/BLOG_AUTOPUBLISH_SDK.md
+++ b/docs/BLOG_AUTOPUBLISH_SDK.md
@@ -117,3 +117,18 @@ The SDK runner writes `artifacts/blog-autopublish-status.json` with `failure_typ
 | `content_validation` | Queue schema/output file mismatch | Fix `docs/blog/automation/topics.json` or output expectations |
 | `unknown` | Uncategorized failure | Check summary + full logs, then rerun with `push_mode=pr` |
 
+## 7) Quality gate policy (hard vs soft)
+
+Workflow runs `pnpm run blog:quality-gate` after generation.
+
+- Hard fail (blocks commit/PR):
+  - missing frontmatter required keys
+  - locale/slug/date structural mismatches
+  - invalid internal CTA/link constraints (`/#waitlist`, `/ko#waitlist`)
+- Soft fail (non-blocking warning in run summary):
+  - repetitive AI boilerplate phrase detection
+
+Quality gate artifact:
+
+- `artifacts/blog-quality-gate.json`
+

--- a/docs/BLOG_AUTOPUBLISH_SDK.md
+++ b/docs/BLOG_AUTOPUBLISH_SDK.md
@@ -46,6 +46,7 @@ Workflow: `.github/workflows/blog-autopublish.yml`
 Required GitHub repository secret:
 
 - `CURSOR_API_KEY`: your Cursor API key
+- `AUTOMATION_GH_TOKEN`: PAT used by `create-pull-request` step when org default workflow permission is read-only
 
 Optional GitHub repository variable:
 
@@ -90,3 +91,29 @@ Use `docs/blog/automation/topics.json`:
 - Keep `CURSOR_API_KEY` out of source control.
 - If branch protection blocks direct push to `main`, use manual `push_mode=pr`.
 - For deployment, use your existing main-branch deploy pipeline (e.g. Vercel auto-deploy on push).
+
+## 5) Token scope minimums (`AUTOMATION_GH_TOKEN`)
+
+Recommended minimum repository scopes:
+
+- `repo` (required for branch push + PR creation in private repos)
+- `workflow` (recommended for operational reruns/dispatch visibility)
+
+If your org allows fine-grained PATs, grant:
+
+- **Repository contents**: Read and write
+- **Pull requests**: Read and write
+- **Actions**: Read (write optional for dispatch APIs)
+
+## 6) Failure recovery playbook
+
+The SDK runner writes `artifacts/blog-autopublish-status.json` with `failure_type`.
+
+| failure_type | Typical cause | Operator action |
+|--------------|---------------|-----------------|
+| `auth` | Missing/invalid `CURSOR_API_KEY` or PR token mismatch | Rotate/update repo secrets and rerun workflow |
+| `env` | Required env var missing from workflow mapping | Fix env mapping in workflow and rerun |
+| `sdk_runtime` | SDK runtime dependency issue (`sqlite3`, ripgrep path, runtime agent error) | Reinstall runtime deps / inspect logs / rerun once |
+| `content_validation` | Queue schema/output file mismatch | Fix `docs/blog/automation/topics.json` or output expectations |
+| `unknown` | Uncategorized failure | Check summary + full logs, then rerun with `push_mode=pr` |
+

--- a/docs/BLOG_POST_PIPELINE.md
+++ b/docs/BLOG_POST_PIPELINE.md
@@ -203,6 +203,15 @@ Document the **exact query strings** in the pack so schedulers don’t invent ad
 - [ ] Front matter includes **`ogImage`** when you want post-specific link previews (see §3).
 - [ ] **Voice:** §**2.5** pass done—read aloud once per locale; KO does not read like English translated line-by-line.
 
+### 7.1 Automation quality gate (SDK workflow)
+
+For SDK automation runs, quality is enforced by `pnpm run blog:quality-gate`:
+
+- **Hard fail** (blocks auto PR): frontmatter/schema/link/locale mismatches.
+- **Soft warning** (non-blocking): repetitive AI boilerplate phrase patterns.
+
+Gate status artifact path: `artifacts/blog-quality-gate.json`.
+
 ---
 
 ## 8. SemVer release posts (product “we ship” narrative)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "db:types": "node scripts/gen-db-types.mjs",
     "buffer:retry-step4": "node scripts/retry-buffer-step4.mjs",
     "blog:autopublish": "node scripts/blog-autopublish-sdk.mjs",
+    "blog:quality-gate": "node scripts/blog-quality-gate.mjs",
     "worker:assembly": "tsx workers/video-assembly/run.ts",
     "prepare": "husky"
   },

--- a/scripts/blog-autopublish-sdk.mjs
+++ b/scripts/blog-autopublish-sdk.mjs
@@ -18,6 +18,10 @@ const dryRun = process.env.BLOG_AUTOPUBLISH_DRY_RUN === "true";
 const enabled = process.env.BLOG_AUTOPUBLISH_ENABLED === "true";
 const modelId = process.env.CURSOR_MODEL || "gpt-5.5";
 const apiKey = process.env.CURSOR_API_KEY;
+const statusPath = path.resolve(
+  cwd,
+  process.env.BLOG_AUTOPUBLISH_STATUS_PATH || "artifacts/blog-autopublish-status.json"
+);
 
 function configureRipgrep() {
   if (typeof configureRipgrepPath !== "function") return;
@@ -136,33 +140,117 @@ async function assertOutputFiles(topic) {
   }
 }
 
+function classifyFailure(error) {
+  const message = String(error?.message || error || "");
+  if (message.includes("Missing required environment variable: CURSOR_API_KEY")) return "auth";
+  if (message.includes("Missing required environment variable")) return "env";
+  if (message.includes("Invalid queue format") || message.includes("Missing expected output file")) {
+    return "content_validation";
+  }
+  if (
+    message.includes("sqlite3") ||
+    message.includes("Ripgrep path not configured") ||
+    message.includes("SDK run emitted error event")
+  ) {
+    return "sdk_runtime";
+  }
+  return "unknown";
+}
+
+function nextActionForFailureType(failureType) {
+  if (failureType === "auth") {
+    return "Check CURSOR_API_KEY and AUTOMATION_GH_TOKEN secrets in repository settings.";
+  }
+  if (failureType === "env") {
+    return "Check required env vars and workflow env mapping for autopublish steps.";
+  }
+  if (failureType === "sdk_runtime") {
+    return "Check sdk runtime dependencies (sqlite3 build, ripgrep path) and retry once.";
+  }
+  if (failureType === "content_validation") {
+    return "Review queue schema/output files and rerun after fixing topic payload.";
+  }
+  return "Inspect workflow logs and rerun manually with push_mode=pr.";
+}
+
+async function emitStatus(statusPayload) {
+  await fs.mkdir(path.dirname(statusPath), { recursive: true });
+  await fs.writeFile(statusPath, `${JSON.stringify(statusPayload, null, 2)}\n`, "utf8");
+  console.log(`[blog-autopublish] Status artifact: ${path.relative(cwd, statusPath)}`);
+  console.log(`[blog-autopublish][status] ${JSON.stringify(statusPayload)}`);
+}
+
 async function main() {
   configureRipgrep();
-  if (!enabled && !dryRun) {
-    console.log("[blog-autopublish] BLOG_AUTOPUBLISH_ENABLED is not true. Exiting.");
-    return;
+  const startedAt = new Date().toISOString();
+  let topicSlug = null;
+  try {
+    if (!enabled && !dryRun) {
+      const statusPayload = {
+        status: "skipped",
+        reason: "BLOG_AUTOPUBLISH_ENABLED is not true",
+        started_at_utc: startedAt,
+        ended_at_utc: new Date().toISOString()
+      };
+      await emitStatus(statusPayload);
+      return;
+    }
+
+    const queue = await readTopicsQueue();
+    const index = queue.topics.findIndex((t) => t.status === "pending");
+    if (index < 0) {
+      const statusPayload = {
+        status: "skipped",
+        reason: "No pending topic found",
+        started_at_utc: startedAt,
+        ended_at_utc: new Date().toISOString()
+      };
+      await emitStatus(statusPayload);
+      return;
+    }
+
+    const topic = sanitizeTopic(queue.topics[index]);
+    topicSlug = topic.slug;
+    const prompt = buildPrompt(topic);
+
+    if (dryRun) {
+      console.log("[blog-autopublish] Dry run enabled. Prompt preview:");
+      console.log(prompt);
+      const statusPayload = {
+        status: "dry_run",
+        topic_slug: topic.slug,
+        started_at_utc: startedAt,
+        ended_at_utc: new Date().toISOString()
+      };
+      await emitStatus(statusPayload);
+      return;
+    }
+
+    console.log(`[blog-autopublish] Running SDK agent for topic: ${topic.slug}`);
+    await runAgent(prompt);
+    await assertOutputFiles(topic);
+    console.log(`[blog-autopublish] Completed topic: ${topic.slug}`);
+    const statusPayload = {
+      status: "success",
+      topic_slug: topic.slug,
+      started_at_utc: startedAt,
+      ended_at_utc: new Date().toISOString()
+    };
+    await emitStatus(statusPayload);
+  } catch (error) {
+    const failureType = classifyFailure(error);
+    const statusPayload = {
+      status: "failed",
+      topic_slug: topicSlug,
+      failure_type: failureType,
+      message: String(error?.message || error || "Unknown error"),
+      next_action: nextActionForFailureType(failureType),
+      started_at_utc: startedAt,
+      ended_at_utc: new Date().toISOString()
+    };
+    await emitStatus(statusPayload);
+    throw error;
   }
-
-  const queue = await readTopicsQueue();
-  const index = queue.topics.findIndex((t) => t.status === "pending");
-  if (index < 0) {
-    console.log("[blog-autopublish] No pending topic found. Exiting.");
-    return;
-  }
-
-  const topic = sanitizeTopic(queue.topics[index]);
-  const prompt = buildPrompt(topic);
-
-  if (dryRun) {
-    console.log("[blog-autopublish] Dry run enabled. Prompt preview:");
-    console.log(prompt);
-    return;
-  }
-
-  console.log(`[blog-autopublish] Running SDK agent for topic: ${topic.slug}`);
-  await runAgent(prompt);
-  await assertOutputFiles(topic);
-  console.log(`[blog-autopublish] Completed topic: ${topic.slug}`);
 }
 
 main().catch((error) => {

--- a/scripts/blog-quality-gate.mjs
+++ b/scripts/blog-quality-gate.mjs
@@ -78,6 +78,16 @@ function validateMarkdownLinks(content, file, errors) {
   }
 }
 
+function countInternalLinks(content) {
+  const linkRe = /\[[^\]]+\]\(([^)]+)\)/g;
+  let count = 0;
+  for (const match of content.matchAll(linkRe)) {
+    const href = match[1].trim();
+    if (href.startsWith("/")) count += 1;
+  }
+  return count;
+}
+
 async function run() {
   const changedPaths = parseGitStatusPaths();
   const candidates = findCandidateBlogFiles(changedPaths);
@@ -135,11 +145,23 @@ async function run() {
 
     validateMarkdownLinks(raw, relPath, hardErrors);
 
-    if (localeFromPath === "en" && !raw.includes("/#waitlist")) {
-      pushError(hardErrors, relPath, "English post must include waitlist CTA link '/#waitlist'.");
-    }
-    if (localeFromPath === "ko" && !raw.includes("/ko#waitlist")) {
-      pushError(hardErrors, relPath, "Korean post must include waitlist CTA link '/ko#waitlist'.");
+    const accessTier = String(meta.access_tier || "");
+    if (accessTier === "public") {
+      if (localeFromPath === "en" && !raw.includes("/#waitlist")) {
+        pushError(hardErrors, relPath, "Public English post must include waitlist CTA link '/#waitlist'.");
+      }
+      if (localeFromPath === "ko" && !raw.includes("/ko#waitlist")) {
+        pushError(hardErrors, relPath, "Public Korean post must include waitlist CTA link '/ko#waitlist'.");
+      }
+    } else {
+      const internalLinkCount = countInternalLinks(raw);
+      if (internalLinkCount < 1) {
+        pushError(
+          hardErrors,
+          relPath,
+          "Member/premium post must include at least one internal CTA/action link."
+        );
+      }
     }
 
     const softPhrases = localeFromPath === "en" ? SOFT_AI_PHRASES_EN : SOFT_AI_PHRASES_KO;

--- a/scripts/blog-quality-gate.mjs
+++ b/scripts/blog-quality-gate.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import matter from "gray-matter";
+
+const cwd = process.cwd();
+const statusPath = path.resolve(
+  cwd,
+  process.env.BLOG_QUALITY_GATE_STATUS_PATH || "artifacts/blog-quality-gate.json"
+);
+
+const HARD_REQUIRED_KEYS = ["title", "description", "date", "slug", "tags", "access_tier", "locale"];
+const ACCESS_TIERS = new Set(["public", "member", "premium"]);
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const SOFT_AI_PHRASES_EN = [
+  "in today's fast-paced world",
+  "game changer",
+  "unprecedented",
+  "it is important to note that",
+  "delve into"
+];
+
+const SOFT_AI_PHRASES_KO = ["빠르게 변화하는 시대", "게임 체인저", "시너지 효과", "혁신적인"];
+
+function parseGitStatusPaths() {
+  const raw = execSync("git status --porcelain", {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"]
+  });
+  return raw
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => {
+      const rawPath = line.slice(3).trim();
+      if (rawPath.includes(" -> ")) {
+        return rawPath.split(" -> ").at(-1);
+      }
+      return rawPath;
+    });
+}
+
+function findCandidateBlogFiles(paths) {
+  return paths.filter((p) => /^content\/blog\/(en|ko)\/[^/]+\.mdx$/.test(p));
+}
+
+function pushError(errors, file, message) {
+  errors.push({ file, message });
+}
+
+function pushWarning(warnings, file, message) {
+  warnings.push({ file, message });
+}
+
+async function writeStatus(payload) {
+  await fs.mkdir(path.dirname(statusPath), { recursive: true });
+  await fs.writeFile(statusPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  console.log(`[blog-quality-gate] Status artifact: ${path.relative(cwd, statusPath)}`);
+  console.log(`[blog-quality-gate][status] ${JSON.stringify(payload)}`);
+}
+
+function validateMarkdownLinks(content, file, errors) {
+  const linkRe = /\[[^\]]+\]\(([^)]+)\)/g;
+  for (const match of content.matchAll(linkRe)) {
+    const href = match[1].trim();
+    if (!href) {
+      pushError(errors, file, "Empty markdown link href detected.");
+      continue;
+    }
+    if (href.startsWith("/") && href.includes(" ")) {
+      pushError(errors, file, `Internal link contains spaces: ${href}`);
+    }
+  }
+}
+
+async function run() {
+  const changedPaths = parseGitStatusPaths();
+  const candidates = findCandidateBlogFiles(changedPaths);
+
+  if (candidates.length === 0) {
+    await writeStatus({
+      status: "skipped",
+      reason: "No changed EN/KO blog MDX files found",
+      checked_files: []
+    });
+    return;
+  }
+
+  const hardErrors = [];
+  const softWarnings = [];
+  const slugLocaleMeta = new Map();
+
+  for (const relPath of candidates) {
+    const absPath = path.resolve(cwd, relPath);
+    const raw = await fs.readFile(absPath, "utf8");
+    const parsed = matter(raw);
+    const meta = parsed.data || {};
+    const localeFromPath = relPath.split("/")[2];
+    const slugFromPath = path.basename(relPath, ".mdx");
+
+    for (const key of HARD_REQUIRED_KEYS) {
+      if (!(key in meta)) {
+        pushError(hardErrors, relPath, `Missing required frontmatter key: ${key}`);
+      }
+    }
+
+    if (meta.locale && meta.locale !== localeFromPath) {
+      pushError(hardErrors, relPath, `Frontmatter locale '${meta.locale}' must match path locale '${localeFromPath}'.`);
+    }
+
+    if (meta.slug && meta.slug !== slugFromPath) {
+      pushError(hardErrors, relPath, `Frontmatter slug '${meta.slug}' must match filename slug '${slugFromPath}'.`);
+    }
+
+    if (meta.date && !DATE_RE.test(String(meta.date))) {
+      pushError(hardErrors, relPath, `Frontmatter date must use YYYY-MM-DD: '${meta.date}'.`);
+    }
+
+    if (meta.access_tier && !ACCESS_TIERS.has(meta.access_tier)) {
+      pushError(
+        hardErrors,
+        relPath,
+        `Invalid access_tier '${meta.access_tier}'. Allowed: public|member|premium.`
+      );
+    }
+
+    if (meta.tags && !Array.isArray(meta.tags)) {
+      pushError(hardErrors, relPath, "Frontmatter tags must be an array.");
+    }
+
+    validateMarkdownLinks(raw, relPath, hardErrors);
+
+    if (localeFromPath === "en" && !raw.includes("/#waitlist")) {
+      pushError(hardErrors, relPath, "English post must include waitlist CTA link '/#waitlist'.");
+    }
+    if (localeFromPath === "ko" && !raw.includes("/ko#waitlist")) {
+      pushError(hardErrors, relPath, "Korean post must include waitlist CTA link '/ko#waitlist'.");
+    }
+
+    const softPhrases = localeFromPath === "en" ? SOFT_AI_PHRASES_EN : SOFT_AI_PHRASES_KO;
+    const lowered = raw.toLowerCase();
+    for (const phrase of softPhrases) {
+      const exists = localeFromPath === "en" ? lowered.includes(phrase) : raw.includes(phrase);
+      if (exists) {
+        pushWarning(
+          softWarnings,
+          relPath,
+          `Potential boilerplate phrase detected: '${phrase}' (soft warning).`
+        );
+      }
+    }
+
+    if (!slugLocaleMeta.has(slugFromPath)) slugLocaleMeta.set(slugFromPath, {});
+    slugLocaleMeta.get(slugFromPath)[localeFromPath] = meta;
+  }
+
+  for (const [slug, localeMeta] of slugLocaleMeta.entries()) {
+    const enPath = path.resolve(cwd, `content/blog/en/${slug}.mdx`);
+    const koPath = path.resolve(cwd, `content/blog/ko/${slug}.mdx`);
+    if (!existsSync(enPath) || !existsSync(koPath)) {
+      pushError(
+        hardErrors,
+        slug,
+        "Both EN and KO files must exist for generated slug (content/blog/en + content/blog/ko)."
+      );
+      continue;
+    }
+    if (localeMeta.en?.date && localeMeta.ko?.date && localeMeta.en.date !== localeMeta.ko.date) {
+      pushError(hardErrors, slug, "EN/KO date mismatch for same slug.");
+    }
+  }
+
+  const payload = {
+    status: hardErrors.length > 0 ? "failed" : softWarnings.length > 0 ? "passed_with_warnings" : "passed",
+    checked_files: candidates,
+    hard_errors: hardErrors,
+    soft_warnings: softWarnings
+  };
+  await writeStatus(payload);
+
+  if (hardErrors.length > 0) {
+    throw new Error("Blog quality gate failed with hard errors.");
+  }
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `scripts/blog-quality-gate.mjs` with hard-fail checks for frontmatter/schema/link/locale integrity
- add soft-warning checks for repetitive AI boilerplate phrasing
- wire gate and gate summary into autopublish workflow and document hard/soft policy in blog operating docs

## Test plan
- pnpm run lint
- pnpm run typecheck
- pnpm run blog:quality-gate
- Confirm workflow summary shows hard/soft counts and artifact path

Made with [Cursor](https://cursor.com)