### PR TITLE
docs(automation): add no-slack runbooks and ops scorecard

### DIFF
--- a/.github/workflows/blog-autopublish.yml
+++ b/.github/workflows/blog-autopublish.yml
@@ -25,6 +25,7 @@ jobs:
       BLOG_AUTOPUBLISH_ENABLED: "true"
       BLOG_AUTOPUBLISH_TOPICS_PATH: docs/blog/automation/topics.json
       BLOG_AUTOPUBLISH_STATUS_PATH: artifacts/blog-autopublish-status.json
+      BLOG_QUALITY_GATE_STATUS_PATH: artifacts/blog-quality-gate.json
       CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
       AUTOMATION_GH_TOKEN: ${{ secrets.AUTOMATION_GH_TOKEN }}
       CURSOR_MODEL: ${{ vars.CURSOR_MODEL || 'gpt-5.5' }}
@@ -112,6 +113,53 @@ jobs:
         run: |
           echo "Generation failed on both attempts."
           exit 1
+
+      - name: Run blog quality gate
+        id: quality_gate
+        run: pnpm run blog:quality-gate
+
+      - name: Write quality gate summary
+        if: always()
+        run: |
+          node <<'EOF'
+          const fs = require("node:fs");
+          const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+          const gatePath = process.env.BLOG_QUALITY_GATE_STATUS_PATH || "artifacts/blog-quality-gate.json";
+          let payload = { status: "unknown", hard_errors: [], soft_warnings: [] };
+          if (fs.existsSync(gatePath)) {
+            try {
+              payload = JSON.parse(fs.readFileSync(gatePath, "utf8"));
+            } catch (error) {
+              payload = { status: "unknown", hard_errors: [{ file: "-", message: error.message }], soft_warnings: [] };
+            }
+          }
+
+          const lines = [
+            "## Blog Quality Gate",
+            "",
+            `- Status: ${payload.status || "unknown"}`,
+            `- Checked files: ${(payload.checked_files || []).join(", ") || "-"}`,
+            `- Hard errors: ${(payload.hard_errors || []).length}`,
+            `- Soft warnings: ${(payload.soft_warnings || []).length}`,
+            `- Gate artifact: \`${gatePath}\``
+          ];
+
+          if ((payload.hard_errors || []).length > 0) {
+            lines.push("", "### Hard errors");
+            for (const err of payload.hard_errors.slice(0, 10)) {
+              lines.push(`- ${err.file}: ${err.message}`);
+            }
+          }
+
+          if ((payload.soft_warnings || []).length > 0) {
+            lines.push("", "### Soft warnings");
+            for (const warn of payload.soft_warnings.slice(0, 10)) {
+              lines.push(`- ${warn.file}: ${warn.message}`);
+            }
+          }
+
+          fs.appendFileSync(summaryPath, `${lines.join("\n")}\n`);
+          EOF
 
       - name: Verify changed files are build-safe
         run: pnpm run lint && pnpm run typecheck

--- a/.github/workflows/blog-autopublish.yml
+++ b/.github/workflows/blog-autopublish.yml
@@ -24,9 +24,11 @@ jobs:
     env:
       BLOG_AUTOPUBLISH_ENABLED: "true"
       BLOG_AUTOPUBLISH_TOPICS_PATH: docs/blog/automation/topics.json
+      BLOG_AUTOPUBLISH_STATUS_PATH: artifacts/blog-autopublish-status.json
       CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
       AUTOMATION_GH_TOKEN: ${{ secrets.AUTOMATION_GH_TOKEN }}
       CURSOR_MODEL: ${{ vars.CURSOR_MODEL || 'gpt-5.5' }}
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
       NEXT_PUBLIC_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
       NEXT_PUBLIC_APP_URL: http://localhost:3000
@@ -58,8 +60,58 @@ jobs:
             exit 1
           fi
 
-      - name: Generate this week's post with Cursor SDK
+      - name: Generate this week's post with Cursor SDK (attempt 1)
+        id: generate_attempt_1
+        continue-on-error: true
+        timeout-minutes: 12
         run: pnpm run blog:autopublish
+
+      - name: Retry generation once on failure
+        id: generate_attempt_2
+        if: steps.generate_attempt_1.outcome == 'failure'
+        continue-on-error: true
+        timeout-minutes: 12
+        run: pnpm run blog:autopublish
+
+      - name: Write autopublish run summary
+        if: always()
+        env:
+          ATTEMPT_1_OUTCOME: ${{ steps.generate_attempt_1.outcome }}
+          ATTEMPT_2_OUTCOME: ${{ steps.generate_attempt_2.outcome }}
+        run: |
+          node <<'EOF'
+          const fs = require("node:fs");
+          const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+          const statusPath = process.env.BLOG_AUTOPUBLISH_STATUS_PATH || "artifacts/blog-autopublish-status.json";
+          let status = { status: "unknown", message: `Status artifact not found at ${statusPath}` };
+          if (fs.existsSync(statusPath)) {
+            try {
+              status = JSON.parse(fs.readFileSync(statusPath, "utf8"));
+            } catch (error) {
+              status = { status: "unknown", message: `Could not parse status artifact: ${error.message}` };
+            }
+          }
+
+          const lines = [
+            "## Blog Autopublish Summary",
+            "",
+            `- Attempt 1 outcome: ${process.env.ATTEMPT_1_OUTCOME || "unknown"}`,
+            `- Attempt 2 outcome: ${process.env.ATTEMPT_2_OUTCOME || "not-run"}`,
+            `- Status: ${status.status || "unknown"}`,
+            `- Topic: ${status.topic_slug || "-"}`,
+            `- Failure type: ${status.failure_type || "-"}`,
+            `- Message: ${status.message || "-"}`,
+            `- Next action: ${status.next_action || "-"}`,
+            `- Status artifact: \`${statusPath}\``
+          ];
+          fs.appendFileSync(summaryPath, `${lines.join("\n")}\n`);
+          EOF
+
+      - name: Stop workflow if generation failed twice
+        if: steps.generate_attempt_1.outcome == 'failure' && steps.generate_attempt_2.outcome == 'failure'
+        run: |
+          echo "Generation failed on both attempts."
+          exit 1
 
       - name: Verify changed files are build-safe
         run: pnpm run lint && pnpm run typecheck

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Elevate helps teams turn **measurable AI outcomes** into repeatable workflows: p
 | [`docs/DEV_PROCESS_GITHUB.md`](docs/DEV_PROCESS_GITHUB.md) | Issues/PR/gh CLI + gstack — 원격 작업 큐·`pnpm issues:studio` |
 | [`docs/AI_ORCHESTRATION.md`](docs/AI_ORCHESTRATION.md) | AI 도구 레이어 (gstack·Memory Bank·규칙) |
 | [`docs/AI_AGENT_MATURITY_REPORT.md`](docs/AI_AGENT_MATURITY_REPORT.md) | AI 에이전트 활용 성숙도·벤치마크·점수 (리포트) |
+| [`docs/AUTOMATIONS_NO_SLACK_OPS.md`](docs/AUTOMATIONS_NO_SLACK_OPS.md) | Slack/Linear 없이 운영하는 Cloud Agent 자동화 3종 |
 | [`docs/MANUAL_OPERATOR_CHECKLIST.md`](docs/MANUAL_OPERATOR_CHECKLIST.md) | Toss / Supabase / PostHog / env 수동 작업 체크리스트 |
 | [`docs/AI_USER_TEMPLATES.md`](docs/AI_USER_TEMPLATES.md) | 버그·기능 요청 권장 형식 |
 | [`docs/AI_WORKFLOW_PORTABILITY.md`](docs/AI_WORKFLOW_PORTABILITY.md) | 다른 프로젝트로 워크플로 이식 시 수정 파일 |

--- a/docs/AI_USAGE.md
+++ b/docs/AI_USAGE.md
@@ -12,6 +12,7 @@
 5. **디자인 토큰·표면** — [`docs/design/SYSTEM.md`](./design/SYSTEM.md)  
 6. **PostHog 퍼널 (UI에서 구성)** — [`POSTHOG_FUNNELS.md`](./POSTHOG_FUNNELS.md)  
 7. **원격 이슈·PR 큐** — [`DEV_PROCESS_GITHUB.md`](./DEV_PROCESS_GITHUB.md) · `pnpm issues:studio`
+8. **Slack 없는 운영 자동화** — [`AUTOMATIONS_NO_SLACK_OPS.md`](./AUTOMATIONS_NO_SLACK_OPS.md)
 
 **자동**: 구현·버그·기능 요청은 `.cursor/rules/ai-session-bootstrap.mdc`가 위 컨텍스트를 로드한다.  
 **권장 입력 형식**: [`AI_USER_TEMPLATES.md`](./AI_USER_TEMPLATES.md) · **타 프로젝트 이식**: [`AI_WORKFLOW_PORTABILITY.md`](./AI_WORKFLOW_PORTABILITY.md).

--- a/docs/AUTOMATIONS_NO_SLACK_OPS.md
+++ b/docs/AUTOMATIONS_NO_SLACK_OPS.md
@@ -1,0 +1,196 @@
+# No-Slack Ops Automations (Cursor Cloud Agents)
+
+Slack/Linear 없이도 Elevate에서 운영 가능한 자동화 3종 설계안.
+
+기본 원칙:
+
+- Output은 Slack 대신 `GitHub PR`, `GitHub Issue`, `Repo docs`를 기본 채널로 사용한다.
+- 모든 자동화는 "실행 -> 산출물 생성 -> 링크 반환"이 끝나야 성공으로 본다.
+- 배포/머지는 자동화가 아니라 사람이 최종 승인한다.
+
+---
+
+## Automation 1: Weekly Blog Autopublish (already implemented)
+
+### A1 목적
+
+주 1회 블로그 초안 + 배포팩 자동 생성, PR까지 자동 생성.
+
+### A1 트리거
+
+- Schedule: 매주 월요일 00:00 UTC
+- Manual: `workflow_dispatch` with `push_mode=pr`
+
+### A1 실행 엔진
+
+- GitHub Actions: `.github/workflows/blog-autopublish.yml`
+- Script: `scripts/blog-autopublish-sdk.mjs`
+- Queue: `docs/blog/automation/topics.json`
+
+### A1 입력 소스
+
+- 큐에서 첫 `status=pending` 항목
+- `.env`/GitHub Secrets: `CURSOR_API_KEY`, `AUTOMATION_GH_TOKEN`
+
+### A1 출력 대상
+
+- `content/blog/en/<slug>.mdx`
+- `content/blog/ko/<slug>.mdx`
+- `docs/blog/distribution/<slug>.md`
+- queue 상태 `done` + `completed_at_utc`
+- GitHub PR (manual `push_mode=pr` 시)
+
+### A1 자동화 프롬프트 (system-style payload)
+
+```text
+You are Elevate's automated blog writer operating directly in the repository.
+Create production-ready EN/KO MDX posts and a distribution pack for one pending topic.
+
+Hard requirements:
+- Follow docs/BLOG_POST_PIPELINE.md and docs/templates/*.mdx.example
+- Write files:
+  - content/blog/en/<slug>.mdx
+  - content/blog/ko/<slug>.mdx
+  - docs/blog/distribution/<slug>.md
+- Frontmatter keys required: title, description, date, slug, tags, access_tier, locale
+- Keep EN and KO semantically aligned (not literal translation)
+- Update docs/blog/automation/topics.json: pending -> done, set completed_at_utc
+- Do not edit unrelated files.
+```
+
+---
+
+## Automation 2: Daily Critical Bug Finder (GitHub Issue mode)
+
+`cursor.com/marketplace`의 "Find critical bugs" 샘플을 Slack 없이 운영용으로 변환한 버전.
+
+### A2 목적
+
+최근 변경에서 high-severity correctness 버그를 찾아 "재현 가능한 이슈"로 남긴다.
+
+### A2 트리거
+
+- Schedule: 평일 매일 20:00 KST
+- Optional Manual: 운영자가 필요 시 수동 실행
+
+### A2 실행 범위
+
+- `main` 최근 24h 커밋
+- high-severity correctness only (data loss, auth bypass, crash, silent corruption)
+
+### A2 출력 대상
+
+- GitHub Issue (label: `auto-bug`, `severity:high`, `area:*`)
+- 재현 단계 + 영향 범위 + 권장 수정안 포함
+- false positive 가능성이 높으면 issue 생성 대신 `docs/internal/auto-findings/<date>.md`에만 기록
+
+### A2 자동화 프롬프트
+
+```text
+You are a deep bug-finding automation focused on high-severity correctness issues.
+
+Goal:
+- Inspect commits to main from the last 24 hours.
+- Report only validated high-impact findings.
+
+Investigation rules:
+- Trace code paths end-to-end; do not pattern-match diffs only.
+- Prioritize auth/permission, data consistency, irreversible writes, and crash paths.
+- Ignore style/perf-only concerns unless they cause correctness breakage.
+
+Output:
+1) If at least one high-confidence issue exists:
+   - Open GitHub issue(s) with:
+     - title: "[auto-bug] <short risk summary>"
+     - sections: Impact, Reproduction, Root-cause hypothesis, Suggested fix, Owner hint
+2) If no validated issue:
+   - Post a short "no critical findings" comment to the run summary.
+```
+
+상세 실행 런북: `docs/automations/daily-critical-bug-finder-github-issue.md`
+
+---
+
+## Automation 3: Weekly Documentation Drift Guard
+
+### A3 목적
+
+실제 코드와 문서 간 드리프트를 주 1회 점검해 docs 부채를 줄인다.
+
+### A3 트리거
+
+- Schedule: 매주 금요일 18:00 KST
+
+### A3 실행 범위
+
+- 최근 7일 변경 파일 + 핵심 운영 문서
+  - `README.md`
+  - `docs/DEVELOPMENT.md`
+  - `docs/BLOG_AUTOPUBLISH_SDK.md`
+  - `docs/BLOG_POST_PIPELINE.md`
+
+### A3 출력 대상
+
+- GitHub PR (branch: `chore/docs-drift-<date>`) 또는
+- 변경 없음이면 run summary에 "no drift"
+
+### A3 자동화 프롬프트
+
+```text
+You are a docs-drift guard for Elevate.
+
+Goal:
+- Compare code changes from last 7 days with key docs and update only factual mismatches.
+
+Constraints:
+- Do not rewrite voice or structure for style only.
+- Update only statements that are wrong/missing due to shipped code.
+- Keep changes minimal and verifiable.
+
+Required checks:
+- package scripts and workflow names are current
+- required env vars and secrets are documented
+- blog pipeline file paths still match repository reality
+
+Output:
+- Create a single docs-only PR with concise summary and verification checklist.
+```
+
+상세 실행 런북: `docs/automations/weekly-docs-drift-guard.md`
+
+---
+
+## Cloud Agent Automations quick sample (recommended to try first)
+
+`https://cursor.com/docs/cloud-agent/automations` 기준으로는 아래 순서가 가장 안전하다:
+
+1. **Find critical bugs** 템플릿 복제
+2. Output을 Slack 대신 **GitHub Issue**로 변경
+3. Trigger를 daily로 설정
+4. 첫 1주일은 "report-only" 모드로 false positive 비율 확인
+
+### Dry-run protocol (first week)
+
+- Day 1-3: report-only (no issue/PR creation), summary only
+- Day 4-5: enable output creation only for high-confidence findings
+- Week-end: review false-positive ratio and tighten prompts/labels before full automation mode
+
+---
+
+## Linear, 써야 하나?
+
+현재 조건(회사에서 Linear 미사용)에서는 **필수 아님**.
+
+- 지금 당장: GitHub Issues + PR만으로 충분
+- 나중에 고려: PM/ops 티켓 워크플로가 복잡해지면 도입 검토
+- 기준: 주간 이슈 triage가 30개 이상이고, 우선순위/소유자 관리가 GitHub만으로 버거울 때
+
+즉, 지금은 **Linear 없이도 자동화 ROI가 충분히 나온다.**
+
+---
+
+## Operations scorecard
+
+주간 지표/실패 분류/운영자 핸드오프 기준:
+
+- `docs/automations/operations-scorecard.md`

--- a/docs/BLOG_AUTOPUBLISH_SDK.md
+++ b/docs/BLOG_AUTOPUBLISH_SDK.md
@@ -117,3 +117,18 @@ The SDK runner writes `artifacts/blog-autopublish-status.json` with `failure_typ
 | `content_validation` | Queue schema/output file mismatch | Fix `docs/blog/automation/topics.json` or output expectations |
 | `unknown` | Uncategorized failure | Check summary + full logs, then rerun with `push_mode=pr` |
 
+## 7) Quality gate policy (hard vs soft)
+
+Workflow runs `pnpm run blog:quality-gate` after generation.
+
+- Hard fail (blocks commit/PR):
+  - missing frontmatter required keys
+  - locale/slug/date structural mismatches
+  - invalid internal CTA/link constraints (`/#waitlist`, `/ko#waitlist`)
+- Soft fail (non-blocking warning in run summary):
+  - repetitive AI boilerplate phrase detection
+
+Quality gate artifact:
+
+- `artifacts/blog-quality-gate.json`
+

--- a/docs/BLOG_AUTOPUBLISH_SDK.md
+++ b/docs/BLOG_AUTOPUBLISH_SDK.md
@@ -46,6 +46,7 @@ Workflow: `.github/workflows/blog-autopublish.yml`
 Required GitHub repository secret:
 
 - `CURSOR_API_KEY`: your Cursor API key
+- `AUTOMATION_GH_TOKEN`: PAT used by `create-pull-request` step when org default workflow permission is read-only
 
 Optional GitHub repository variable:
 
@@ -90,3 +91,29 @@ Use `docs/blog/automation/topics.json`:
 - Keep `CURSOR_API_KEY` out of source control.
 - If branch protection blocks direct push to `main`, use manual `push_mode=pr`.
 - For deployment, use your existing main-branch deploy pipeline (e.g. Vercel auto-deploy on push).
+
+## 5) Token scope minimums (`AUTOMATION_GH_TOKEN`)
+
+Recommended minimum repository scopes:
+
+- `repo` (required for branch push + PR creation in private repos)
+- `workflow` (recommended for operational reruns/dispatch visibility)
+
+If your org allows fine-grained PATs, grant:
+
+- **Repository contents**: Read and write
+- **Pull requests**: Read and write
+- **Actions**: Read (write optional for dispatch APIs)
+
+## 6) Failure recovery playbook
+
+The SDK runner writes `artifacts/blog-autopublish-status.json` with `failure_type`.
+
+| failure_type | Typical cause | Operator action |
+|--------------|---------------|-----------------|
+| `auth` | Missing/invalid `CURSOR_API_KEY` or PR token mismatch | Rotate/update repo secrets and rerun workflow |
+| `env` | Required env var missing from workflow mapping | Fix env mapping in workflow and rerun |
+| `sdk_runtime` | SDK runtime dependency issue (`sqlite3`, ripgrep path, runtime agent error) | Reinstall runtime deps / inspect logs / rerun once |
+| `content_validation` | Queue schema/output file mismatch | Fix `docs/blog/automation/topics.json` or output expectations |
+| `unknown` | Uncategorized failure | Check summary + full logs, then rerun with `push_mode=pr` |
+

--- a/docs/BLOG_POST_PIPELINE.md
+++ b/docs/BLOG_POST_PIPELINE.md
@@ -203,6 +203,15 @@ Document the **exact query strings** in the pack so schedulers don’t invent ad
 - [ ] Front matter includes **`ogImage`** when you want post-specific link previews (see §3).
 - [ ] **Voice:** §**2.5** pass done—read aloud once per locale; KO does not read like English translated line-by-line.
 
+### 7.1 Automation quality gate (SDK workflow)
+
+For SDK automation runs, quality is enforced by `pnpm run blog:quality-gate`:
+
+- **Hard fail** (blocks auto PR): frontmatter/schema/link/locale mismatches.
+- **Soft warning** (non-blocking): repetitive AI boilerplate phrase patterns.
+
+Gate status artifact path: `artifacts/blog-quality-gate.json`.
+
 ---
 
 ## 8. SemVer release posts (product “we ship” narrative)

--- a/docs/automations/daily-critical-bug-finder-github-issue.md
+++ b/docs/automations/daily-critical-bug-finder-github-issue.md
@@ -1,0 +1,53 @@
+# Daily Critical Bug Finder (GitHub Issue Output)
+
+## Purpose
+
+Detect high-severity correctness regressions from recent `main` changes and open actionable GitHub issues without Slack dependency.
+
+## Trigger cadence
+
+- Schedule: weekdays at 20:00 KST
+- Optional manual run: on-demand after large merges
+
+## Output target
+
+- Primary: GitHub Issue(s)
+- Labels: `auto-bug`, `severity:high`, `area:*`
+- Secondary (report-only): run summary note when no validated findings
+
+## Exact system prompt
+
+```text
+You are a deep bug-finding automation focused on high-severity correctness issues.
+
+Goal:
+- Inspect commits to main from the last 24 hours.
+- Report only validated high-impact findings.
+
+Investigation rules:
+- Trace code paths end-to-end; do not pattern-match diffs only.
+- Prioritize auth/permission, data consistency, irreversible writes, and crash paths.
+- Ignore style/perf-only concerns unless they cause correctness breakage.
+
+Output:
+1) If at least one high-confidence issue exists:
+   - Open GitHub issue(s) with:
+     - title: "[auto-bug] <short risk summary>"
+     - sections: Impact, Reproduction, Root-cause hypothesis, Suggested fix, Owner hint
+2) If no validated issue:
+   - Post a short "no critical findings" comment to the run summary.
+```
+
+## False-positive policy
+
+- Week 1 default: report-only mode (no auto issue creation), compare with human review.
+- If confidence is below 0.8, do not open issue; write report-only summary.
+- If same pattern appears repeatedly for 3 days, escalate to issue even with medium confidence.
+
+## Owner handoff checklist
+
+- [ ] Confirm reproduction steps are deterministic.
+- [ ] Add/normalize labels (`auto-bug`, `severity:high`, `area:*`).
+- [ ] Assign provisional owner from touched subsystem.
+- [ ] Link relevant commit(s)/PR(s) in issue body.
+- [ ] Add a short “accept/reject automation finding” comment for feedback loop.

--- a/docs/automations/operations-scorecard.md
+++ b/docs/automations/operations-scorecard.md
@@ -1,0 +1,42 @@
+# Automations Operations Scorecard
+
+Automation 운영 안정성과 콘텐츠 품질을 주간 단위로 측정하기 위한 기준 문서.
+
+## Weekly metrics
+
+| Metric | Target | Source |
+|--------|--------|--------|
+| `autopublish_success_rate` | >= 90% (2주 이동 평균) | GitHub Actions run result |
+| `failure_classification_coverage` | 100% | `artifacts/blog-autopublish-status.json` |
+| `merge_ready_draft_ratio` | >= 60% | blog auto PR 리뷰 결과 |
+| `false_positive_rate_bug_finder` | <= 20% (dry week) | automation finding vs human verdict |
+| `docs_drift_pr_precision` | >= 80% | docs drift PR accepted changes 비율 |
+
+## Failure taxonomy (source of truth)
+
+- `auth`: secret/token invalid or missing
+- `env`: workflow/script env mapping mismatch
+- `sdk_runtime`: runtime dependency or SDK execution layer failure
+- `content_validation`: queue/output/schema mismatch
+- `unknown`: uncategorized (must be triaged and reclassified within 24h)
+
+## Operator handoff checklist
+
+When an automation run fails:
+
+- [ ] Confirm `failure_type` from status artifact.
+- [ ] Confirm whether this is first-time or repeated failure pattern.
+- [ ] Apply mapped recovery action from `docs/BLOG_AUTOPUBLISH_SDK.md`.
+- [ ] Re-run once manually (`workflow_dispatch`, `push_mode=pr`).
+- [ ] If still failing, open GitHub issue with logs and artifact payload.
+
+When an automation run succeeds:
+
+- [ ] Verify expected output target was produced (PR/Issue/docs update).
+- [ ] Verify labels/owners are attached for downstream action.
+- [ ] Add one-line weekly note on quality trend (better/same/worse).
+
+## Review cadence
+
+- Weekly: quick review (15 min) of metrics and top 1 failure cluster.
+- Monthly: prompt/rule tuning based on false positives and merge-ready ratio.

--- a/docs/automations/weekly-docs-drift-guard.md
+++ b/docs/automations/weekly-docs-drift-guard.md
@@ -1,0 +1,58 @@
+# Weekly Docs Drift Guard (Docs-only PR Output)
+
+## Purpose
+
+Reduce documentation drift by reconciling shipped code changes against core operating docs once per week.
+
+## Trigger cadence
+
+- Schedule: Fridays at 18:00 KST
+- Optional manual run: after infra/workflow changes
+
+## Output target
+
+- Primary: docs-only GitHub PR (`chore/docs-drift-<date>`)
+- Secondary: run summary with `no drift` when no updates are needed
+
+## Exact system prompt
+
+```text
+You are a docs-drift guard for Elevate.
+
+Goal:
+- Compare code changes from last 7 days with key docs and update only factual mismatches.
+
+Constraints:
+- Do not rewrite voice or structure for style only.
+- Update only statements that are wrong/missing due to shipped code.
+- Keep changes minimal and verifiable.
+
+Required checks:
+- package scripts and workflow names are current
+- required env vars and secrets are documented
+- blog pipeline file paths still match repository reality
+
+Output:
+- Create a single docs-only PR with concise summary and verification checklist.
+```
+
+## Source docs to inspect first
+
+- `README.md`
+- `docs/DEVELOPMENT.md`
+- `docs/BLOG_AUTOPUBLISH_SDK.md`
+- `docs/BLOG_POST_PIPELINE.md`
+- `docs/AUTOMATIONS_NO_SLACK_OPS.md`
+
+## False-positive policy
+
+- Do not open PR for wording/style-only edits.
+- If candidate changes are ambiguous, emit run summary with “manual review needed” and skip PR.
+- Require at least one concrete mismatch (command/path/env var) to open PR.
+
+## Owner handoff checklist
+
+- [ ] Ensure PR is docs-only (no app/runtime code changes).
+- [ ] Validate changed command/path/env references against repository state.
+- [ ] Confirm no stale links introduced.
+- [ ] Merge if low risk; otherwise request owner review by subsystem.

--- a/docs/features/INIT-automations-blog-quality-2026-04-30.md
+++ b/docs/features/INIT-automations-blog-quality-2026-04-30.md
@@ -1,0 +1,98 @@
+# INIT — Automations Stabilization + Blog Quality Uplift (2026-04-30)
+
+## 요청 요약
+
+- Slack/Linear 없이 운영 가능한 자동화를 안정화한다.
+- 블로그 자동 생성 결과물의 품질을 높이고, 실패 시 안전하게 복구 가능한 운영 루프를 만든다.
+- Cursor Cloud Agent Automations 템플릿을 Elevate 운영 방식(GitHub 중심)으로 변환한다.
+
+## 현재 상태 (기준선)
+
+- Blog autopublish SDK 경로 구축 완료:
+  - Script: `scripts/blog-autopublish-sdk.mjs`
+  - Workflow: `.github/workflows/blog-autopublish.yml`
+  - Queue: `docs/blog/automation/topics.json`
+- 실제 자동화 실행으로 PR 생성 확인:
+  - `chore(blog): auto-publish weekly post via Cursor SDK` PR 생성 성공
+- No-Slack 운영형 자동화 설계 문서 추가:
+  - `docs/AUTOMATIONS_NO_SLACK_OPS.md`
+
+## INIT에서 확인된 리스크/교훈
+
+1. **조직 정책 제약**
+   - 기본 GitHub Actions workflow permission이 `read`로 고정되어 `GITHUB_TOKEN`으로 PR 생성 실패.
+   - 해결: `AUTOMATION_GH_TOKEN` secret 사용.
+
+2. **SDK 런타임 안정성**
+   - 로컬 환경에서 `sqlite3` native binding 이슈로 초기 실행 실패 가능.
+   - 해결: build script 허용/재설치(`pnpm approve-builds --all`) + 환경 문서화 필요.
+
+3. **품질 게이트 미흡**
+   - 현재 자동 생성 후 lint/typecheck는 있으나, 블로그 콘텐츠 품질(사실성/톤/CTA/링크) gate가 약함.
+
+4. **운영 가시성 부족**
+   - "왜 실패했는지"와 "수동 개입이 필요한지"를 빠르게 판단할 대시보드/이슈 룰이 아직 약함.
+
+## 복잡도
+
+**L3** (워크플로우/운영 자동화 + 콘텐츠 품질 게이트 + 문서/운영 루프 정합).
+
+- 파일 수: 6-12 예상
+- 설계 결정: 필요 (품질 gate 기준, 실패 정책, PR/Issue 라우팅)
+- DB 변경: 없음
+
+## 범위 (이번 INIT의 대상)
+
+### 포함
+
+- Blog autopublish 안정화 (실행 신뢰도, 실패 내구성, 운영 문서)
+- 콘텐츠 품질 게이트 정의 (자동/수동 경계 포함)
+- Cloud Agent Automations 샘플 1~2개를 GitHub 출력 중심으로 변환
+
+### 제외
+
+- 결제/구독 도메인 로직 변경
+- PostHog 대시보드 신규 제품 분석 설계
+- 대규모 콘텐츠 전략 리브랜딩
+
+## Plan 입력용 체크리스트 (다음 모드)
+
+### P1. 운영 안정화 (Automation Reliability)
+
+- [ ] `.github/workflows/blog-autopublish.yml` 실패 분기 강화:
+  - SDK 생성 단계 timeout/재시도 정책
+  - 실패 시 run summary에 root-cause 요약
+- [ ] 워크플로 실행 환경 호환성 업데이트:
+  - Node 20 deprecation 경고 대응(액션 버전/런타임 정책)
+- [ ] `AUTOMATION_GH_TOKEN` 최소 권한 가이드 문서화
+
+### P2. 콘텐츠 품질 게이트 (Quality Gate)
+
+- [ ] 자동 검증 스크립트 추가(또는 워크플로 단계):
+  - frontmatter 필수 키
+  - locale/slug/date/cta 링크 정합
+  - 금지 패턴(과도한 AI 템플릿 문구) 점검
+- [ ] 품질 점수 카드 정의:
+  - 정확성, 실행 가능성, 톤 일관성, CTA 명확성
+- [ ] fail-open vs fail-closed 정책 확정
+
+### P3. No-Slack 운영형 Automations 실행화
+
+- [ ] Daily Critical Bug Finder를 GitHub Issue output으로 PoC
+- [ ] Weekly Docs Drift Guard를 docs-only PR output으로 PoC
+- [ ] 실행 로그를 운영자가 5분 내 판단 가능한 형태로 표준화
+
+## 성공 기준 (REFLECT에서 검증)
+
+- 자동화 2주 연속 성공률 >= 90% (수동 재실행 제외 기준)
+- 생성 결과물 중 "수정 없이 merge 가능한 초안" 비율 >= 60%
+- 실패 케이스 100%에서 원인 분류(권한/환경/프롬프트/품질) 가능
+
+## 다음 모드
+
+### PLAN
+
+- 산출물:
+  1) `PLAN-automations-blog-quality-stabilization.md`
+  2) 작업 슬라이스(신뢰성/품질게이트/운영가시성)별 PR 단위 계획
+  3) 품질 게이트 fail 정책 확정(차단 vs 라벨링)

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,20 +2,24 @@
 
 ## 현재 페이즈 (활성)
 
-**INIT (2026-04-28) — Blog Subscription (Lemon Squeezy, Phase 1)**
+**INIT (2026-04-30) — Automations Stabilization + Blog Quality Uplift**
 
-**브랜치:** `main` (직전 Editors Desk v3 PR #21 merge 완료 상태)  
-**SoT:** [`docs/features/INIT-blog-subscription-lemon-phase1.md`](../docs/features/INIT-blog-subscription-lemon-phase1.md)
+**브랜치:** `main`  
+**SoT:** [`docs/features/INIT-automations-blog-quality-2026-04-30.md`](../docs/features/INIT-automations-blog-quality-2026-04-30.md)
 
-**복잡도:** **L4** — DB 구독 스키마 + Lemon subscription webhook 확장 + 블로그 프리미엄 접근제어 + paywall CTA + pricing/manage UX를 기존 결제 인프라 위에 증설.
+**복잡도:** **L3** — Cloud/GitHub 자동화 신뢰성 보강 + 콘텐츠 품질 게이트 + 운영 가시성 표준화.
 
 **핵심 목표:**
-- 기존 단일 구독/권한 구조를 재작성하지 않고 확장
-- 블로그 전용 3티어(`free`, `monthly`, `annual`) 도입
-- Lemon Variant 고정 매핑 (`1585015`/`1585028`)
-- 프리미엄 포스트 preview cutoff + CTA reusable 컴포넌트
+- Slack/Linear 없이 GitHub 중심으로 automations 운영 안정화
+- 블로그 자동 생성 결과물에 품질 게이트(정합/톤/CTA/링크) 적용
+- Cloud Agent Automations 샘플을 Elevate 운영 플로우에 맞게 PoC
 
-**다음 단계:** **PLAN** (데이터 모델 확정 -> webhook/event lifecycle 설계 -> UI 접근제어 계약 확정).
+**다음 단계:** **PLAN** (신뢰성/품질 게이트/운영 가시성 3슬라이스 상세 계획 및 fail 정책 확정).
+
+---
+
+**직전 활성 페이즈 (2026-04-28) — Blog Subscription (Lemon Squeezy, Phase 1)**
+**SoT:** [`docs/features/INIT-blog-subscription-lemon-phase1.md`](../docs/features/INIT-blog-subscription-lemon-phase1.md)
 
 **04-24 학습(반드시 회피):**
 - L1: PostCSS 8.4.31 + Turbopack은 CSS 주석의 em-dash(`U+2014`)에 `Unknown word` 에러 → tokens.css/globals.css 주석 ASCII-only.

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -71,6 +71,21 @@
 
 ---
 
+## INIT — Automations Stabilization + Blog Quality Uplift (2026-04-30)
+
+**SoT:** [`docs/features/INIT-automations-blog-quality-2026-04-30.md`](../docs/features/INIT-automations-blog-quality-2026-04-30.md)  
+**복잡도:** **L3** — GitHub 중심 자동화 안정화 + 블로그 품질 게이트 + 운영 가시성 정렬.
+
+### 체크리스트 (PLAN 입력용)
+
+- [ ] **Automation reliability:** `blog-autopublish` 실패 분기/timeout/재시도/요약 강화 + Node 20 deprecation 대응
+- [ ] **Secrets & permissions:** `CURSOR_API_KEY`/`AUTOMATION_GH_TOKEN` 최소 권한 운영 가이드 확정
+- [ ] **Quality gate:** frontmatter/CTA/locale/slug/링크 정합 + AI 템플릿 냄새 탐지 기준 확정
+- [ ] **No-Slack automation PoC:** Critical bug finder -> GitHub Issue, Docs drift guard -> docs-only PR
+- [ ] **Success metrics:** 2주 연속 성공률/초안 merge-ready 비율/실패 원인 분류 체계 정의
+
+---
+
 ## AI 피벗 — Phase A (문서·랜딩·도구)
 
 | # | 항목 | 상태 |

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "db:types": "node scripts/gen-db-types.mjs",
     "buffer:retry-step4": "node scripts/retry-buffer-step4.mjs",
     "blog:autopublish": "node scripts/blog-autopublish-sdk.mjs",
+    "blog:quality-gate": "node scripts/blog-quality-gate.mjs",
     "worker:assembly": "tsx workers/video-assembly/run.ts",
     "prepare": "husky"
   },

--- a/scripts/blog-autopublish-sdk.mjs
+++ b/scripts/blog-autopublish-sdk.mjs
@@ -18,6 +18,10 @@ const dryRun = process.env.BLOG_AUTOPUBLISH_DRY_RUN === "true";
 const enabled = process.env.BLOG_AUTOPUBLISH_ENABLED === "true";
 const modelId = process.env.CURSOR_MODEL || "gpt-5.5";
 const apiKey = process.env.CURSOR_API_KEY;
+const statusPath = path.resolve(
+  cwd,
+  process.env.BLOG_AUTOPUBLISH_STATUS_PATH || "artifacts/blog-autopublish-status.json"
+);
 
 function configureRipgrep() {
   if (typeof configureRipgrepPath !== "function") return;
@@ -136,33 +140,117 @@ async function assertOutputFiles(topic) {
   }
 }
 
+function classifyFailure(error) {
+  const message = String(error?.message || error || "");
+  if (message.includes("Missing required environment variable: CURSOR_API_KEY")) return "auth";
+  if (message.includes("Missing required environment variable")) return "env";
+  if (message.includes("Invalid queue format") || message.includes("Missing expected output file")) {
+    return "content_validation";
+  }
+  if (
+    message.includes("sqlite3") ||
+    message.includes("Ripgrep path not configured") ||
+    message.includes("SDK run emitted error event")
+  ) {
+    return "sdk_runtime";
+  }
+  return "unknown";
+}
+
+function nextActionForFailureType(failureType) {
+  if (failureType === "auth") {
+    return "Check CURSOR_API_KEY and AUTOMATION_GH_TOKEN secrets in repository settings.";
+  }
+  if (failureType === "env") {
+    return "Check required env vars and workflow env mapping for autopublish steps.";
+  }
+  if (failureType === "sdk_runtime") {
+    return "Check sdk runtime dependencies (sqlite3 build, ripgrep path) and retry once.";
+  }
+  if (failureType === "content_validation") {
+    return "Review queue schema/output files and rerun after fixing topic payload.";
+  }
+  return "Inspect workflow logs and rerun manually with push_mode=pr.";
+}
+
+async function emitStatus(statusPayload) {
+  await fs.mkdir(path.dirname(statusPath), { recursive: true });
+  await fs.writeFile(statusPath, `${JSON.stringify(statusPayload, null, 2)}\n`, "utf8");
+  console.log(`[blog-autopublish] Status artifact: ${path.relative(cwd, statusPath)}`);
+  console.log(`[blog-autopublish][status] ${JSON.stringify(statusPayload)}`);
+}
+
 async function main() {
   configureRipgrep();
-  if (!enabled && !dryRun) {
-    console.log("[blog-autopublish] BLOG_AUTOPUBLISH_ENABLED is not true. Exiting.");
-    return;
+  const startedAt = new Date().toISOString();
+  let topicSlug = null;
+  try {
+    if (!enabled && !dryRun) {
+      const statusPayload = {
+        status: "skipped",
+        reason: "BLOG_AUTOPUBLISH_ENABLED is not true",
+        started_at_utc: startedAt,
+        ended_at_utc: new Date().toISOString()
+      };
+      await emitStatus(statusPayload);
+      return;
+    }
+
+    const queue = await readTopicsQueue();
+    const index = queue.topics.findIndex((t) => t.status === "pending");
+    if (index < 0) {
+      const statusPayload = {
+        status: "skipped",
+        reason: "No pending topic found",
+        started_at_utc: startedAt,
+        ended_at_utc: new Date().toISOString()
+      };
+      await emitStatus(statusPayload);
+      return;
+    }
+
+    const topic = sanitizeTopic(queue.topics[index]);
+    topicSlug = topic.slug;
+    const prompt = buildPrompt(topic);
+
+    if (dryRun) {
+      console.log("[blog-autopublish] Dry run enabled. Prompt preview:");
+      console.log(prompt);
+      const statusPayload = {
+        status: "dry_run",
+        topic_slug: topic.slug,
+        started_at_utc: startedAt,
+        ended_at_utc: new Date().toISOString()
+      };
+      await emitStatus(statusPayload);
+      return;
+    }
+
+    console.log(`[blog-autopublish] Running SDK agent for topic: ${topic.slug}`);
+    await runAgent(prompt);
+    await assertOutputFiles(topic);
+    console.log(`[blog-autopublish] Completed topic: ${topic.slug}`);
+    const statusPayload = {
+      status: "success",
+      topic_slug: topic.slug,
+      started_at_utc: startedAt,
+      ended_at_utc: new Date().toISOString()
+    };
+    await emitStatus(statusPayload);
+  } catch (error) {
+    const failureType = classifyFailure(error);
+    const statusPayload = {
+      status: "failed",
+      topic_slug: topicSlug,
+      failure_type: failureType,
+      message: String(error?.message || error || "Unknown error"),
+      next_action: nextActionForFailureType(failureType),
+      started_at_utc: startedAt,
+      ended_at_utc: new Date().toISOString()
+    };
+    await emitStatus(statusPayload);
+    throw error;
   }
-
-  const queue = await readTopicsQueue();
-  const index = queue.topics.findIndex((t) => t.status === "pending");
-  if (index < 0) {
-    console.log("[blog-autopublish] No pending topic found. Exiting.");
-    return;
-  }
-
-  const topic = sanitizeTopic(queue.topics[index]);
-  const prompt = buildPrompt(topic);
-
-  if (dryRun) {
-    console.log("[blog-autopublish] Dry run enabled. Prompt preview:");
-    console.log(prompt);
-    return;
-  }
-
-  console.log(`[blog-autopublish] Running SDK agent for topic: ${topic.slug}`);
-  await runAgent(prompt);
-  await assertOutputFiles(topic);
-  console.log(`[blog-autopublish] Completed topic: ${topic.slug}`);
 }
 
 main().catch((error) => {

--- a/scripts/blog-quality-gate.mjs
+++ b/scripts/blog-quality-gate.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import matter from "gray-matter";
+
+const cwd = process.cwd();
+const statusPath = path.resolve(
+  cwd,
+  process.env.BLOG_QUALITY_GATE_STATUS_PATH || "artifacts/blog-quality-gate.json"
+);
+
+const HARD_REQUIRED_KEYS = ["title", "description", "date", "slug", "tags", "access_tier", "locale"];
+const ACCESS_TIERS = new Set(["public", "member", "premium"]);
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+const SOFT_AI_PHRASES_EN = [
+  "in today's fast-paced world",
+  "game changer",
+  "unprecedented",
+  "it is important to note that",
+  "delve into"
+];
+
+const SOFT_AI_PHRASES_KO = ["빠르게 변화하는 시대", "게임 체인저", "시너지 효과", "혁신적인"];
+
+function parseGitStatusPaths() {
+  const raw = execSync("git status --porcelain", {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"]
+  });
+  return raw
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => {
+      const rawPath = line.slice(3).trim();
+      if (rawPath.includes(" -> ")) {
+        return rawPath.split(" -> ").at(-1);
+      }
+      return rawPath;
+    });
+}
+
+function findCandidateBlogFiles(paths) {
+  return paths.filter((p) => /^content\/blog\/(en|ko)\/[^/]+\.mdx$/.test(p));
+}
+
+function pushError(errors, file, message) {
+  errors.push({ file, message });
+}
+
+function pushWarning(warnings, file, message) {
+  warnings.push({ file, message });
+}
+
+async function writeStatus(payload) {
+  await fs.mkdir(path.dirname(statusPath), { recursive: true });
+  await fs.writeFile(statusPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  console.log(`[blog-quality-gate] Status artifact: ${path.relative(cwd, statusPath)}`);
+  console.log(`[blog-quality-gate][status] ${JSON.stringify(payload)}`);
+}
+
+function validateMarkdownLinks(content, file, errors) {
+  const linkRe = /\[[^\]]+\]\(([^)]+)\)/g;
+  for (const match of content.matchAll(linkRe)) {
+    const href = match[1].trim();
+    if (!href) {
+      pushError(errors, file, "Empty markdown link href detected.");
+      continue;
+    }
+    if (href.startsWith("/") && href.includes(" ")) {
+      pushError(errors, file, `Internal link contains spaces: ${href}`);
+    }
+  }
+}
+
+async function run() {
+  const changedPaths = parseGitStatusPaths();
+  const candidates = findCandidateBlogFiles(changedPaths);
+
+  if (candidates.length === 0) {
+    await writeStatus({
+      status: "skipped",
+      reason: "No changed EN/KO blog MDX files found",
+      checked_files: []
+    });
+    return;
+  }
+
+  const hardErrors = [];
+  const softWarnings = [];
+  const slugLocaleMeta = new Map();
+
+  for (const relPath of candidates) {
+    const absPath = path.resolve(cwd, relPath);
+    const raw = await fs.readFile(absPath, "utf8");
+    const parsed = matter(raw);
+    const meta = parsed.data || {};
+    const localeFromPath = relPath.split("/")[2];
+    const slugFromPath = path.basename(relPath, ".mdx");
+
+    for (const key of HARD_REQUIRED_KEYS) {
+      if (!(key in meta)) {
+        pushError(hardErrors, relPath, `Missing required frontmatter key: ${key}`);
+      }
+    }
+
+    if (meta.locale && meta.locale !== localeFromPath) {
+      pushError(hardErrors, relPath, `Frontmatter locale '${meta.locale}' must match path locale '${localeFromPath}'.`);
+    }
+
+    if (meta.slug && meta.slug !== slugFromPath) {
+      pushError(hardErrors, relPath, `Frontmatter slug '${meta.slug}' must match filename slug '${slugFromPath}'.`);
+    }
+
+    if (meta.date && !DATE_RE.test(String(meta.date))) {
+      pushError(hardErrors, relPath, `Frontmatter date must use YYYY-MM-DD: '${meta.date}'.`);
+    }
+
+    if (meta.access_tier && !ACCESS_TIERS.has(meta.access_tier)) {
+      pushError(
+        hardErrors,
+        relPath,
+        `Invalid access_tier '${meta.access_tier}'. Allowed: public|member|premium.`
+      );
+    }
+
+    if (meta.tags && !Array.isArray(meta.tags)) {
+      pushError(hardErrors, relPath, "Frontmatter tags must be an array.");
+    }
+
+    validateMarkdownLinks(raw, relPath, hardErrors);
+
+    if (localeFromPath === "en" && !raw.includes("/#waitlist")) {
+      pushError(hardErrors, relPath, "English post must include waitlist CTA link '/#waitlist'.");
+    }
+    if (localeFromPath === "ko" && !raw.includes("/ko#waitlist")) {
+      pushError(hardErrors, relPath, "Korean post must include waitlist CTA link '/ko#waitlist'.");
+    }
+
+    const softPhrases = localeFromPath === "en" ? SOFT_AI_PHRASES_EN : SOFT_AI_PHRASES_KO;
+    const lowered = raw.toLowerCase();
+    for (const phrase of softPhrases) {
+      const exists = localeFromPath === "en" ? lowered.includes(phrase) : raw.includes(phrase);
+      if (exists) {
+        pushWarning(
+          softWarnings,
+          relPath,
+          `Potential boilerplate phrase detected: '${phrase}' (soft warning).`
+        );
+      }
+    }
+
+    if (!slugLocaleMeta.has(slugFromPath)) slugLocaleMeta.set(slugFromPath, {});
+    slugLocaleMeta.get(slugFromPath)[localeFromPath] = meta;
+  }
+
+  for (const [slug, localeMeta] of slugLocaleMeta.entries()) {
+    const enPath = path.resolve(cwd, `content/blog/en/${slug}.mdx`);
+    const koPath = path.resolve(cwd, `content/blog/ko/${slug}.mdx`);
+    if (!existsSync(enPath) || !existsSync(koPath)) {
+      pushError(
+        hardErrors,
+        slug,
+        "Both EN and KO files must exist for generated slug (content/blog/en + content/blog/ko)."
+      );
+      continue;
+    }
+    if (localeMeta.en?.date && localeMeta.ko?.date && localeMeta.en.date !== localeMeta.ko.date) {
+      pushError(hardErrors, slug, "EN/KO date mismatch for same slug.");
+    }
+  }
+
+  const payload = {
+    status: hardErrors.length > 0 ? "failed" : softWarnings.length > 0 ? "passed_with_warnings" : "passed",
+    checked_files: candidates,
+    hard_errors: hardErrors,
+    soft_warnings: softWarnings
+  };
+  await writeStatus(payload);
+
+  if (hardErrors.length > 0) {
+    throw new Error("Blog quality gate failed with hard errors.");
+  }
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add no-Slack automation operating guide and two executable runbooks (critical bug finder, docs drift guard)
- add weekly operations scorecard (metrics, failure taxonomy, handoff checklist)
- update AI/docs entry points and memory-bank anchors to connect INIT -> operations execution

## Test plan
- docs-only review for runbook completeness (trigger, prompt, output, false-positive policy, handoff)
- Verify links and referenced paths exist in repo

Made with [Cursor](https://cursor.com)