### PR TITLE
feat(content-ops): harden review gate, retry publish, and ops runbook

### DIFF
--- a/docs/features/IA-admin-content-ops.md
+++ b/docs/features/IA-admin-content-ops.md
@@ -1,0 +1,122 @@
+# IA — `/admin` Content Ops
+
+## Goal
+
+Provide a practical operator interface for:
+
+- reviewing generated content
+- scheduling/publishing approved content
+- managing ingestion sources
+- tracking automation runs
+- handling subscriber lifecycle
+
+## Route Map
+
+## 1) `/admin/content-queue`
+
+Primary queue board for editorial operations.
+
+### List view
+
+- Columns: `type`, `title`, `status`, `scheduled_at`, `source_quality_score`, `updated_at`
+- Filters:
+  - `type`: `blog`, `newsletter`
+  - `status`: `draft`, `review_required`, `approved`, `scheduled`, `publishing`, `published`, `send_failed`, `rejected`
+  - date range (`updated_at`, `scheduled_at`)
+  - reviewer (`reviewed_by`)
+  - locale
+
+### Item detail panel
+
+- Content preview (summary + markdown body)
+- Source attribution list (from `content_item_source_map`)
+- Quality/fact-check signal
+- Review notes history
+
+### Actions
+
+- `Approve`
+- `Reject`
+- `Request changes` (sets `review_required` + note)
+- `Schedule`
+- `Publish now`
+- `Retry publish/send` (for failed states)
+- `Duplicate as draft` (optional, phase 2)
+
+## 2) `/admin/news-sources`
+
+Source registry and weighting controls.
+
+### List view
+
+- Columns: `name`, `kind`, `is_active`, `trust_weight`, `fetch_interval_minutes`, `updated_at`
+- Filters: active/inactive, kind, tags
+
+### Actions
+
+- `Add source`
+- `Disable/Enable`
+- `Edit trust weight`
+- `Run ingest now` (manual trigger)
+- `Preview latest entries` (read-only inspector)
+
+## 3) `/admin/runs`
+
+Automation run monitoring and operational recovery.
+
+### List view
+
+- Columns: `run_type`, `status`, `trigger_type`, `started_at`, `ended_at`, `error_summary`
+- Filters: status, run type, date range
+
+### Actions
+
+- `Re-run`
+- `View logs`
+- `Cancel` (if currently running)
+- `Retry failed unit` (phase 2, per-item)
+
+## 4) `/admin/subscribers`
+
+Subscriber lifecycle operations for newsletter.
+
+### List view
+
+- Columns: `email`, `status`, `frequency_pref`, `locale`, `consent_at`, `unsubscribe_at`, `source`
+- Filters: status, frequency, locale, tags
+
+### Actions
+
+- `Add subscriber`
+- `Mark unsubscribed`
+- `Resubscribe`
+- `Update preference`
+- `Export CSV`
+- `Suppress permanently` (for hard bounce/complaint)
+
+## Shared Admin UX Contracts
+
+- All destructive actions require confirmation modal with plain-language impact note.
+- All status-changing actions emit an audit entry.
+- Bulk actions allowed only for safe transitions:
+  - `Approve selected`
+  - `Schedule selected`
+  - `Publish approved selected`
+  - no bulk hard delete in MVP
+
+## Status Transition Guards
+
+- `draft` -> `review_required` (auto or manual)
+- `review_required` -> `approved` only if:
+  - at least one source link exists
+  - title/body non-empty
+  - review note required when overriding failed quality checks
+- `approved` -> `scheduled` or `publishing`
+- `publishing` -> `published` or `send_failed`
+- `send_failed` -> `publishing` via retry
+
+## Existing Route Integration Notes
+
+- keep existing `/admin/waitlist` for lead capture management
+- add `/admin/subscribers` for newsletter operations
+- maintain existing access model from `src/app/(admin)/layout.tsx`

--- a/docs/features/INIT-ai-newsletter-blog-content-ops.md
+++ b/docs/features/INIT-ai-newsletter-blog-content-ops.md
@@ -1,0 +1,77 @@
+# INIT — AI Newsletter/Blog Content Ops
+
+## Request Summary
+
+Build an operational system where AI-assisted content is generated, reviewed by humans, and distributed from `/admin` with one-click controls. The system must support:
+
+- daily AI/news digest drafts
+- deeper blog drafts for subscribers
+- explicit review/approval gate before delivery
+- queue-driven publish now / scheduled publish
+- reusable content for future ebook packaging
+
+## Fixed Decisions (INIT SoT)
+
+1. **Publishing model:** move to DB-first CMS flow (`db-cms`) for queue/review/audit durability.
+2. **Subscriber source:** create a dedicated `newsletter_subscribers` domain (do not overload `waitlist_signups`).
+3. **Control point:** `/admin` is the primary operator surface.
+4. **Safety model:** human-in-the-loop is required before any external send.
+
+## Why This Direction
+
+- File-based autopublish is useful for bootstrapping but weak for queue status transitions, reviewer workflows, retries, and post-send analytics.
+- Dedicated subscriber lifecycle is required for opt-in/out compliance, preference controls, and long-term productization (newsletter -> paid bundles/ebooks).
+- Existing Elevate assets already fit this shape: admin shell, content/payment foundation, and operational workflow patterns.
+
+## Codebase Anchors
+
+- Admin shell/access: `src/app/(admin)/layout.tsx`, `src/app/(admin)/admin/page.tsx`
+- Existing waitlist email path: `src/app/api/waitlist/route.ts`, `src/lib/email/send-waitlist-confirmation-email.ts`
+- Existing admin waitlist ops: `src/actions/waitlist-admin.ts`
+- Existing blog file automation path (to keep as temporary fallback): `.github/workflows/blog-autopublish.yml`, `scripts/blog-autopublish-sdk.mjs`, `docs/blog/automation/topics.json`
+- Schema/types anchors: `supabase/migrations/`, `src/types/database.types.ts`
+
+## Scope and Non-Goals
+
+### In Scope (INIT -> PLAN input)
+
+- Content queue lifecycle + status machine
+- News source registry + ingestion/run logging
+- Draft/review/approve/schedule/publish operations in `/admin`
+- Subscriber lifecycle model with opt-in/out and frequency preference
+- Delivery pathways for blog publish and newsletter send
+- Operational retries and failure visibility
+
+### Out of Scope (this INIT)
+
+- Full auto-send without human approval
+- Hard migration/deletion of legacy file-based blog autopublish on day one
+- Complex personalization/recommendation engine
+- Deep BI dashboards beyond minimum run/reporting metrics
+
+## Complexity Assessment
+
+**L4**
+
+- Multiple surfaces: schema, server actions, admin routes, delivery integrations
+- New domain model and transition rules
+- Compliance and trust constraints (opt-in/out, source attribution)
+- Migration strategy needed between legacy and new flow
+
+## Deliverables Created from This INIT
+
+- Schema draft: `docs/features/SCHEMA-ai-newsletter-blog-content-ops.md`
+- Admin IA: `docs/features/IA-admin-content-ops.md`
+- Workflow/state machine: `docs/features/WORKFLOW-ai-content-ops.md`
+- 2-week MVP rollout: `docs/features/PLAN-ai-content-ops-2week-mvp.md`
+
+## Success Criteria (MVP)
+
+- Operators can generate N drafts/day, review, and publish from `/admin`
+- Failed deliveries are retryable with visible failure reason
+- Subscriber unsubscribe/resubscribe state applies immediately
+- Blog/newsletter content is reusable as source material for ebook packaging
+
+## Next Mode
+
+`PLAN` for implementation breakdown, migration phases, and slice-level execution.

--- a/docs/features/PLAN-ai-content-ops-2week-mvp.md
+++ b/docs/features/PLAN-ai-content-ops-2week-mvp.md
@@ -1,0 +1,107 @@
+# PLAN — AI Content Ops 2-Week MVP
+
+## Objective
+
+Ship a usable admin-operated content pipeline in 2 weeks:
+
+1. generate drafts
+2. review/approve in queue
+3. publish blog and send newsletter
+4. recover from failures
+
+## Week 1 — Foundation
+
+## Day 1-2: Data layer
+
+- add migrations for:
+  - `newsletter_subscribers`
+  - `content_sources`
+  - `content_items`
+  - `content_item_source_map`
+  - `content_runs`
+  - `content_publications`
+- apply baseline RLS policies (admin/service role oriented)
+- regenerate DB types
+
+## Day 3-4: Queue admin surface (minimum)
+
+- implement `/admin/content-queue` list/detail with filters
+- implement core actions:
+  - `Approve`
+  - `Reject`
+  - `Request changes`
+  - `Schedule`
+  - `Publish now` (manual trigger stub allowed first)
+- wire action logs to `content_runs` and audit events
+
+## Day 5: Ingestion + draft generation baseline
+
+- implement source registry (`/admin/news-sources`)
+- add manual "Run ingest now" trigger
+- ingest from trusted RSS/blog sources
+- dedupe by hash and map to source attribution table
+- generate draft records in `content_items` with `draft` status
+
+## Week 2 — Operations
+
+## Day 6-7: Review gate and publishing reliability
+
+- implement quality gate checks before approval
+- add channel records in `content_publications`
+- implement publish worker logic:
+  - blog channel publish
+  - email channel send via Resend
+- implement retries for `send_failed`
+
+## Day 8-9: Run monitoring + subscribers admin
+
+- implement `/admin/runs` for execution history and failures
+- implement `/admin/subscribers` lifecycle actions:
+  - subscribe/unsubscribe
+  - frequency updates
+  - bounce/complaint suppression
+- add CSV export for operator workflow
+
+## Day 10: Stabilization
+
+- status transition hardening and guard checks
+- failure path tests + manual smoke for publish pipeline
+- verify migration/backfill scripts and rollback notes
+
+## Transition Strategy (`waitlist_signups` -> `newsletter_subscribers`)
+
+### Phase A: Parallel run
+
+- keep `waitlist_signups` unchanged for lead capture and existing flows
+- start all newsletter sends from `newsletter_subscribers` only
+
+### Phase B: Backfill
+
+- one-time backfill script from opt-in eligible waitlist entries
+- mark source as `waitlist_backfill` in subscriber metadata
+
+### Phase C: Funnel alignment
+
+- update growth forms to write:
+  - `waitlist_signups` (lead)
+  - `newsletter_subscribers` (opt-in newsletter) when consent is explicit
+
+### Phase D: Operational default
+
+- `/admin/waitlist`: acquisition view
+- `/admin/subscribers`: newsletter operations view
+- remove any implicit assumptions that waitlist equals newsletter consent
+
+## Risks and Mitigations
+
+- **Source reliability drift:** keep source trust weights and fast disable switch.
+- **Hallucinated claims:** require source attribution and reviewer approval.
+- **Deliverability issues:** maintain suppression statuses (`bounced`, `complained`).
+- **Operator overload:** support bulk approve/schedule for approved-safe states.
+
+## Exit Criteria (end of week 2)
+
+- operator can run ingest, review drafts, and publish from `/admin`
+- failed sends can be retried with visible error reason
+- unsubscribe status is respected immediately in send path
+- content metadata is reusable for later ebook packaging workflows

--- a/docs/features/RUNBOOK-content-ops.md
+++ b/docs/features/RUNBOOK-content-ops.md
@@ -1,0 +1,57 @@
+# RUNBOOK: Content Ops
+
+## Scope
+
+This runbook covers daily operation of the content pipeline:
+
+- `ingest` -> `draft_generate` -> `review_gate` -> `publish`
+- Admin dashboards: `/admin/content-queue`, `/admin/runs`, `/admin/news-sources`, `/admin/subscribers`
+
+## Daily Operation Order
+
+1. Open `/admin/runs` and check latest run summary cards.
+2. Run `ingest` manually if no scheduled automation has run in the last 24h.
+3. Run `draft_generate`.
+4. Run `review_gate`.
+5. Open `/admin/content-queue` and review items marked `review_required`.
+6. Approve/schedule items for publish.
+7. Run `publish` (or `Retry failed only` if failures already exist).
+8. Confirm result badges and failure tooltips in `/admin/runs`.
+
+## Incident Response Order
+
+1. **Identify class**
+   - `resend_not_configured`: Email provider config issue.
+   - `newsletter_no_subscribers`: No active audience.
+   - `rss_fetch_error:*`: Source fetch outage or parser error.
+2. **Contain**
+   - Stop repeated retries if `attempt_count` reached max.
+   - Disable broken source in `/admin/news-sources` when needed.
+3. **Recover**
+   - Fix root cause (env var/source URL/subscriber status).
+   - Use `Retry failed only` from `/admin/runs` or `/admin/content-queue`.
+4. **Verify**
+   - Ensure new run is `성공` or `부분실패` with expected warning only.
+   - Confirm queue items move from `send_failed` to `published`.
+
+## Minimum Checklist
+
+- [ ] `ingest` completed today (or intentionally skipped)
+- [ ] `draft_generate` completed today
+- [ ] `review_gate` completed and failures triaged
+- [ ] `publish` completed (or retry scheduled)
+- [ ] `/admin/runs` top failure reason acknowledged
+- [ ] No repeated `resend_not_configured` warnings
+- [ ] No stale `send_failed` item older than 24h without owner
+
+## CI / Script Operations
+
+Dry-run scripts for CI safety:
+
+- `pnpm content-ops:smoke:dry-run`
+- `pnpm content-ops:cleanup:dry-run`
+
+Live scripts (write mode):
+
+- `pnpm content-ops:smoke`
+- `pnpm content-ops:cleanup`

--- a/docs/features/SCHEMA-ai-newsletter-blog-content-ops.md
+++ b/docs/features/SCHEMA-ai-newsletter-blog-content-ops.md
@@ -1,0 +1,199 @@
+# Schema Draft — AI Newsletter/Blog Content Ops
+
+## Goal
+
+Define a durable DB model for:
+
+- subscriber lifecycle
+- source ingestion and traceability
+- content queue and review workflow
+- publication scheduling and send/result tracking
+- operational run logs
+
+This is a draft for implementation planning, not an applied migration.
+
+## 1) `newsletter_subscribers`
+
+Purpose: dedicated newsletter opt-in domain (separate from waitlist lead capture).
+
+```sql
+create table newsletter_subscribers (
+  id uuid primary key default gen_random_uuid(),
+  email text not null,
+  email_normalized text generated always as (lower(trim(email))) stored,
+  status text not null default 'subscribed'
+    check (status in ('subscribed','unsubscribed','bounced','complained')),
+  consent_at timestamptz,
+  unsubscribe_at timestamptz,
+  locale text not null default 'en',
+  frequency_pref text not null default 'weekly'
+    check (frequency_pref in ('daily','weekly')),
+  source text not null default 'manual',
+  source_ref text,
+  tags text[] not null default '{}',
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  unique (email_normalized)
+);
+```
+
+## 2) `content_sources`
+
+Purpose: source registry for news/blog ingestion.
+
+```sql
+create table content_sources (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  kind text not null check (kind in ('rss','blog','api','manual')),
+  base_url text not null,
+  rss_url text,
+  is_active boolean not null default true,
+  trust_weight int not null default 50 check (trust_weight between 0 and 100),
+  topic_tags text[] not null default '{}',
+  locale text,
+  fetch_interval_minutes int not null default 1440,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+```
+
+## 3) `content_items`
+
+Purpose: canonical queue unit for both blog/newsletter drafts.
+
+```sql
+create table content_items (
+  id uuid primary key default gen_random_uuid(),
+  type text not null check (type in ('blog','newsletter')),
+  title text not null,
+  slug text,
+  locale text not null default 'en',
+  summary text,
+  body_markdown text not null default '',
+  source_quality_score numeric(5,2),
+  fact_check_score numeric(5,2),
+  status text not null default 'draft'
+    check (status in (
+      'draft',
+      'review_required',
+      'approved',
+      'rejected',
+      'scheduled',
+      'publishing',
+      'published',
+      'send_failed'
+    )),
+  review_notes text,
+  reviewed_by uuid references auth.users(id),
+  reviewed_at timestamptz,
+  approved_by uuid references auth.users(id),
+  approved_at timestamptz,
+  scheduled_at timestamptz,
+  published_at timestamptz,
+  generation_model text,
+  generation_prompt_version text,
+  cta_variant text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_by uuid references auth.users(id),
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create unique index content_items_unique_slug_per_locale
+  on content_items (slug, locale)
+  where slug is not null;
+```
+
+## 4) `content_item_source_map`
+
+Purpose: attribution + dedupe traceability.
+
+```sql
+create table content_item_source_map (
+  id uuid primary key default gen_random_uuid(),
+  content_item_id uuid not null references content_items(id) on delete cascade,
+  source_id uuid not null references content_sources(id) on delete restrict,
+  source_url text not null,
+  source_title text,
+  source_published_at timestamptz,
+  snippet_hash text not null,
+  excerpt text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  unique (content_item_id, source_url),
+  unique (snippet_hash)
+);
+```
+
+## 5) `content_runs`
+
+Purpose: pipeline run observability and restart coordination.
+
+```sql
+create table content_runs (
+  id uuid primary key default gen_random_uuid(),
+  run_type text not null
+    check (run_type in ('ingest','draft_generate','review_gate','publish')),
+  status text not null default 'queued'
+    check (status in ('queued','running','succeeded','failed','cancelled')),
+  trigger_type text not null default 'manual'
+    check (trigger_type in ('manual','scheduled','retry','api')),
+  started_at timestamptz,
+  ended_at timestamptz,
+  error_summary text,
+  error_details jsonb,
+  initiated_by uuid references auth.users(id),
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now())
+);
+```
+
+## 6) `content_publications`
+
+Purpose: channel-level publish/send state tracking per content item.
+
+```sql
+create table content_publications (
+  id uuid primary key default gen_random_uuid(),
+  content_item_id uuid not null references content_items(id) on delete cascade,
+  channel text not null check (channel in ('blog','email')),
+  status text not null default 'queued'
+    check (status in ('queued','scheduled','processing','sent','published','failed','cancelled')),
+  provider text not null default 'internal',
+  provider_message_id text,
+  attempt_count int not null default 0,
+  last_error text,
+  scheduled_at timestamptz,
+  processed_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  unique (content_item_id, channel, scheduled_at)
+);
+```
+
+## RLS Draft Policy Direction
+
+- Admin-only write for `content_items`, `content_sources`, `content_runs`, `content_publications`.
+- Service-role bypass allowed for ingestion/generation workers.
+- `newsletter_subscribers`:
+  - admin can read/write.
+  - public API route only allows unsubscribe token-based status changes.
+- Future org scoping can be added by introducing `organization_id` across all tables if content ops becomes tenant-specific.
+
+## Migration Strategy from Existing Data
+
+1. Keep `waitlist_signups` as lead capture source of truth.
+2. Backfill `newsletter_subscribers` from opt-in-eligible records.
+3. Keep file-based blog automation in parallel while `content_items` publish path stabilizes.
+4. Once stable, make DB queue primary and reduce Git-based autopublish responsibilities.
+
+## Open Decisions for PLAN
+
+- `content_items.slug` requirement for newsletter type (nullable vs generated)
+- whether `snippet_hash` uniqueness should be global or scoped by source
+- exact unsubscribe token table design (new table vs signed token approach)
+- whether to add `content_templates` table in MVP or phase 2

--- a/docs/features/WORKFLOW-ai-content-ops.md
+++ b/docs/features/WORKFLOW-ai-content-ops.md
@@ -1,0 +1,118 @@
+# Workflow — AI Content Ops (Ingest -> Review -> Publish)
+
+## Objective
+
+Lock the operational workflow for AI-assisted newsletter/blog content with explicit human review before delivery.
+
+## End-to-End Flow
+
+```mermaid
+flowchart TD
+  sourceRegistry[SourceRegistry] --> ingestRun[IngestRun]
+  ingestRun --> dedupeAttribution[DedupeAndAttribution]
+  dedupeAttribution --> draftCompose[DraftCompose]
+  draftCompose --> queueDraft[ContentQueueDraft]
+  queueDraft --> reviewGate[EditorReviewGate]
+  reviewGate -->|"approve"| approvedState[ApprovedState]
+  reviewGate -->|"requestChanges"| reviewRequired[ReviewRequiredState]
+  reviewGate -->|"reject"| rejectedState[RejectedState]
+  approvedState -->|"schedule"| scheduledState[ScheduledState]
+  approvedState -->|"publishNow"| publishingState[PublishingState]
+  scheduledState --> schedulerTick[SchedulerTick]
+  schedulerTick --> publishingState
+  publishingState -->|"success"| publishedState[PublishedState]
+  publishingState -->|"error"| failedState[SendFailedState]
+  failedState -->|"retry"| publishingState
+  publishedState --> packagingLoop[AnalyticsAndEbookPackagingLoop]
+```
+
+## State Machine (Content Item)
+
+### Core states
+
+- `draft`
+- `review_required`
+- `approved`
+- `rejected`
+- `scheduled`
+- `publishing`
+- `published`
+- `send_failed`
+
+### Transition rules
+
+1. `draft` -> `review_required`
+   - set automatically after generation, or manually by operator.
+2. `review_required` -> `approved`
+   - requires source attribution and non-empty content.
+3. `review_required` -> `rejected`
+   - reviewer note required.
+4. `approved` -> `scheduled`
+   - requires `scheduled_at`.
+5. `approved` -> `publishing`
+   - "Publish now" action.
+6. `scheduled` -> `publishing`
+   - scheduler trigger at/after `scheduled_at`.
+7. `publishing` -> `published`
+   - all selected publication channels succeed.
+8. `publishing` -> `send_failed`
+   - at least one channel fails.
+9. `send_failed` -> `publishing`
+   - explicit retry only.
+
+## Quality Gate Contract
+
+Before `approved`, enforce:
+
+- at least one source link in `content_item_source_map`
+- summary and body not empty
+- plagiarism-safe policy: no raw copy/paste from source
+- fact-check score threshold OR manual override note
+- CTA presence check (for business objective consistency)
+
+## Publication Contract
+
+Channel behavior is independent by row in `content_publications`.
+
+- `blog` channel:
+  - writes/updates canonical blog entry from `content_items`
+  - updates `published_at` on success
+- `email` channel:
+  - resolves active subscribers from `newsletter_subscribers`
+  - sends via provider (Resend in MVP)
+  - stores provider IDs and attempts
+
+If one channel fails, item status is `send_failed`; successful channels remain recorded.
+
+## Run Types and Orchestration
+
+- `ingest`:
+  - fetch sources, normalize entries, map attribution
+- `draft_generate`:
+  - create digest/blog drafts and queue as `draft`
+- `review_gate`:
+  - optional automated checks before human review
+- `publish`:
+  - process scheduled/approved entries
+
+Each run writes to `content_runs` for observability and replay.
+
+## Human-in-the-loop Rules
+
+- No automatic external send from `draft` or `review_required`.
+- `Publish now` requires prior `approved` state.
+- Overrides are allowed but must leave review/audit notes.
+
+## Recovery and Retry
+
+- Delivery failures produce `send_failed` with `last_error`.
+- Retries increment attempt counters in `content_publications`.
+- Repeated failure threshold can move item to `review_required` for rework (phase 2 policy).
+
+## Packaging Reuse Contract
+
+Published content remains reusable:
+
+- source-grounded snippets for future long-form synthesis
+- newsletter editions as chapter candidates
+- analytics signals as selection heuristic for ebook bundles

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,20 +2,28 @@
 
 ## 현재 페이즈 (활성)
 
-**INIT (2026-04-28) — Blog Subscription (Lemon Squeezy, Phase 1)**
+**INIT (2026-04-30) — AI Newsletter/Blog Content Ops (Admin Queue)**
 
-**브랜치:** `main` (직전 Editors Desk v3 PR #21 merge 완료 상태)  
-**SoT:** [`docs/features/INIT-blog-subscription-lemon-phase1.md`](../docs/features/INIT-blog-subscription-lemon-phase1.md)
+**브랜치:** `main`  
+**SoT:** [`docs/features/INIT-ai-newsletter-blog-content-ops.md`](../docs/features/INIT-ai-newsletter-blog-content-ops.md)
 
-**복잡도:** **L4** — DB 구독 스키마 + Lemon subscription webhook 확장 + 블로그 프리미엄 접근제어 + paywall CTA + pricing/manage UX를 기존 결제 인프라 위에 증설.
+**복잡도:** **L4** — 신규 구독자 도메인 + 콘텐츠 큐/검수 상태 머신 + 발행 채널(blog/email) + `/admin` 운영 화면 동시 설계.
 
 **핵심 목표:**
-- 기존 단일 구독/권한 구조를 재작성하지 않고 확장
-- 블로그 전용 3티어(`free`, `monthly`, `annual`) 도입
-- Lemon Variant 고정 매핑 (`1585015`/`1585028`)
-- 프리미엄 포스트 preview cutoff + CTA reusable 컴포넌트
+- 자동 생성 + 사람 검수 + 딸깍 배포 구조를 `/admin` 중심으로 고정
+- 블로그/뉴스레터를 공통 `content_items` 큐로 관리
+- `waitlist_signups`와 분리된 `newsletter_subscribers` 도메인 확립
+- 장기적으로 전자책 패키징 재사용이 가능한 콘텐츠 원장 구축
 
-**다음 단계:** **PLAN** (데이터 모델 확정 -> webhook/event lifecycle 설계 -> UI 접근제어 계약 확정).
+**다음 단계:** **BUILD** (마이그레이션 초안 SQL + 서버 액션/API + `/admin/content-queue` 최소 구현 착수).
+
+**INIT 산출물 (완료):**
+- [`SCHEMA-ai-newsletter-blog-content-ops.md`](../docs/features/SCHEMA-ai-newsletter-blog-content-ops.md)
+- [`IA-admin-content-ops.md`](../docs/features/IA-admin-content-ops.md)
+- [`WORKFLOW-ai-content-ops.md`](../docs/features/WORKFLOW-ai-content-ops.md)
+- [`PLAN-ai-content-ops-2week-mvp.md`](../docs/features/PLAN-ai-content-ops-2week-mvp.md)
+
+**기존 INIT 상태:** `INIT-blog-subscription-lemon-phase1.md`는 보류로 전환 (tasks.md 기준).
 
 **04-24 학습(반드시 회피):**
 - L1: PostCSS 8.4.31 + Turbopack은 CSS 주석의 em-dash(`U+2014`)에 `Unknown word` 에러 → tokens.css/globals.css 주석 ASCII-only.

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -56,7 +56,23 @@
 
 ---
 
-## INIT — Blog Subscription (Lemon, Phase 1) — 활성
+## INIT — AI Newsletter/Blog Content Ops (Admin Queue) — 활성
+
+**SoT:** [`docs/features/INIT-ai-newsletter-blog-content-ops.md`](../docs/features/INIT-ai-newsletter-blog-content-ops.md)  
+**복잡도:** **L4** — 신규 구독자 도메인 + 콘텐츠 큐/검수 상태 머신 + 발행 채널(blog/email) + 운영 UI 동시 설계.
+
+### 체크리스트
+
+- [x] **INIT 문서:** 목표/범위/앵커/성공 기준 고정 — [`INIT-ai-newsletter-blog-content-ops.md`](../docs/features/INIT-ai-newsletter-blog-content-ops.md)
+- [x] **스키마 초안:** subscribers/sources/content/runs/publications/source-map — [`SCHEMA-ai-newsletter-blog-content-ops.md`](../docs/features/SCHEMA-ai-newsletter-blog-content-ops.md)
+- [x] **Admin IA:** `/admin/content-queue`, `/admin/news-sources`, `/admin/runs`, `/admin/subscribers` — [`IA-admin-content-ops.md`](../docs/features/IA-admin-content-ops.md)
+- [x] **워크플로 고정:** 수집→생성→검수→발행 상태 머신 — [`WORKFLOW-ai-content-ops.md`](../docs/features/WORKFLOW-ai-content-ops.md)
+- [x] **2주 MVP 계획:** Week1(기반)·Week2(운영) + waitlist→subscriber 전환 — [`PLAN-ai-content-ops-2week-mvp.md`](../docs/features/PLAN-ai-content-ops-2week-mvp.md)
+- [ ] **다음 단계 (BUILD):** 마이그레이션 초안 SQL + 서버 액션/API + `/admin/content-queue` 최소 구현 착수
+
+---
+
+## INIT — Blog Subscription (Lemon, Phase 1) — 보류
 
 **SoT:** [`docs/features/INIT-blog-subscription-lemon-phase1.md`](../docs/features/INIT-blog-subscription-lemon-phase1.md)  
 **복잡도:** **L4** — 구독 스키마/웹훅/블로그 접근제어/페이월 UI/가격 페이지 동시 변경.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "blog:autopublish": "node scripts/blog-autopublish-sdk.mjs",
     "blog:quality-gate": "node scripts/blog-quality-gate.mjs",
     "content-ops:smoke": "pnpm tsx scripts/content-ops-smoke.ts",
+    "content-ops:smoke:dry-run": "pnpm tsx scripts/content-ops-smoke.ts --dry-run",
     "content-ops:cleanup": "pnpm tsx scripts/content-ops-cleanup.ts",
+    "content-ops:cleanup:dry-run": "pnpm tsx scripts/content-ops-cleanup.ts --dry-run",
     "worker:assembly": "tsx workers/video-assembly/run.ts",
     "prepare": "husky"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "buffer:retry-step4": "node scripts/retry-buffer-step4.mjs",
     "blog:autopublish": "node scripts/blog-autopublish-sdk.mjs",
     "blog:quality-gate": "node scripts/blog-quality-gate.mjs",
+    "content-ops:smoke": "pnpm tsx scripts/content-ops-smoke.ts",
+    "content-ops:cleanup": "pnpm tsx scripts/content-ops-cleanup.ts",
     "worker:assembly": "tsx workers/video-assembly/run.ts",
     "prepare": "husky"
   },
@@ -60,6 +62,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "resend": "^6.10.0",
+    "server-only": "^0.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       resend:
         specifier: ^6.10.0
         version: 6.10.0
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -4065,6 +4068,9 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
@@ -8983,6 +8989,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  server-only@0.0.1: {}
 
   set-blocking@2.0.0:
     optional: true

--- a/scripts/content-ops-cleanup.ts
+++ b/scripts/content-ops-cleanup.ts
@@ -1,0 +1,91 @@
+import dotenv from "dotenv";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+dotenv.config({ path: ".env.local" });
+
+async function cleanupSmokeFixtures() {
+  const admin = createAdminClient();
+
+  const { data: smokeSources } = await admin
+    .from("content_sources")
+    .select("id, name")
+    .ilike("name", "[SMOKE]%");
+  const sourceIds = (smokeSources ?? []).map((row) => row.id);
+
+  let deletedMapRows = 0;
+  let deletedItems = 0;
+  let deletedPublications = 0;
+
+  if (sourceIds.length > 0) {
+    const { data: mappedItemRows } = await admin
+      .from("content_item_source_map")
+      .select("content_item_id")
+      .in("source_id", sourceIds);
+    const contentItemIds = Array.from(
+      new Set((mappedItemRows ?? []).map((row) => row.content_item_id)),
+    );
+
+    if (contentItemIds.length > 0) {
+      const { count: pubCount } = await admin
+        .from("content_publications")
+        .delete({ count: "exact" })
+        .in("content_item_id", contentItemIds);
+      deletedPublications = pubCount ?? 0;
+    }
+
+    const { count: mapCount } = await admin
+      .from("content_item_source_map")
+      .delete({ count: "exact" })
+      .in("source_id", sourceIds);
+    deletedMapRows = mapCount ?? 0;
+
+    if (contentItemIds.length > 0) {
+      const { count: itemCount } = await admin
+        .from("content_items")
+        .delete({ count: "exact" })
+        .in("id", contentItemIds);
+      deletedItems = itemCount ?? 0;
+    }
+  }
+
+  const { count: deletedSmokeBlogs } = await admin
+    .from("content_items")
+    .delete({ count: "exact" })
+    .contains("metadata", { smoke_fixture: true });
+
+  const { count: deletedSubscribers } = await admin
+    .from("newsletter_subscribers")
+    .delete({ count: "exact" })
+    .eq("source", "smoke_fixture");
+
+  const { count: deletedRuns } = await admin
+    .from("content_runs")
+    .delete({ count: "exact" })
+    .contains("metadata", { smoke_fixture: true });
+
+  const { count: deletedSources } = await admin
+    .from("content_sources")
+    .delete({ count: "exact" })
+    .in("id", sourceIds);
+
+  console.log(
+    JSON.stringify(
+      {
+        deletedSources: deletedSources ?? 0,
+        deletedMapRows,
+        deletedItems,
+        deletedPublications,
+        deletedSmokeBlogs: deletedSmokeBlogs ?? 0,
+        deletedSubscribers: deletedSubscribers ?? 0,
+        deletedRuns: deletedRuns ?? 0,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+cleanupSmokeFixtures().catch((error) => {
+  console.error("[content-ops-cleanup] failed:", error);
+  process.exit(1);
+});

--- a/scripts/content-ops-cleanup.ts
+++ b/scripts/content-ops-cleanup.ts
@@ -2,6 +2,7 @@ import dotenv from "dotenv";
 import { createAdminClient } from "@/lib/supabase/admin";
 
 dotenv.config({ path: ".env.local" });
+const DRY_RUN = process.argv.includes("--dry-run");
 
 async function cleanupSmokeFixtures() {
   const admin = createAdminClient();
@@ -15,16 +16,18 @@ async function cleanupSmokeFixtures() {
   let deletedMapRows = 0;
   let deletedItems = 0;
   let deletedPublications = 0;
+  const { data: mappedItemRows } =
+    sourceIds.length > 0
+      ? await admin
+          .from("content_item_source_map")
+          .select("content_item_id")
+          .in("source_id", sourceIds)
+      : { data: [] as { content_item_id: string }[] };
+  const contentItemIds = Array.from(
+    new Set((mappedItemRows ?? []).map((row) => row.content_item_id)),
+  );
 
-  if (sourceIds.length > 0) {
-    const { data: mappedItemRows } = await admin
-      .from("content_item_source_map")
-      .select("content_item_id")
-      .in("source_id", sourceIds);
-    const contentItemIds = Array.from(
-      new Set((mappedItemRows ?? []).map((row) => row.content_item_id)),
-    );
-
+  if (sourceIds.length > 0 && !DRY_RUN) {
     if (contentItemIds.length > 0) {
       const { count: pubCount } = await admin
         .from("content_publications")
@@ -46,6 +49,70 @@ async function cleanupSmokeFixtures() {
         .in("id", contentItemIds);
       deletedItems = itemCount ?? 0;
     }
+  }
+
+  if (DRY_RUN) {
+    const [
+      smokeBlogRows,
+      subscriberRows,
+      runRows,
+      mappedRows,
+      publicationRows,
+      sourceRows,
+    ] = await Promise.all([
+      admin
+        .from("content_items")
+        .select("id", { count: "exact", head: true })
+        .contains("metadata", { smoke_fixture: true }),
+      admin
+        .from("newsletter_subscribers")
+        .select("id", { count: "exact", head: true })
+        .eq("source", "smoke_fixture"),
+      admin
+        .from("content_runs")
+        .select("id", { count: "exact", head: true })
+        .contains("metadata", { smoke_fixture: true }),
+      sourceIds.length > 0
+        ? admin
+            .from("content_item_source_map")
+            .select("id", { count: "exact", head: true })
+            .in("source_id", sourceIds)
+        : Promise.resolve({ count: 0 } as { count: number }),
+      contentItemIds.length > 0
+        ? admin
+            .from("content_publications")
+            .select("id", { count: "exact", head: true })
+            .in("content_item_id", contentItemIds)
+        : Promise.resolve({ count: 0 } as { count: number }),
+      sourceIds.length > 0
+        ? admin
+            .from("content_sources")
+            .select("id", { count: "exact", head: true })
+            .in("id", sourceIds)
+        : Promise.resolve({ count: 0 } as { count: number }),
+    ]);
+
+    console.log(
+      JSON.stringify(
+        {
+          mode: "dry-run",
+          check: "content-ops-cleanup",
+          wouldDelete: {
+            deletedSources: sourceRows.count ?? 0,
+            deletedMapRows: mappedRows.count ?? 0,
+            deletedItems: contentItemIds.length,
+            deletedPublications: publicationRows.count ?? 0,
+            deletedSmokeBlogs: smokeBlogRows.count ?? 0,
+            deletedSubscribers: subscriberRows.count ?? 0,
+            deletedRuns: runRows.count ?? 0,
+          },
+          note: "No rows were deleted.",
+        },
+        null,
+        2,
+      ),
+    );
+    return;
   }
 
   const { count: deletedSmokeBlogs } = await admin

--- a/scripts/content-ops-smoke.ts
+++ b/scripts/content-ops-smoke.ts
@@ -9,7 +9,12 @@ import type { Json } from "@/types/database.types";
 
 dotenv.config({ path: ".env.local" });
 
+const DRY_RUN = process.argv.includes("--dry-run");
+
 async function createRun(runType: string): Promise<string> {
+  if (DRY_RUN) {
+    return `dry-run-${runType}-${Date.now()}`;
+  }
   const admin = createAdminClient();
   const { data, error } = await admin
     .from("content_runs")
@@ -36,6 +41,7 @@ async function finishRun(params: {
   metadata: Json;
   errorSummary: string | null;
 }) {
+  if (DRY_RUN) return;
   const admin = createAdminClient();
   await admin
     .from("content_runs")
@@ -53,6 +59,23 @@ async function finishRun(params: {
 
 async function seedScenarioFixtures() {
   const admin = createAdminClient();
+  if (DRY_RUN) {
+    const [{ count: sourceCount }, { count: subscriberCount }] = await Promise.all([
+      admin
+        .from("content_sources")
+        .select("id", { count: "exact", head: true })
+        .eq("is_active", true),
+      admin
+        .from("newsletter_subscribers")
+        .select("id", { count: "exact", head: true })
+        .eq("status", "subscribed"),
+    ]);
+    return {
+      activeSources: sourceCount ?? 0,
+      subscribers: subscriberCount ?? 0,
+      wouldSeed: true,
+    };
+  }
 
   const sourceFixtures = [
     {
@@ -115,10 +138,32 @@ async function seedScenarioFixtures() {
       smoke_fixture: true,
     },
   });
+
+  return {
+    activeSources: sourceFixtures.length,
+    subscribers: 1,
+    wouldSeed: true,
+  };
 }
 
 async function main() {
-  await seedScenarioFixtures();
+  const seedInfo = await seedScenarioFixtures();
+  if (DRY_RUN) {
+    console.log(
+      JSON.stringify(
+        {
+          mode: "dry-run",
+          check: "content-ops-smoke",
+          seedInfo,
+          plannedRuns: ["ingest", "draft_generate", "publish"],
+          note: "No DB writes or email sends were executed.",
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
 
   const ingestRunId = await createRun("ingest");
   const ingest = await runIngestPipeline(ingestRunId);

--- a/scripts/content-ops-smoke.ts
+++ b/scripts/content-ops-smoke.ts
@@ -1,0 +1,179 @@
+import dotenv from "dotenv";
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  runDraftGeneratePipeline,
+  runIngestPipeline,
+  runPublishPipeline,
+} from "@/lib/content-ops/pipeline-runner";
+import type { Json } from "@/types/database.types";
+
+dotenv.config({ path: ".env.local" });
+
+async function createRun(runType: string): Promise<string> {
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("content_runs")
+    .insert({
+      run_type: runType,
+      status: "running",
+      trigger_type: "manual",
+      started_at: new Date().toISOString(),
+      metadata: {
+        smoke_fixture: true,
+      },
+    })
+    .select("id")
+    .single();
+  if (error || !data?.id) {
+    throw new Error(`failed to create run(${runType}): ${error?.message ?? "unknown"}`);
+  }
+  return data.id;
+}
+
+async function finishRun(params: {
+  id: string;
+  status: "succeeded" | "failed";
+  metadata: Json;
+  errorSummary: string | null;
+}) {
+  const admin = createAdminClient();
+  await admin
+    .from("content_runs")
+    .update({
+      status: params.status,
+      ended_at: new Date().toISOString(),
+      metadata: {
+        smoke_fixture: true,
+        result: params.metadata,
+      },
+      error_summary: params.errorSummary,
+    })
+    .eq("id", params.id);
+}
+
+async function seedScenarioFixtures() {
+  const admin = createAdminClient();
+
+  const sourceFixtures = [
+    {
+      name: "[SMOKE] HNRSS Frontpage",
+      kind: "rss",
+      base_url: "https://hnrss.org/frontpage",
+      rss_url: "https://hnrss.org/frontpage",
+      is_active: true,
+      trust_weight: 75,
+      fetch_interval_minutes: 60,
+      updated_at: new Date().toISOString(),
+    },
+    {
+      name: "[SMOKE] Broken RSS Fixture",
+      kind: "rss",
+      base_url: "https://example.invalid/rss",
+      rss_url: "https://example.invalid/rss",
+      is_active: true,
+      trust_weight: 80,
+      fetch_interval_minutes: 60,
+      updated_at: new Date().toISOString(),
+    },
+  ] as const;
+
+  for (const fixture of sourceFixtures) {
+    const { data: existing } = await admin
+      .from("content_sources")
+      .select("id")
+      .eq("base_url", fixture.base_url)
+      .maybeSingle();
+
+    if (existing?.id) {
+      await admin.from("content_sources").update(fixture).eq("id", existing.id);
+    } else {
+      await admin.from("content_sources").insert(fixture);
+    }
+  }
+
+  await admin.from("newsletter_subscribers").upsert(
+    {
+      email: "invalid-email",
+      status: "subscribed",
+      locale: "en",
+      frequency_pref: "daily",
+      source: "smoke_fixture",
+      consent_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "email_normalized" },
+  );
+
+  await admin.from("content_items").insert({
+    type: "blog",
+    title: `Smoke Blog Publish ${new Date().toISOString().slice(0, 19)}`,
+    locale: "ko",
+    summary: "Smoke test item for locale template + CTA enforcement.",
+    body_markdown: "이 문서는 스모크 테스트를 위한 본문입니다.",
+    status: "approved",
+    metadata: {
+      smoke_fixture: true,
+    },
+  });
+}
+
+async function main() {
+  await seedScenarioFixtures();
+
+  const ingestRunId = await createRun("ingest");
+  const ingest = await runIngestPipeline(ingestRunId);
+  await finishRun({
+    id: ingestRunId,
+    status: "succeeded",
+    metadata: ingest as unknown as Json,
+    errorSummary:
+      ingest.failureMessages.length > 0
+        ? `warning:${ingest.failureMessages[0]}`
+        : null,
+  });
+
+  const generateRunId = await createRun("draft_generate");
+  const draft = await runDraftGeneratePipeline(generateRunId);
+  await finishRun({
+    id: generateRunId,
+    status: "succeeded",
+    metadata: draft as unknown as Json,
+    errorSummary: null,
+  });
+
+  const admin = createAdminClient();
+  await admin
+    .from("content_items")
+    .update({ status: "approved", updated_at: new Date().toISOString() })
+    .eq("type", "newsletter")
+    .eq("status", "draft");
+
+  const publishRunId = await createRun("publish");
+  const publish = await runPublishPipeline();
+  await finishRun({
+    id: publishRunId,
+    status: publish.failedCount > 0 ? "failed" : "succeeded",
+    metadata: publish as unknown as Json,
+    errorSummary:
+      publish.failureMessages.length > 0
+        ? `warning:${publish.failureMessages[0]}`
+        : null,
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        ingest,
+        draft,
+        publish,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  console.error("[content-ops-smoke] failed:", error);
+  process.exit(1);
+});

--- a/src/actions/admin-content-ops.ts
+++ b/src/actions/admin-content-ops.ts
@@ -8,6 +8,7 @@ import {
   runDraftGeneratePipeline,
   runIngestPipeline,
   runPublishPipeline,
+  runReviewGatePipeline,
 } from "@/lib/content-ops/pipeline-runner";
 import type { Json } from "@/types/database.types";
 
@@ -23,6 +24,7 @@ export type AdminContentItemRow = {
   source_quality_score: number | null;
   fact_check_score: number | null;
   scheduled_at: string | null;
+  metadata: Json | null;
   updated_at: string;
 };
 
@@ -92,7 +94,7 @@ export async function listAdminContentQueue(filters?: {
     let query = admin
       .from("content_items")
       .select(
-        "id, type, title, locale, status, source_quality_score, fact_check_score, scheduled_at, updated_at",
+        "id, type, title, locale, status, source_quality_score, fact_check_score, scheduled_at, metadata, updated_at",
       )
       .order("updated_at", { ascending: false })
       .limit(300);
@@ -297,8 +299,10 @@ async function executeAdminRunType(runType: string): Promise<void> {
         metadata = await runDraftGeneratePipeline(runRow.id);
       } else if (runType === "publish") {
         metadata = await runPublishPipeline();
+      } else if (runType === "publish_retry_failed") {
+        metadata = await runPublishPipeline({ retryFailedOnly: true });
       } else if (runType === "review_gate") {
-        metadata = { skipped: true, reason: "build1_scaffold_no_rule_engine_yet" };
+        metadata = await runReviewGatePipeline(runRow.id);
       } else {
         metadata = { skipped: true, reason: "unknown_run_type" };
       }
@@ -309,7 +313,7 @@ async function executeAdminRunType(runType: string): Promise<void> {
 
     if (!errorSummary && metadata && typeof metadata === "object" && !Array.isArray(metadata)) {
       if (
-        runType === "publish" &&
+        (runType === "publish" || runType === "publish_retry_failed") &&
         typeof (metadata as Record<string, unknown>).failedCount === "number" &&
         ((metadata as Record<string, unknown>).failedCount as number) > 0
       ) {
@@ -360,6 +364,12 @@ export async function runAdminContentOpsScenario(): Promise<void> {
   } catch (e) {
     console.error("[runAdminContentOpsScenario] failed", e);
   }
+}
+
+export async function runRetryFailedPublishOnly(): Promise<void> {
+  const gate = await assertPlatformAdmin();
+  if (!gate.ok) return;
+  await executeAdminRunType("publish_retry_failed");
 }
 
 export async function listAdminNewsletterSubscribers(): Promise<

--- a/src/actions/admin-content-ops.ts
+++ b/src/actions/admin-content-ops.ts
@@ -1,0 +1,460 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { canAccessElevateServiceAdmin } from "@/lib/auth/platform-admin";
+import {
+  runDraftGeneratePipeline,
+  runIngestPipeline,
+  runPublishPipeline,
+} from "@/lib/content-ops/pipeline-runner";
+import type { Json } from "@/types/database.types";
+
+const EMAIL_RE =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+export type AdminContentItemRow = {
+  id: string;
+  type: "blog" | "newsletter";
+  title: string;
+  locale: string;
+  status: string;
+  source_quality_score: number | null;
+  fact_check_score: number | null;
+  scheduled_at: string | null;
+  updated_at: string;
+};
+
+export type AdminContentSourceRow = {
+  id: string;
+  name: string;
+  kind: string;
+  base_url: string;
+  is_active: boolean;
+  trust_weight: number;
+  fetch_interval_minutes: number;
+  updated_at: string;
+};
+
+export type AdminContentRunRow = {
+  id: string;
+  run_type: string;
+  status: string;
+  trigger_type: string;
+  started_at: string | null;
+  ended_at: string | null;
+  error_summary: string | null;
+  metadata: Json | null;
+  created_at: string;
+};
+
+export type AdminNewsletterSubscriberRow = {
+  id: string;
+  email: string;
+  status: string;
+  locale: string;
+  frequency_pref: string;
+  consent_at: string | null;
+  unsubscribe_at: string | null;
+  source: string;
+  created_at: string;
+};
+
+const RUN_SEQUENCE = ["ingest", "draft_generate", "publish"] as const;
+
+async function assertPlatformAdmin(): Promise<
+  { ok: true } | { ok: false; error: string }
+> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.email) return { ok: false, error: "unauthorized" };
+
+  if (!canAccessElevateServiceAdmin(user.email)) {
+    return { ok: false, error: "forbidden" };
+  }
+  return { ok: true };
+}
+
+export async function listAdminContentQueue(filters?: {
+  type?: "blog" | "newsletter" | "all";
+  status?: string;
+}): Promise<
+  { ok: true; rows: AdminContentItemRow[] } | { ok: false; error: string }
+> {
+  const gate = await assertPlatformAdmin();
+  if (!gate.ok) return { ok: false, error: gate.error };
+
+  try {
+    const admin = createAdminClient();
+    let query = admin
+      .from("content_items")
+      .select(
+        "id, type, title, locale, status, source_quality_score, fact_check_score, scheduled_at, updated_at",
+      )
+      .order("updated_at", { ascending: false })
+      .limit(300);
+
+    if (filters?.type && filters.type !== "all") {
+      query = query.eq("type", filters.type);
+    }
+    if (filters?.status && filters.status !== "all") {
+      query = query.eq("status", filters.status);
+    }
+
+    const { data, error } = await query;
+    if (error) return { ok: false, error: error.message };
+    return { ok: true, rows: (data ?? []) as unknown as AdminContentItemRow[] };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "unknown" };
+  }
+}
+
+export async function updateContentItemStatus(formData: FormData): Promise<void> {
+  const gate = await assertPlatformAdmin();
+  if (!gate.ok) return;
+
+  const id = String(formData.get("id") ?? "").trim();
+  const nextStatus = String(formData.get("status") ?? "").trim();
+
+  if (!id || !nextStatus) return;
+
+  try {
+    const nowIso = new Date().toISOString();
+    const admin = createAdminClient();
+    const patch: Record<string, unknown> = {
+      status: nextStatus,
+      updated_at: nowIso,
+    };
+
+    if (nextStatus === "scheduled") {
+      const raw = String(formData.get("scheduled_at") ?? "").trim();
+      patch.scheduled_at = raw ? raw : nowIso;
+    }
+    if (nextStatus === "published") {
+      patch.published_at = nowIso;
+    }
+
+    const { error } = await admin.from("content_items").update(patch).eq("id", id);
+    if (error) return;
+
+    if (nextStatus === "publishing") {
+      await runPublishPipeline({ contentItemId: id });
+    }
+
+    revalidatePath("/admin/content-queue");
+    revalidatePath("/admin/runs");
+    revalidatePath("/admin/subscribers");
+  } catch (e) {
+    console.error("[updateContentItemStatus] failed", e);
+  }
+}
+
+export async function listAdminNewsSources(): Promise<
+  { ok: true; rows: AdminContentSourceRow[] } | { ok: false; error: string }
+> {
+  const gate = await assertPlatformAdmin();
+  if (!gate.ok) return { ok: false, error: gate.error };
+
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("content_sources")
+      .select(
+        "id, name, kind, base_url, is_active, trust_weight, fetch_interval_minutes, updated_at",
+      )
+      .order("updated_at", { ascending: false })
+      .limit(200);
+    if (error) return { ok: false, error: error.message };
+    return { ok: true, rows: (data ?? []) as unknown as AdminContentSourceRow[] };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "unknown" };
+  }
+}
+
+export async function upsertAdminNewsSource(formData: FormData): Promise<void> {
+  const gate = await assertPlatformAdmin();
+  if (!gate.ok) return;
+
+  const name = String(formData.get("name") ?? "").trim();
+  const kind = String(formData.get("kind") ?? "rss").trim();
+  const baseUrl = String(formData.get("base_url") ?? "").trim();
+  const trustWeightRaw = Number.parseInt(
+    String(formData.get("trust_weight") ?? "50"),
+    10,
+  );
+  const fetchIntervalRaw = Number.parseInt(
+    String(formData.get("fetch_interval_minutes") ?? "1440"),
+    10,
+  );
+
+  if (!name || !baseUrl) return;
+
+  const trustWeight = Number.isFinite(trustWeightRaw)
+    ? Math.max(0, Math.min(100, trustWeightRaw))
+    : 50;
+  const fetchIntervalMinutes =
+    Number.isFinite(fetchIntervalRaw) && fetchIntervalRaw > 0
+      ? fetchIntervalRaw
+      : 1440;
+
+  try {
+    const admin = createAdminClient();
+    const { error } = await admin.from("content_sources").insert({
+      name,
+      kind,
+      base_url: baseUrl,
+      trust_weight: trustWeight,
+      fetch_interval_minutes: fetchIntervalMinutes,
+      is_active: true,
+      updated_at: new Date().toISOString(),
+    });
+    if (error) return;
+    revalidatePath("/admin/news-sources");
+  } catch (e) {
+    console.error("[upsertAdminNewsSource] failed", e);
+  }
+}
+
+export async function setAdminNewsSourceActive(formData: FormData): Promise<void> {
+  const gate = await assertPlatformAdmin();
+  if (!gate.ok) return;
+
+  const id = String(formData.get("id") ?? "").trim();
+  const next = String(formData.get("is_active") ?? "").trim() === "true";
+  if (!id) return;
+
+  try {
+    const admin = createAdminClient();
+    const { error } = await admin
+      .from("content_sources")
+      .update({ is_active: next, updated_at: new Date().toISOString() })
+      .eq("id", id);
+    if (error) return;
+    revalidatePath("/admin/news-sources");
+  } catch (e) {
+    console.error("[setAdminNewsSourceActive] failed", e);
+  }
+}
+
+export async function listAdminContentRuns(): Promise<
+  { ok: true; rows: AdminContentRunRow[] } | { ok: false; error: string }
+> {
+  const gate = await assertPlatformAdmin();
+  if (!gate.ok) return { ok: false, error: gate.error };
+
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("content_runs")
+      .select(
+        "id, run_type, status, trigger_type, started_at, ended_at, error_summary, metadata, created_at",
+      )
+      .order("created_at", { ascending: false })
+      .limit(300);
+    if (error) return { ok: false, error: error.message };
+    return { ok: true, rows: (data ?? []) as unknown as AdminContentRunRow[] };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "unknown" };
+  }
+}
+
+export async function createManualContentRun(formData: FormData): Promise<void> {
+  const gate = await assertPlatformAdmin();
+  if (!gate.ok) return;
+
+  const runType = String(formData.get("run_type") ?? "").trim();
+  if (!runType) return;
+  await executeAdminRunType(runType);
+}
+
+async function executeAdminRunType(runType: string): Promise<void> {
+  try {
+    const nowIso = new Date().toISOString();
+    const admin = createAdminClient();
+    const { data: runRow, error } = await admin
+      .from("content_runs")
+      .insert({
+        run_type: runType,
+        status: "running",
+        trigger_type: "manual",
+        started_at: nowIso,
+      })
+      .select("id")
+      .single();
+    if (error || !runRow?.id) return;
+
+    let status: "succeeded" | "failed" = "succeeded";
+    let metadata: Json | null = null;
+    let errorSummary: string | null = null;
+
+    try {
+      if (runType === "ingest") {
+        metadata = await runIngestPipeline(runRow.id);
+      } else if (runType === "draft_generate") {
+        metadata = await runDraftGeneratePipeline(runRow.id);
+      } else if (runType === "publish") {
+        metadata = await runPublishPipeline();
+      } else if (runType === "review_gate") {
+        metadata = { skipped: true, reason: "build1_scaffold_no_rule_engine_yet" };
+      } else {
+        metadata = { skipped: true, reason: "unknown_run_type" };
+      }
+    } catch (e) {
+      status = "failed";
+      errorSummary = e instanceof Error ? e.message : "unknown";
+    }
+
+    if (!errorSummary && metadata && typeof metadata === "object" && !Array.isArray(metadata)) {
+      if (
+        runType === "publish" &&
+        typeof (metadata as Record<string, unknown>).failedCount === "number" &&
+        ((metadata as Record<string, unknown>).failedCount as number) > 0
+      ) {
+        status = "failed";
+      }
+      const maybeFailures = (metadata as Record<string, unknown>).failureMessages;
+      if (Array.isArray(maybeFailures) && maybeFailures.length > 0) {
+        const first = maybeFailures.find((v) => typeof v === "string");
+        errorSummary = typeof first === "string" ? `warning:${first}` : "warning:partial_failures";
+      }
+      const maybeFailedSources = (metadata as Record<string, unknown>).failedSources;
+      if (!errorSummary && typeof maybeFailedSources === "number" && maybeFailedSources > 0) {
+        errorSummary = `warning:${maybeFailedSources}_sources_failed`;
+      }
+      const maybeFailedCount = (metadata as Record<string, unknown>).failedCount;
+      if (!errorSummary && typeof maybeFailedCount === "number" && maybeFailedCount > 0) {
+        errorSummary = `warning:${maybeFailedCount}_items_failed`;
+      }
+    }
+
+    await admin
+      .from("content_runs")
+      .update({
+        status,
+        ended_at: new Date().toISOString(),
+        metadata: (metadata ?? {}) as Json,
+        error_summary: errorSummary,
+      })
+      .eq("id", runRow.id);
+
+    revalidatePath("/admin/runs");
+    revalidatePath("/admin/content-queue");
+    revalidatePath("/admin/subscribers");
+    revalidatePath("/admin/news-sources");
+  } catch (e) {
+    console.error("[executeAdminRunType] failed", e);
+  }
+}
+
+export async function runAdminContentOpsScenario(): Promise<void> {
+  const gate = await assertPlatformAdmin();
+  if (!gate.ok) return;
+
+  try {
+    for (const runType of RUN_SEQUENCE) {
+      await executeAdminRunType(runType);
+    }
+  } catch (e) {
+    console.error("[runAdminContentOpsScenario] failed", e);
+  }
+}
+
+export async function listAdminNewsletterSubscribers(): Promise<
+  | { ok: true; rows: AdminNewsletterSubscriberRow[] }
+  | { ok: false; error: string }
+> {
+  const gate = await assertPlatformAdmin();
+  if (!gate.ok) return { ok: false, error: gate.error };
+
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("newsletter_subscribers")
+      .select(
+        "id, email, status, locale, frequency_pref, consent_at, unsubscribe_at, source, created_at",
+      )
+      .order("created_at", { ascending: false })
+      .limit(500);
+    if (error) return { ok: false, error: error.message };
+    return {
+      ok: true,
+      rows: (data ?? []) as unknown as AdminNewsletterSubscriberRow[],
+    };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "unknown" };
+  }
+}
+
+export async function addAdminNewsletterSubscriber(formData: FormData): Promise<void> {
+  const gate = await assertPlatformAdmin();
+  if (!gate.ok) return;
+
+  const emailRaw = String(formData.get("email") ?? "").trim().toLowerCase();
+  const locale = String(formData.get("locale") ?? "en").trim() || "en";
+  const frequencyPref =
+    String(formData.get("frequency_pref") ?? "weekly").trim() || "weekly";
+
+  if (!EMAIL_RE.test(emailRaw) || emailRaw.length > 254) {
+    return;
+  }
+
+  try {
+    const nowIso = new Date().toISOString();
+    const admin = createAdminClient();
+    const { error } = await admin.from("newsletter_subscribers").upsert(
+      {
+        email: emailRaw,
+        status: "subscribed",
+        locale,
+        frequency_pref: frequencyPref,
+        consent_at: nowIso,
+        unsubscribe_at: null,
+        source: "admin_manual",
+        updated_at: nowIso,
+      },
+      { onConflict: "email_normalized" },
+    );
+    if (error) return;
+    revalidatePath("/admin/subscribers");
+  } catch (e) {
+    console.error("[addAdminNewsletterSubscriber] failed", e);
+  }
+}
+
+export async function updateAdminNewsletterSubscriberStatus(
+  formData: FormData,
+): Promise<void> {
+  const gate = await assertPlatformAdmin();
+  if (!gate.ok) return;
+
+  const id = String(formData.get("id") ?? "").trim();
+  const status = String(formData.get("status") ?? "").trim();
+  if (!id || !status) return;
+
+  try {
+    const nowIso = new Date().toISOString();
+    const patch: Record<string, unknown> = {
+      status,
+      updated_at: nowIso,
+    };
+    if (status === "unsubscribed") {
+      patch.unsubscribe_at = nowIso;
+    } else if (status === "subscribed") {
+      patch.unsubscribe_at = null;
+      patch.consent_at = nowIso;
+    }
+
+    const admin = createAdminClient();
+    const { error } = await admin
+      .from("newsletter_subscribers")
+      .update(patch)
+      .eq("id", id);
+    if (error) return;
+    revalidatePath("/admin/subscribers");
+  } catch (e) {
+    console.error("[updateAdminNewsletterSubscriberStatus] failed", e);
+  }
+}

--- a/src/app/(admin)/admin/content-queue/page.tsx
+++ b/src/app/(admin)/admin/content-queue/page.tsx
@@ -1,0 +1,205 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { ListChecks } from "lucide-react";
+import {
+  listAdminContentQueue,
+  updateContentItemStatus,
+} from "@/actions/admin-content-ops";
+
+export const metadata: Metadata = {
+  title: "Admin | Content Queue",
+};
+
+type SearchParams = Promise<{
+  type?: string;
+  status?: string;
+}>;
+
+const TYPE_OPTIONS = ["all", "blog", "newsletter"] as const;
+const STATUS_OPTIONS = [
+  "all",
+  "draft",
+  "review_required",
+  "approved",
+  "rejected",
+  "scheduled",
+  "publishing",
+  "published",
+  "send_failed",
+] as const;
+
+export default async function AdminContentQueuePage(props: {
+  searchParams: SearchParams;
+}) {
+  const searchParams = await props.searchParams;
+  const typeFilter =
+    TYPE_OPTIONS.find((v) => v === searchParams.type) ?? "all";
+  const statusFilter =
+    STATUS_OPTIONS.find((v) => v === searchParams.status) ?? "all";
+
+  const listRes = await listAdminContentQueue({
+    type: typeFilter,
+    status: statusFilter,
+  });
+  const rows = listRes.ok ? listRes.rows : [];
+
+  return (
+    <div className="min-h-screen bg-paper-50">
+      <div className="sticky top-0 z-30 flex h-12 items-center justify-between border-b border-ink-100 bg-paper-50 px-6">
+        <div className="flex min-w-0 items-center gap-2">
+          <ListChecks className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+          <h1 className="truncate text-sm font-medium text-ink-900">Content Queue</h1>
+        </div>
+        <Link
+          href="/admin"
+          className="text-xs text-vermilion-600 transition-colors hover:text-vermilion-700"
+        >
+          Back to admin
+        </Link>
+      </div>
+
+      <div className="max-w-6xl space-y-4 p-6">
+        <p className="text-sm leading-relaxed text-ink-700">
+          Review generated blog/newsletter drafts and move approved items to schedule
+          or immediate publish.
+        </p>
+
+        <form className="flex flex-wrap items-end gap-3 border border-ink-100 bg-paper-0 p-3">
+          <div className="space-y-1">
+            <label htmlFor="type" className="text-xs text-ink-500">
+              Type
+            </label>
+            <select
+              id="type"
+              name="type"
+              defaultValue={typeFilter}
+              className="min-w-[140px] border border-ink-100 bg-paper-50 px-2 py-1.5 text-xs text-ink-900"
+            >
+              {TYPE_OPTIONS.map((opt) => (
+                <option key={opt} value={opt}>
+                  {opt}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="status" className="text-xs text-ink-500">
+              Status
+            </label>
+            <select
+              id="status"
+              name="status"
+              defaultValue={statusFilter}
+              className="min-w-[170px] border border-ink-100 bg-paper-50 px-2 py-1.5 text-xs text-ink-900"
+            >
+              {STATUS_OPTIONS.map((opt) => (
+                <option key={opt} value={opt}>
+                  {opt}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button
+            type="submit"
+            className="border border-ink-100 bg-paper-50 px-3 py-1.5 text-xs text-ink-900 hover:bg-highlight"
+          >
+            Apply filters
+          </button>
+        </form>
+
+        {!listRes.ok ? <p className="text-xs text-danger">{listRes.error}</p> : null}
+
+        {rows.length === 0 ? (
+          <p className="text-xs text-ink-500">No queue items found.</p>
+        ) : (
+          <div className="overflow-x-auto border border-ink-100">
+            <table className="w-full text-left text-xs">
+              <thead>
+                <tr className="border-b border-ink-100 bg-paper-50">
+                  <th className="p-2 font-medium text-ink-700">Title</th>
+                  <th className="p-2 font-medium text-ink-700">Type</th>
+                  <th className="p-2 font-medium text-ink-700">Status</th>
+                  <th className="p-2 font-medium text-ink-700">Quality</th>
+                  <th className="p-2 font-medium text-ink-700">Updated</th>
+                  <th className="p-2 font-medium text-ink-700">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.id} className="border-b border-ink-100/80">
+                    <td className="p-2 text-ink-900">
+                      <div className="font-medium">{row.title}</div>
+                      <div className="mt-0.5 text-[11px] text-ink-500">{row.locale}</div>
+                    </td>
+                    <td className="p-2 text-ink-700">{row.type}</td>
+                    <td className="p-2 text-ink-700">{row.status}</td>
+                    <td className="p-2 text-ink-700">
+                      {row.source_quality_score ?? "-"} / {row.fact_check_score ?? "-"}
+                    </td>
+                    <td className="p-2 whitespace-nowrap text-ink-500">
+                      {new Date(row.updated_at).toISOString().replace("T", " ").slice(0, 19)} UTC
+                    </td>
+                    <td className="p-2">
+                      <div className="flex flex-wrap gap-1.5">
+                        <form action={updateContentItemStatus}>
+                          <input type="hidden" name="id" value={row.id} />
+                          <input type="hidden" name="status" value="approved" />
+                          <button
+                            type="submit"
+                            className="border border-ink-100 px-2 py-1 text-[11px] text-ink-700 hover:bg-highlight"
+                          >
+                            Approve
+                          </button>
+                        </form>
+                        <form action={updateContentItemStatus}>
+                          <input type="hidden" name="id" value={row.id} />
+                          <input type="hidden" name="status" value="review_required" />
+                          <button
+                            type="submit"
+                            className="border border-ink-100 px-2 py-1 text-[11px] text-ink-700 hover:bg-highlight"
+                          >
+                            Request changes
+                          </button>
+                        </form>
+                        <form action={updateContentItemStatus}>
+                          <input type="hidden" name="id" value={row.id} />
+                          <input type="hidden" name="status" value="scheduled" />
+                          <button
+                            type="submit"
+                            className="border border-ink-100 px-2 py-1 text-[11px] text-ink-700 hover:bg-highlight"
+                          >
+                            Schedule
+                          </button>
+                        </form>
+                        <form action={updateContentItemStatus}>
+                          <input type="hidden" name="id" value={row.id} />
+                          <input type="hidden" name="status" value="publishing" />
+                          <button
+                            type="submit"
+                            className="border border-ink-100 px-2 py-1 text-[11px] text-ink-700 hover:bg-highlight"
+                          >
+                            Publish now
+                          </button>
+                        </form>
+                        <form action={updateContentItemStatus}>
+                          <input type="hidden" name="id" value={row.id} />
+                          <input type="hidden" name="status" value="send_failed" />
+                          <button
+                            type="submit"
+                            className="border border-ink-100 px-2 py-1 text-[11px] text-ink-700 hover:bg-highlight"
+                          >
+                            Retry mark
+                          </button>
+                        </form>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/content-queue/page.tsx
+++ b/src/app/(admin)/admin/content-queue/page.tsx
@@ -3,8 +3,10 @@ import type { Metadata } from "next";
 import { ListChecks } from "lucide-react";
 import {
   listAdminContentQueue,
+  runRetryFailedPublishOnly,
   updateContentItemStatus,
 } from "@/actions/admin-content-ops";
+import type { Json } from "@/types/database.types";
 
 export const metadata: Metadata = {
   title: "Admin | Content Queue",
@@ -105,6 +107,13 @@ export default async function AdminContentQueuePage(props: {
           >
             Apply filters
           </button>
+          <button
+            type="submit"
+            formAction={runRetryFailedPublishOnly}
+            className="border border-ink-100 bg-vermilion-100/40 px-3 py-1.5 text-xs text-ink-900 hover:bg-vermilion-100"
+          >
+            Retry failed only
+          </button>
         </form>
 
         {!listRes.ok ? <p className="text-xs text-danger">{listRes.error}</p> : null}
@@ -120,6 +129,7 @@ export default async function AdminContentQueuePage(props: {
                   <th className="p-2 font-medium text-ink-700">Type</th>
                   <th className="p-2 font-medium text-ink-700">Status</th>
                   <th className="p-2 font-medium text-ink-700">Quality</th>
+                  <th className="p-2 font-medium text-ink-700">Gate</th>
                   <th className="p-2 font-medium text-ink-700">Updated</th>
                   <th className="p-2 font-medium text-ink-700">Actions</th>
                 </tr>
@@ -135,6 +145,9 @@ export default async function AdminContentQueuePage(props: {
                     <td className="p-2 text-ink-700">{row.status}</td>
                     <td className="p-2 text-ink-700">
                       {row.source_quality_score ?? "-"} / {row.fact_check_score ?? "-"}
+                    </td>
+                    <td className="p-2 text-ink-700">
+                      <ReviewGateCell metadata={row.metadata} />
                     </td>
                     <td className="p-2 whitespace-nowrap text-ink-500">
                       {new Date(row.updated_at).toISOString().replace("T", " ").slice(0, 19)} UTC
@@ -202,4 +215,57 @@ export default async function AdminContentQueuePage(props: {
       </div>
     </div>
   );
+}
+
+function ReviewGateCell({ metadata }: { metadata: Json | null }) {
+  const latest = readLatestReviewGate(metadata);
+  if (!latest) {
+    return <span className="text-ink-500">-</span>;
+  }
+  if (latest.passed) {
+    return (
+      <span className="inline-flex border border-ink-100 bg-paper-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
+        pass
+      </span>
+    );
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {latest.reasons.length === 0 ? (
+        <span className="inline-flex border border-ink-100 bg-paper-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+          fail
+        </span>
+      ) : (
+        latest.reasons.map((reason) => (
+          <span
+            key={reason}
+            className="inline-flex border border-ink-100 bg-paper-50 px-2 py-0.5 text-[11px] font-medium text-amber-700"
+          >
+            {reason}
+          </span>
+        ))
+      )}
+    </div>
+  );
+}
+
+function readLatestReviewGate(metadata: Json | null): {
+  passed: boolean;
+  reasons: string[];
+} | null {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return null;
+  const reviewGate = (metadata as Record<string, unknown>).review_gate;
+  if (!reviewGate || typeof reviewGate !== "object" || Array.isArray(reviewGate)) {
+    return null;
+  }
+  const latest = (reviewGate as Record<string, unknown>).latest;
+  if (!latest || typeof latest !== "object" || Array.isArray(latest)) return null;
+  const passed = (latest as Record<string, unknown>).passed;
+  const reasons = (latest as Record<string, unknown>).reasons;
+  return {
+    passed: passed === true,
+    reasons: Array.isArray(reasons)
+      ? reasons.filter((v): v is string => typeof v === "string")
+      : [],
+  };
 }

--- a/src/app/(admin)/admin/news-sources/page.tsx
+++ b/src/app/(admin)/admin/news-sources/page.tsx
@@ -1,0 +1,133 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { Newspaper } from "lucide-react";
+import {
+  listAdminNewsSources,
+  setAdminNewsSourceActive,
+  upsertAdminNewsSource,
+} from "@/actions/admin-content-ops";
+
+export const metadata: Metadata = {
+  title: "Admin | News Sources",
+};
+
+export default async function AdminNewsSourcesPage() {
+  const listRes = await listAdminNewsSources();
+  const rows = listRes.ok ? listRes.rows : [];
+
+  return (
+    <div className="min-h-screen bg-paper-50">
+      <div className="sticky top-0 z-30 flex h-12 items-center justify-between border-b border-ink-100 bg-paper-50 px-6">
+        <div className="flex min-w-0 items-center gap-2">
+          <Newspaper className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+          <h1 className="truncate text-sm font-medium text-ink-900">News Sources</h1>
+        </div>
+        <Link
+          href="/admin"
+          className="text-xs text-vermilion-600 transition-colors hover:text-vermilion-700"
+        >
+          Back to admin
+        </Link>
+      </div>
+
+      <div className="max-w-5xl space-y-5 p-6">
+        <p className="text-sm leading-relaxed text-ink-700">
+          Register trusted sources for automated ingestion and control trust weighting.
+        </p>
+
+        <form action={upsertAdminNewsSource} className="space-y-3 border border-ink-100 bg-paper-0 p-4">
+          <h2 className="text-sm font-medium text-ink-900">Add source</h2>
+          <div className="grid gap-2 md:grid-cols-2">
+            <input
+              name="name"
+              required
+              placeholder="Source name"
+              className="border border-ink-100 bg-paper-50 px-2.5 py-2 text-xs text-ink-900"
+            />
+            <select
+              name="kind"
+              defaultValue="rss"
+              className="border border-ink-100 bg-paper-50 px-2.5 py-2 text-xs text-ink-900"
+            >
+              <option value="rss">rss</option>
+              <option value="blog">blog</option>
+              <option value="api">api</option>
+              <option value="manual">manual</option>
+            </select>
+            <input
+              name="base_url"
+              required
+              placeholder="https://example.com"
+              className="border border-ink-100 bg-paper-50 px-2.5 py-2 text-xs text-ink-900 md:col-span-2"
+            />
+            <input
+              name="trust_weight"
+              type="number"
+              min={0}
+              max={100}
+              defaultValue={50}
+              className="border border-ink-100 bg-paper-50 px-2.5 py-2 text-xs text-ink-900"
+            />
+            <input
+              name="fetch_interval_minutes"
+              type="number"
+              min={10}
+              defaultValue={1440}
+              className="border border-ink-100 bg-paper-50 px-2.5 py-2 text-xs text-ink-900"
+            />
+          </div>
+          <button
+            type="submit"
+            className="border border-ink-100 bg-paper-50 px-3 py-1.5 text-xs text-ink-900 hover:bg-highlight"
+          >
+            Save source
+          </button>
+        </form>
+
+        {!listRes.ok ? <p className="text-xs text-danger">{listRes.error}</p> : null}
+
+        {rows.length === 0 ? (
+          <p className="text-xs text-ink-500">No sources yet.</p>
+        ) : (
+          <div className="overflow-x-auto border border-ink-100">
+            <table className="w-full text-left text-xs">
+              <thead>
+                <tr className="border-b border-ink-100 bg-paper-50">
+                  <th className="p-2 font-medium text-ink-700">Name</th>
+                  <th className="p-2 font-medium text-ink-700">Kind</th>
+                  <th className="p-2 font-medium text-ink-700">URL</th>
+                  <th className="p-2 font-medium text-ink-700">Trust</th>
+                  <th className="p-2 font-medium text-ink-700">Active</th>
+                  <th className="p-2 font-medium text-ink-700">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.id} className="border-b border-ink-100/80">
+                    <td className="p-2 text-ink-900">{row.name}</td>
+                    <td className="p-2 text-ink-700">{row.kind}</td>
+                    <td className="p-2 text-ink-700">{row.base_url}</td>
+                    <td className="p-2 text-ink-700">{row.trust_weight}</td>
+                    <td className="p-2 text-ink-700">{row.is_active ? "yes" : "no"}</td>
+                    <td className="p-2">
+                      <form action={setAdminNewsSourceActive}>
+                        <input type="hidden" name="id" value={row.id} />
+                        <input type="hidden" name="is_active" value={row.is_active ? "false" : "true"} />
+                        <button
+                          type="submit"
+                          className="border border-ink-100 px-2 py-1 text-[11px] text-ink-700 hover:bg-highlight"
+                        >
+                          {row.is_active ? "Disable" : "Enable"}
+                        </button>
+                      </form>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import type { Metadata } from "next";
-import { BookOpen, Cable, ListChecks, Mail, Shield } from "lucide-react";
+import { Activity, BookOpen, Cable, ListChecks, Mail, Newspaper, Shield, Users } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -35,6 +35,30 @@ export default async function ElevateServiceAdminHomePage() {
       title: t("cards.purchaseAllowlist.title"),
       desc: t("cards.purchaseAllowlist.desc"),
       icon: ListChecks,
+    },
+    {
+      href: "/admin/content-queue",
+      title: "Content queue",
+      desc: "Review, approve, schedule, and publish blog/newsletter drafts.",
+      icon: ListChecks,
+    },
+    {
+      href: "/admin/news-sources",
+      title: "News sources",
+      desc: "Manage RSS/blog sources and trust weights for ingestion.",
+      icon: Newspaper,
+    },
+    {
+      href: "/admin/runs",
+      title: "Automation runs",
+      desc: "Inspect run logs and queue manual ingest/generate/publish runs.",
+      icon: Activity,
+    },
+    {
+      href: "/admin/subscribers",
+      title: "Subscribers",
+      desc: "Operate newsletter subscriber lifecycle separately from waitlist.",
+      icon: Users,
     },
   ];
 

--- a/src/app/(admin)/admin/runs/page.tsx
+++ b/src/app/(admin)/admin/runs/page.tsx
@@ -5,6 +5,7 @@ import {
   createManualContentRun,
   listAdminContentRuns,
   runAdminContentOpsScenario,
+  runRetryFailedPublishOnly,
 } from "@/actions/admin-content-ops";
 import type { Json } from "@/types/database.types";
 
@@ -15,6 +16,7 @@ export const metadata: Metadata = {
 export default async function AdminRunsPage() {
   const listRes = await listAdminContentRuns();
   const rows = listRes.ok ? listRes.rows : [];
+  const summary = buildRunSummary(rows);
 
   return (
     <div className="min-h-screen bg-paper-50">
@@ -35,6 +37,16 @@ export default async function AdminRunsPage() {
         <p className="text-sm leading-relaxed text-ink-700">
           Inspect ingestion/generation/publish run history and trigger manual runs.
         </p>
+        <div className="grid gap-2 md:grid-cols-4">
+          <SummaryCard label="Created" value={summary.createdCount} tone="neutral" />
+          <SummaryCard label="Sent" value={summary.sentCount} tone="success" />
+          <SummaryCard label="Failed" value={summary.failedCount} tone="danger" />
+          <SummaryCard
+            label="Top failure reason"
+            value={summary.topFailureReason ?? "-"}
+            tone="warning"
+          />
+        </div>
         <div className="border border-ink-100 bg-paper-0 p-3 text-xs leading-relaxed text-ink-700">
           <p className="font-medium text-ink-900">Recommended 1-pass scenario</p>
           <p className="mt-1">
@@ -59,6 +71,7 @@ export default async function AdminRunsPage() {
               <option value="draft_generate">draft_generate</option>
               <option value="review_gate">review_gate</option>
               <option value="publish">publish</option>
+              <option value="publish_retry_failed">publish_retry_failed</option>
             </select>
           </div>
           <button
@@ -73,6 +86,13 @@ export default async function AdminRunsPage() {
             className="border border-ink-100 bg-vermilion-100/40 px-3 py-1.5 text-xs text-ink-900 hover:bg-vermilion-100"
           >
             Run ingest → generate → publish
+          </button>
+          <button
+            type="submit"
+            formAction={runRetryFailedPublishOnly}
+            className="border border-ink-100 bg-paper-50 px-3 py-1.5 text-xs text-ink-900 hover:bg-highlight"
+          >
+            Retry failed only
           </button>
         </form>
 
@@ -129,13 +149,38 @@ export default async function AdminRunsPage() {
   );
 }
 
+function SummaryCard({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number | string;
+  tone: "neutral" | "success" | "danger" | "warning";
+}) {
+  const toneClass =
+    tone === "success"
+      ? "text-emerald-700"
+      : tone === "danger"
+        ? "text-danger"
+        : tone === "warning"
+          ? "text-amber-700"
+          : "text-ink-900";
+  return (
+    <div className="border border-ink-100 bg-paper-0 p-3">
+      <p className="text-[11px] uppercase tracking-wide text-ink-500">{label}</p>
+      <p className={`mt-1 text-sm font-medium ${toneClass}`}>{String(value)}</p>
+    </div>
+  );
+}
+
 function renderRunResultBadge(
   status: string,
   errorSummary: string | null,
   metadata: Json | null,
 ) {
   const result = getRunResult(status, errorSummary, metadata);
-  const failureHint = getFirstFailureMessage(errorSummary, metadata);
+  const failureHint = getFailureHint(errorSummary, metadata);
   if (result === "failure") {
     return (
       <span
@@ -204,17 +249,21 @@ function arrayLength(value: unknown): number {
   return Array.isArray(value) ? value.length : 0;
 }
 
-function getFirstFailureMessage(
+function getFailureHint(
   errorSummary: string | null,
   metadata: Json | null,
 ): string | null {
-  if (errorSummary?.trim()) return errorSummary.trim();
+  const firstFromError = errorSummary?.trim() ? errorSummary.trim() : null;
+  const count = getFailureCount(errorSummary, metadata);
+  if (firstFromError) {
+    return count > 1 ? `${firstFromError} (+${count - 1})` : firstFromError;
+  }
   if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
     return null;
   }
   const obj = metadata as Record<string, unknown>;
   const direct = firstStringInFailureMessages(obj.failureMessages);
-  if (direct) return direct;
+  if (direct) return count > 1 ? `${direct} (+${count - 1})` : direct;
   const nestedResult = obj.result;
   if (
     nestedResult &&
@@ -223,7 +272,7 @@ function getFirstFailureMessage(
   ) {
     const nested = nestedResult as Record<string, unknown>;
     const nestedMsg = firstStringInFailureMessages(nested.failureMessages);
-    if (nestedMsg) return nestedMsg;
+    if (nestedMsg) return count > 1 ? `${nestedMsg} (+${count - 1})` : nestedMsg;
   }
   return null;
 }
@@ -232,4 +281,97 @@ function firstStringInFailureMessages(value: unknown): string | null {
   if (!Array.isArray(value) || value.length === 0) return null;
   const first = value.find((item) => typeof item === "string");
   return typeof first === "string" ? first : null;
+}
+
+function getFailureCount(errorSummary: string | null, metadata: Json | null): number {
+  if (errorSummary?.startsWith("warning:")) {
+    return 1;
+  }
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return errorSummary?.trim() ? 1 : 0;
+  }
+
+  const obj = metadata as Record<string, unknown>;
+  const failedCount = numericValue(obj.failedCount);
+  if (failedCount > 0) return failedCount;
+
+  const directMsgs = Array.isArray(obj.failureMessages) ? obj.failureMessages.length : 0;
+  if (directMsgs > 0) return directMsgs;
+
+  const nestedResult = obj.result;
+  if (
+    nestedResult &&
+    typeof nestedResult === "object" &&
+    !Array.isArray(nestedResult)
+  ) {
+    const nested = nestedResult as Record<string, unknown>;
+    const nestedFailedCount = numericValue(nested.failedCount);
+    if (nestedFailedCount > 0) return nestedFailedCount;
+    const nestedMsgs = Array.isArray(nested.failureMessages)
+      ? nested.failureMessages.length
+      : 0;
+    if (nestedMsgs > 0) return nestedMsgs;
+  }
+  return errorSummary?.trim() ? 1 : 0;
+}
+
+function buildRunSummary(rows: Array<{ error_summary: string | null; metadata: Json | null }>) {
+  let createdCount = 0;
+  let sentCount = 0;
+  let failedCount = 0;
+  const reasonCounts = new Map<string, number>();
+
+  for (const row of rows.slice(0, 100)) {
+    const payload = normalizeRunMetadata(row.metadata);
+    createdCount += numericValue(payload.createdItems);
+    sentCount += numericValue(payload.sentCount);
+    failedCount += numericValue(payload.failedCount);
+    for (const reason of parseFailureReasons(row.error_summary, payload.failureMessages)) {
+      reasonCounts.set(reason, (reasonCounts.get(reason) ?? 0) + 1);
+    }
+  }
+
+  let topFailureReason: string | null = null;
+  let topCount = 0;
+  for (const [reason, count] of reasonCounts.entries()) {
+    if (count > topCount) {
+      topCount = count;
+      topFailureReason = `${reason} (${count})`;
+    }
+  }
+
+  return { createdCount, sentCount, failedCount, topFailureReason };
+}
+
+function normalizeRunMetadata(metadata: Json | null): Record<string, unknown> {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return {};
+  }
+  const obj = metadata as Record<string, unknown>;
+  const nested = obj.result;
+  if (nested && typeof nested === "object" && !Array.isArray(nested)) {
+    return nested as Record<string, unknown>;
+  }
+  return obj;
+}
+
+function parseFailureReasons(
+  errorSummary: string | null,
+  failureMessagesRaw: unknown,
+): string[] {
+  const parsed: string[] = [];
+  if (errorSummary?.trim()) {
+    parsed.push(errorSummary.replace(/^warning:/, "").trim());
+  }
+  if (Array.isArray(failureMessagesRaw)) {
+    for (const message of failureMessagesRaw) {
+      if (typeof message !== "string") continue;
+      const cleaned = message
+        .replace(/^\[[^\]]+\]\s*/, "")
+        .replace(/^warning:/, "")
+        .trim();
+      if (cleaned) parsed.push(cleaned);
+    }
+  }
+  return parsed;
 }

--- a/src/app/(admin)/admin/runs/page.tsx
+++ b/src/app/(admin)/admin/runs/page.tsx
@@ -1,0 +1,235 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { Activity } from "lucide-react";
+import {
+  createManualContentRun,
+  listAdminContentRuns,
+  runAdminContentOpsScenario,
+} from "@/actions/admin-content-ops";
+import type { Json } from "@/types/database.types";
+
+export const metadata: Metadata = {
+  title: "Admin | Automation Runs",
+};
+
+export default async function AdminRunsPage() {
+  const listRes = await listAdminContentRuns();
+  const rows = listRes.ok ? listRes.rows : [];
+
+  return (
+    <div className="min-h-screen bg-paper-50">
+      <div className="sticky top-0 z-30 flex h-12 items-center justify-between border-b border-ink-100 bg-paper-50 px-6">
+        <div className="flex min-w-0 items-center gap-2">
+          <Activity className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+          <h1 className="truncate text-sm font-medium text-ink-900">Automation Runs</h1>
+        </div>
+        <Link
+          href="/admin"
+          className="text-xs text-vermilion-600 transition-colors hover:text-vermilion-700"
+        >
+          Back to admin
+        </Link>
+      </div>
+
+      <div className="max-w-5xl space-y-5 p-6">
+        <p className="text-sm leading-relaxed text-ink-700">
+          Inspect ingestion/generation/publish run history and trigger manual runs.
+        </p>
+        <div className="border border-ink-100 bg-paper-0 p-3 text-xs leading-relaxed text-ink-700">
+          <p className="font-medium text-ink-900">Recommended 1-pass scenario</p>
+          <p className="mt-1">
+            Run in order: <code>ingest</code> {"->"} <code>draft_generate</code> {"->"}{" "}
+            <code>publish</code>. If <code>Error</code> shows <code>warning:</code>,
+            open the metadata summary in this table for failure details.
+          </p>
+        </div>
+
+        <form action={createManualContentRun} className="flex flex-wrap items-end gap-2 border border-ink-100 bg-paper-0 p-3">
+          <div className="space-y-1">
+            <label htmlFor="run_type" className="text-xs text-ink-500">
+              Run type
+            </label>
+            <select
+              id="run_type"
+              name="run_type"
+              defaultValue="ingest"
+              className="min-w-[180px] border border-ink-100 bg-paper-50 px-2 py-1.5 text-xs text-ink-900"
+            >
+              <option value="ingest">ingest</option>
+              <option value="draft_generate">draft_generate</option>
+              <option value="review_gate">review_gate</option>
+              <option value="publish">publish</option>
+            </select>
+          </div>
+          <button
+            type="submit"
+            className="border border-ink-100 bg-paper-50 px-3 py-1.5 text-xs text-ink-900 hover:bg-highlight"
+          >
+            Queue manual run
+          </button>
+          <button
+            type="submit"
+            formAction={runAdminContentOpsScenario}
+            className="border border-ink-100 bg-vermilion-100/40 px-3 py-1.5 text-xs text-ink-900 hover:bg-vermilion-100"
+          >
+            Run ingest → generate → publish
+          </button>
+        </form>
+
+        {!listRes.ok ? <p className="text-xs text-danger">{listRes.error}</p> : null}
+
+        {rows.length === 0 ? (
+          <p className="text-xs text-ink-500">No run logs yet.</p>
+        ) : (
+          <div className="overflow-x-auto border border-ink-100">
+            <table className="w-full text-left text-xs">
+              <thead>
+                <tr className="border-b border-ink-100 bg-paper-50">
+                  <th className="p-2 font-medium text-ink-700">Type</th>
+                  <th className="p-2 font-medium text-ink-700">Result</th>
+                  <th className="p-2 font-medium text-ink-700">Status</th>
+                  <th className="p-2 font-medium text-ink-700">Trigger</th>
+                  <th className="p-2 font-medium text-ink-700">Started</th>
+                  <th className="p-2 font-medium text-ink-700">Ended</th>
+                  <th className="p-2 font-medium text-ink-700">Error</th>
+                  <th className="p-2 font-medium text-ink-700">Metadata</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.id} className="border-b border-ink-100/80">
+                    <td className="p-2 text-ink-900">{row.run_type}</td>
+                    <td className="p-2">{renderRunResultBadge(row.status, row.error_summary, row.metadata)}</td>
+                    <td className="p-2 text-ink-700">{row.status}</td>
+                    <td className="p-2 text-ink-700">{row.trigger_type}</td>
+                    <td className="p-2 whitespace-nowrap text-ink-500">
+                      {row.started_at
+                        ? `${new Date(row.started_at).toISOString().replace("T", " ").slice(0, 19)} UTC`
+                        : "-"}
+                    </td>
+                    <td className="p-2 whitespace-nowrap text-ink-500">
+                      {row.ended_at
+                        ? `${new Date(row.ended_at).toISOString().replace("T", " ").slice(0, 19)} UTC`
+                        : "-"}
+                    </td>
+                    <td className="p-2 text-danger">{row.error_summary ?? "-"}</td>
+                    <td className="p-2 text-ink-500">
+                      <pre className="max-w-[340px] overflow-x-auto whitespace-pre-wrap wrap-break-word text-[11px] leading-relaxed">
+                        {row.metadata ? JSON.stringify(row.metadata) : "-"}
+                      </pre>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function renderRunResultBadge(
+  status: string,
+  errorSummary: string | null,
+  metadata: Json | null,
+) {
+  const result = getRunResult(status, errorSummary, metadata);
+  const failureHint = getFirstFailureMessage(errorSummary, metadata);
+  if (result === "failure") {
+    return (
+      <span
+        className="inline-flex border border-ink-100 bg-paper-50 px-2 py-0.5 text-[11px] font-medium text-danger"
+        title={failureHint ?? undefined}
+      >
+        실패
+      </span>
+    );
+  }
+  if (result === "partial") {
+    return (
+      <span
+        className="inline-flex border border-ink-100 bg-paper-50 px-2 py-0.5 text-[11px] font-medium text-amber-700"
+        title={failureHint ?? "부분실패 (상세는 metadata 확인)"}
+      >
+        부분실패
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex border border-ink-100 bg-paper-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
+      성공
+    </span>
+  );
+}
+
+function getRunResult(
+  status: string,
+  errorSummary: string | null,
+  metadata: Json | null,
+): "success" | "partial" | "failure" {
+  if (status === "failed") return "failure";
+  if (status !== "succeeded") return "partial";
+
+  if (errorSummary?.startsWith("warning:")) return "partial";
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return "success";
+  }
+
+  const obj = metadata as Record<string, unknown>;
+  if (numericValue(obj.failedCount) > 0) return "partial";
+  if (numericValue(obj.failedSources) > 0) return "partial";
+  if (arrayLength(obj.failureMessages) > 0) return "partial";
+
+  const nestedResult = obj.result;
+  if (
+    nestedResult &&
+    typeof nestedResult === "object" &&
+    !Array.isArray(nestedResult)
+  ) {
+    const nested = nestedResult as Record<string, unknown>;
+    if (numericValue(nested.failedCount) > 0) return "partial";
+    if (numericValue(nested.failedSources) > 0) return "partial";
+    if (arrayLength(nested.failureMessages) > 0) return "partial";
+  }
+
+  return "success";
+}
+
+function numericValue(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function arrayLength(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function getFirstFailureMessage(
+  errorSummary: string | null,
+  metadata: Json | null,
+): string | null {
+  if (errorSummary?.trim()) return errorSummary.trim();
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return null;
+  }
+  const obj = metadata as Record<string, unknown>;
+  const direct = firstStringInFailureMessages(obj.failureMessages);
+  if (direct) return direct;
+  const nestedResult = obj.result;
+  if (
+    nestedResult &&
+    typeof nestedResult === "object" &&
+    !Array.isArray(nestedResult)
+  ) {
+    const nested = nestedResult as Record<string, unknown>;
+    const nestedMsg = firstStringInFailureMessages(nested.failureMessages);
+    if (nestedMsg) return nestedMsg;
+  }
+  return null;
+}
+
+function firstStringInFailureMessages(value: unknown): string | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  const first = value.find((item) => typeof item === "string");
+  return typeof first === "string" ? first : null;
+}

--- a/src/app/(admin)/admin/subscribers/page.tsx
+++ b/src/app/(admin)/admin/subscribers/page.tsx
@@ -1,0 +1,139 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { Users } from "lucide-react";
+import {
+  addAdminNewsletterSubscriber,
+  listAdminNewsletterSubscribers,
+  updateAdminNewsletterSubscriberStatus,
+} from "@/actions/admin-content-ops";
+
+export const metadata: Metadata = {
+  title: "Admin | Newsletter Subscribers",
+};
+
+export default async function AdminSubscribersPage() {
+  const listRes = await listAdminNewsletterSubscribers();
+  const rows = listRes.ok ? listRes.rows : [];
+
+  return (
+    <div className="min-h-screen bg-paper-50">
+      <div className="sticky top-0 z-30 flex h-12 items-center justify-between border-b border-ink-100 bg-paper-50 px-6">
+        <div className="flex min-w-0 items-center gap-2">
+          <Users className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+          <h1 className="truncate text-sm font-medium text-ink-900">Subscribers</h1>
+        </div>
+        <Link
+          href="/admin"
+          className="text-xs text-vermilion-600 transition-colors hover:text-vermilion-700"
+        >
+          Back to admin
+        </Link>
+      </div>
+
+      <div className="max-w-6xl space-y-5 p-6">
+        <p className="text-sm leading-relaxed text-ink-700">
+          Manage newsletter subscription lifecycle independently from waitlist leads.
+        </p>
+
+        <form action={addAdminNewsletterSubscriber} className="space-y-3 border border-ink-100 bg-paper-0 p-4">
+          <h2 className="text-sm font-medium text-ink-900">Add subscriber</h2>
+          <div className="grid gap-2 md:grid-cols-3">
+            <input
+              type="email"
+              name="email"
+              required
+              placeholder="name@company.com"
+              className="border border-ink-100 bg-paper-50 px-2.5 py-2 text-xs text-ink-900 md:col-span-2"
+            />
+            <input
+              name="locale"
+              defaultValue="en"
+              placeholder="en"
+              className="border border-ink-100 bg-paper-50 px-2.5 py-2 text-xs text-ink-900"
+            />
+            <select
+              name="frequency_pref"
+              defaultValue="weekly"
+              className="border border-ink-100 bg-paper-50 px-2.5 py-2 text-xs text-ink-900"
+            >
+              <option value="daily">daily</option>
+              <option value="weekly">weekly</option>
+            </select>
+          </div>
+          <button
+            type="submit"
+            className="border border-ink-100 bg-paper-50 px-3 py-1.5 text-xs text-ink-900 hover:bg-highlight"
+          >
+            Save subscriber
+          </button>
+        </form>
+
+        {!listRes.ok ? <p className="text-xs text-danger">{listRes.error}</p> : null}
+
+        {rows.length === 0 ? (
+          <p className="text-xs text-ink-500">No subscribers yet.</p>
+        ) : (
+          <div className="overflow-x-auto border border-ink-100">
+            <table className="w-full text-left text-xs">
+              <thead>
+                <tr className="border-b border-ink-100 bg-paper-50">
+                  <th className="p-2 font-medium text-ink-700">Email</th>
+                  <th className="p-2 font-medium text-ink-700">Status</th>
+                  <th className="p-2 font-medium text-ink-700">Frequency</th>
+                  <th className="p-2 font-medium text-ink-700">Locale</th>
+                  <th className="p-2 font-medium text-ink-700">Source</th>
+                  <th className="p-2 font-medium text-ink-700">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.id} className="border-b border-ink-100/80">
+                    <td className="p-2 font-mono text-ink-900">{row.email}</td>
+                    <td className="p-2 text-ink-700">{row.status}</td>
+                    <td className="p-2 text-ink-700">{row.frequency_pref}</td>
+                    <td className="p-2 text-ink-700">{row.locale}</td>
+                    <td className="p-2 text-ink-700">{row.source}</td>
+                    <td className="p-2">
+                      <div className="flex flex-wrap gap-1.5">
+                        <form action={updateAdminNewsletterSubscriberStatus}>
+                          <input type="hidden" name="id" value={row.id} />
+                          <input type="hidden" name="status" value="subscribed" />
+                          <button
+                            type="submit"
+                            className="border border-ink-100 px-2 py-1 text-[11px] text-ink-700 hover:bg-highlight"
+                          >
+                            Subscribe
+                          </button>
+                        </form>
+                        <form action={updateAdminNewsletterSubscriberStatus}>
+                          <input type="hidden" name="id" value={row.id} />
+                          <input type="hidden" name="status" value="unsubscribed" />
+                          <button
+                            type="submit"
+                            className="border border-ink-100 px-2 py-1 text-[11px] text-ink-700 hover:bg-highlight"
+                          >
+                            Unsubscribe
+                          </button>
+                        </form>
+                        <form action={updateAdminNewsletterSubscriberStatus}>
+                          <input type="hidden" name="id" value={row.id} />
+                          <input type="hidden" name="status" value="bounced" />
+                          <button
+                            type="submit"
+                            className="border border-ink-100 px-2 py-1 text-[11px] text-ink-700 hover:bg-highlight"
+                          >
+                            Mark bounced
+                          </button>
+                        </form>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/desk/CommandBar.tsx
+++ b/src/components/desk/CommandBar.tsx
@@ -65,6 +65,30 @@ export function CommandBar({
           href: "/admin/waitlist",
           index: "03",
         },
+        {
+          id: "admin-content-queue",
+          label: tx("routes.contentQueue", "Content queue"),
+          href: "/admin/content-queue",
+          index: "04",
+        },
+        {
+          id: "admin-news-sources",
+          label: tx("routes.newsSources", "News sources"),
+          href: "/admin/news-sources",
+          index: "05",
+        },
+        {
+          id: "admin-runs",
+          label: tx("routes.runs", "Runs"),
+          href: "/admin/runs",
+          index: "06",
+        },
+        {
+          id: "admin-subscribers",
+          label: tx("routes.subscribers", "Subscribers"),
+          href: "/admin/subscribers",
+          index: "07",
+        },
       ];
     }
     return [

--- a/src/components/desk/TOC.tsx
+++ b/src/components/desk/TOC.tsx
@@ -12,6 +12,7 @@ import {
   CircleHelp,
   Clapperboard,
   CreditCard,
+  ListChecks,
   Shield,
   Sparkles,
   UserRound,
@@ -95,7 +96,20 @@ export function TOC({
           items: [
             { href: "/admin", label: tx("house.admin", "Admin") },
             { href: "/admin/content", label: tx("admin.content", "Content") },
+            {
+              href: "/admin/content-queue",
+              label: tx("admin.contentQueue", "Content queue"),
+            },
             { href: "/admin/waitlist", label: tx("admin.waitlist", "Waitlist") },
+            {
+              href: "/admin/news-sources",
+              label: tx("admin.newsSources", "News sources"),
+            },
+            { href: "/admin/runs", label: tx("admin.runs", "Runs") },
+            {
+              href: "/admin/subscribers",
+              label: tx("admin.subscribers", "Subscribers"),
+            },
             {
               href: "/admin/purchase-allowlist",
               label: tx("admin.purchaseAllowlist", "Checkout allowlist"),
@@ -197,7 +211,11 @@ export function TOC({
       "/dashboard/help": CircleHelp,
       "/admin": Shield,
       "/admin/content": BookOpen,
+      "/admin/content-queue": ListChecks,
       "/admin/waitlist": Users,
+      "/admin/news-sources": Sparkles,
+      "/admin/runs": CircleHelp,
+      "/admin/subscribers": Users,
       "/admin/purchase-allowlist": Shield,
       "/admin/prompt-studio-allowlist": Sparkles,
     };

--- a/src/lib/content-ops/blog-publish-adapter.ts
+++ b/src/lib/content-ops/blog-publish-adapter.ts
@@ -1,0 +1,117 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import matter from "gray-matter";
+
+const BLOG_ROOT = path.join(process.cwd(), "content/blog");
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+type LocaleTemplate = {
+  introTitle: string;
+  introBody: string;
+  ctaTitle: string;
+  ctaBody: string;
+};
+
+const LOCALE_TEMPLATES: Record<string, LocaleTemplate> = {
+  en: {
+    introTitle: "Why this matters",
+    introBody:
+      "This post is generated in the Elevate editorial pipeline and reviewed before publishing.",
+    ctaTitle: "Next step",
+    ctaBody:
+      "Subscribe to the newsletter for the daily digest and practical workflows.",
+  },
+  ko: {
+    introTitle: "왜 중요한가",
+    introBody:
+      "이 글은 Elevate 에디토리얼 파이프라인에서 생성 후 검수 과정을 거쳐 발행됩니다.",
+    ctaTitle: "다음 단계",
+    ctaBody:
+      "일간 요약과 실전 워크플로를 받으려면 뉴스레터를 구독하세요.",
+  },
+  ja: {
+    introTitle: "なぜ重要か",
+    introBody:
+      "この投稿は Elevate の編集パイプラインで生成され、レビュー後に公開されます。",
+    ctaTitle: "次のアクション",
+    ctaBody:
+      "日次ダイジェストと実践ワークフローを受け取るにはニュースレターを購読してください。",
+  },
+  "zh-CN": {
+    introTitle: "为什么重要",
+    introBody:
+      "这篇文章由 Elevate 编辑流程生成，并在发布前完成人工审核。",
+    ctaTitle: "下一步",
+    ctaBody: "订阅新闻通讯，获取每日摘要和可落地的工作流建议。",
+  },
+  "zh-TW": {
+    introTitle: "為什麼重要",
+    introBody:
+      "這篇文章由 Elevate 編輯流程生成，並在發佈前完成人工審核。",
+    ctaTitle: "下一步",
+    ctaBody: "訂閱電子報，取得每日摘要與可落地的工作流程建議。",
+  },
+};
+
+function resolveLocaleTemplate(locale: string): LocaleTemplate {
+  return LOCALE_TEMPLATES[locale] ?? LOCALE_TEMPLATES.en;
+}
+
+function applyLocaleTemplate(locale: string, bodyMarkdown: string): string {
+  const template = resolveLocaleTemplate(locale);
+  const trimmedBody = bodyMarkdown.trim() || "Draft content.";
+  const hasCta =
+    trimmedBody.includes("## Next step") ||
+    trimmedBody.includes("## 다음 단계") ||
+    trimmedBody.includes("## 次のアクション") ||
+    trimmedBody.includes("## 下一步");
+  const ctaBlock = hasCta
+    ? ""
+    : `\n\n## ${template.ctaTitle}\n\n${template.ctaBody}`;
+  return `## ${template.introTitle}\n\n${template.introBody}\n\n${trimmedBody}${ctaBlock}`;
+}
+
+function slugify(input: string): string {
+  const normalized = input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return normalized.length > 0 ? normalized.slice(0, 80) : "untitled";
+}
+
+export async function publishContentItemToBlog(params: {
+  locale: string;
+  slug?: string | null;
+  title: string;
+  summary?: string | null;
+  bodyMarkdown: string;
+}): Promise<{ ok: true; slug: string; filePath: string } | { ok: false; error: string }> {
+  try {
+    const locale = params.locale?.trim() || "en";
+    const computedSlug = params.slug?.trim() || slugify(params.title);
+    if (!SLUG_RE.test(computedSlug)) {
+      return { ok: false, error: "invalid_slug" };
+    }
+
+    const dirPath = path.join(BLOG_ROOT, locale);
+    await fs.mkdir(dirPath, { recursive: true });
+    const filePath = path.join(dirPath, `${computedSlug}.mdx`);
+
+    const body = applyLocaleTemplate(locale, params.bodyMarkdown);
+    const frontmatter = matter.stringify(
+      body,
+      {
+        title: params.title.trim() || "Untitled",
+        description: params.summary?.trim() || "",
+        date: new Date().toISOString().slice(0, 10),
+        access_tier: "public",
+      },
+    );
+
+    await fs.writeFile(filePath, frontmatter, "utf8");
+    return { ok: true, slug: computedSlug, filePath };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "unknown" };
+  }
+}

--- a/src/lib/content-ops/blog-publish-adapter.ts
+++ b/src/lib/content-ops/blog-publish-adapter.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import matter from "gray-matter";
+import {
+  BLOG_TEMPLATE_VERSION,
+  resolveLocaleTemplateConfig,
+} from "@/lib/content-ops/locale-template-config";
 
 const BLOG_ROOT = path.join(process.cwd(), "content/blog");
 const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
@@ -12,49 +16,14 @@ type LocaleTemplate = {
   ctaBody: string;
 };
 
-const LOCALE_TEMPLATES: Record<string, LocaleTemplate> = {
-  en: {
-    introTitle: "Why this matters",
-    introBody:
-      "This post is generated in the Elevate editorial pipeline and reviewed before publishing.",
-    ctaTitle: "Next step",
-    ctaBody:
-      "Subscribe to the newsletter for the daily digest and practical workflows.",
-  },
-  ko: {
-    introTitle: "왜 중요한가",
-    introBody:
-      "이 글은 Elevate 에디토리얼 파이프라인에서 생성 후 검수 과정을 거쳐 발행됩니다.",
-    ctaTitle: "다음 단계",
-    ctaBody:
-      "일간 요약과 실전 워크플로를 받으려면 뉴스레터를 구독하세요.",
-  },
-  ja: {
-    introTitle: "なぜ重要か",
-    introBody:
-      "この投稿は Elevate の編集パイプラインで生成され、レビュー後に公開されます。",
-    ctaTitle: "次のアクション",
-    ctaBody:
-      "日次ダイジェストと実践ワークフローを受け取るにはニュースレターを購読してください。",
-  },
-  "zh-CN": {
-    introTitle: "为什么重要",
-    introBody:
-      "这篇文章由 Elevate 编辑流程生成，并在发布前完成人工审核。",
-    ctaTitle: "下一步",
-    ctaBody: "订阅新闻通讯，获取每日摘要和可落地的工作流建议。",
-  },
-  "zh-TW": {
-    introTitle: "為什麼重要",
-    introBody:
-      "這篇文章由 Elevate 編輯流程生成，並在發佈前完成人工審核。",
-    ctaTitle: "下一步",
-    ctaBody: "訂閱電子報，取得每日摘要與可落地的工作流程建議。",
-  },
-};
-
 function resolveLocaleTemplate(locale: string): LocaleTemplate {
-  return LOCALE_TEMPLATES[locale] ?? LOCALE_TEMPLATES.en;
+  const config = resolveLocaleTemplateConfig(locale);
+  return {
+    introTitle: config.blogIntroTitle,
+    introBody: config.blogIntroBody,
+    ctaTitle: config.blogCtaTitle,
+    ctaBody: config.blogCtaBody,
+  };
 }
 
 function applyLocaleTemplate(locale: string, bodyMarkdown: string): string {
@@ -106,6 +75,7 @@ export async function publishContentItemToBlog(params: {
         description: params.summary?.trim() || "",
         date: new Date().toISOString().slice(0, 10),
         access_tier: "public",
+        template_version: BLOG_TEMPLATE_VERSION,
       },
     );
 

--- a/src/lib/content-ops/locale-template-config.ts
+++ b/src/lib/content-ops/locale-template-config.ts
@@ -1,0 +1,73 @@
+export const NEWSLETTER_TEMPLATE_VERSION = "v1.1.0";
+export const BLOG_TEMPLATE_VERSION = "v1.1.0";
+
+export type LocaleTemplateConfig = {
+  intro: string;
+  ctaLabel: string;
+  ctaHref: string;
+  blogIntroTitle: string;
+  blogIntroBody: string;
+  blogCtaTitle: string;
+  blogCtaBody: string;
+};
+
+export const LOCALE_TEMPLATE_CONFIG: Record<string, LocaleTemplateConfig> = {
+  en: {
+    intro: "Practical AI updates curated for workflow operators.",
+    ctaLabel: "Open Elevate",
+    ctaHref: "https://elevate.ai.kr/dashboard",
+    blogIntroTitle: "Why this matters",
+    blogIntroBody:
+      "This post is generated in the Elevate editorial pipeline and reviewed before publishing.",
+    blogCtaTitle: "Next step",
+    blogCtaBody:
+      "Subscribe to the newsletter for the daily digest and practical workflows.",
+  },
+  ko: {
+    intro: "실무 운영자를 위해 큐레이션한 AI 업데이트입니다.",
+    ctaLabel: "Elevate 열기",
+    ctaHref: "https://elevate.ai.kr/dashboard",
+    blogIntroTitle: "왜 중요한가",
+    blogIntroBody:
+      "이 글은 Elevate 에디토리얼 파이프라인에서 생성 후 검수 과정을 거쳐 발행됩니다.",
+    blogCtaTitle: "다음 단계",
+    blogCtaBody:
+      "일간 요약과 실전 워크플로를 받으려면 뉴스레터를 구독하세요.",
+  },
+  ja: {
+    intro: "実務オペレーター向けに厳選したAIアップデートです。",
+    ctaLabel: "Elevate を開く",
+    ctaHref: "https://elevate.ai.kr/dashboard",
+    blogIntroTitle: "なぜ重要か",
+    blogIntroBody:
+      "この投稿は Elevate の編集パイプラインで生成され、レビュー後に公開されます。",
+    blogCtaTitle: "次のアクション",
+    blogCtaBody:
+      "日次ダイジェストと実践ワークフローを受け取るにはニュースレターを購読してください。",
+  },
+  "zh-CN": {
+    intro: "为工作流运营者精选的 AI 更新。",
+    ctaLabel: "打开 Elevate",
+    ctaHref: "https://elevate.ai.kr/dashboard",
+    blogIntroTitle: "为什么重要",
+    blogIntroBody:
+      "这篇文章由 Elevate 编辑流程生成，并在发布前完成人工审核。",
+    blogCtaTitle: "下一步",
+    blogCtaBody: "订阅新闻通讯，获取每日摘要和可落地的工作流建议。",
+  },
+  "zh-TW": {
+    intro: "為工作流程營運者精選的 AI 更新。",
+    ctaLabel: "開啟 Elevate",
+    ctaHref: "https://elevate.ai.kr/dashboard",
+    blogIntroTitle: "為什麼重要",
+    blogIntroBody:
+      "這篇文章由 Elevate 編輯流程生成，並在發佈前完成人工審核。",
+    blogCtaTitle: "下一步",
+    blogCtaBody: "訂閱電子報，取得每日摘要與可落地的工作流程建議。",
+  },
+};
+
+export function resolveLocaleTemplateConfig(locale?: string | null): LocaleTemplateConfig {
+  if (!locale) return LOCALE_TEMPLATE_CONFIG.en;
+  return LOCALE_TEMPLATE_CONFIG[locale] ?? LOCALE_TEMPLATE_CONFIG.en;
+}

--- a/src/lib/content-ops/newsletter-send-adapter.ts
+++ b/src/lib/content-ops/newsletter-send-adapter.ts
@@ -1,0 +1,115 @@
+import { Resend } from "resend";
+
+type NewsletterLocaleTemplate = {
+  preheader: string;
+  heading: string;
+  intro: string;
+  ctaLabel: string;
+};
+
+const LOCALE_TEMPLATES: Record<string, NewsletterLocaleTemplate> = {
+  en: {
+    preheader: "Daily AI signal for operators",
+    heading: "Elevate Daily Brief",
+    intro: "Practical AI updates curated for workflow operators.",
+    ctaLabel: "Open Elevate",
+  },
+  ko: {
+    preheader: "운영자를 위한 일간 AI 시그널",
+    heading: "Elevate 데일리 브리프",
+    intro: "실무 운영자를 위해 큐레이션한 AI 업데이트입니다.",
+    ctaLabel: "Elevate 열기",
+  },
+  ja: {
+    preheader: "運用担当者向けの毎日AIシグナル",
+    heading: "Elevate デイリーブリーフ",
+    intro: "実務オペレーター向けに厳選したAIアップデートです。",
+    ctaLabel: "Elevate を開く",
+  },
+  "zh-CN": {
+    preheader: "面向运营者的每日 AI 信号",
+    heading: "Elevate 每日简报",
+    intro: "为工作流运营者精选的 AI 更新。",
+    ctaLabel: "打开 Elevate",
+  },
+  "zh-TW": {
+    preheader: "給營運者的每日 AI 訊號",
+    heading: "Elevate 每日簡報",
+    intro: "為工作流程營運者精選的 AI 更新。",
+    ctaLabel: "開啟 Elevate",
+  },
+};
+
+function resolveTemplate(locale?: string | null): NewsletterLocaleTemplate {
+  if (!locale) return LOCALE_TEMPLATES.en;
+  return LOCALE_TEMPLATES[locale] ?? LOCALE_TEMPLATES.en;
+}
+
+function markdownToHtml(input: string): string {
+  const escaped = input
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+  return escaped.replaceAll("\n\n", "</p><p>").replaceAll("\n", "<br/>");
+}
+
+function buildBrandedNewsletterHtml(params: {
+  locale?: string | null;
+  subject: string;
+  markdownBody: string;
+}): string {
+  const t = resolveTemplate(params.locale);
+  const body = markdownToHtml(params.markdownBody.trim());
+  return `
+<div style="background:#f7f6f3;padding:24px 0;font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#181512">
+  <div style="max-width:620px;margin:0 auto;border:1px solid #e5e2da;background:#ffffff">
+    <div style="padding:18px 20px;border-bottom:1px solid #e5e2da;background:#faf9f7">
+      <div style="font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:#7b7569">${t.preheader}</div>
+      <h1 style="margin:10px 0 0;font-size:20px;line-height:1.35;color:#181512">${t.heading}</h1>
+      <p style="margin:8px 0 0;font-size:13px;line-height:1.6;color:#5f594f">${t.intro}</p>
+    </div>
+    <div style="padding:20px">
+      <h2 style="margin:0 0 12px;font-size:18px;line-height:1.4;color:#181512">${params.subject.trim()}</h2>
+      <div style="font-size:14px;line-height:1.7;color:#2a261f"><p>${body}</p></div>
+      <div style="margin-top:22px">
+        <a href="https://elevate.ai.kr/dashboard" style="display:inline-block;border:1px solid #d7d0c2;background:#fdf8f0;padding:10px 14px;font-size:12px;color:#181512;text-decoration:none">${t.ctaLabel}</a>
+      </div>
+    </div>
+  </div>
+</div>`.trim();
+}
+
+export async function sendNewsletterEmail(params: {
+  to: string;
+  subject: string;
+  markdownBody: string;
+  locale?: string | null;
+}): Promise<{ ok: true; providerMessageId?: string } | { ok: false; error: string }> {
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  const from = process.env.RESEND_FROM_EMAIL?.trim();
+  if (!apiKey || !from) {
+    return { ok: false, error: "resend_not_configured" };
+  }
+
+  try {
+    const resend = new Resend(apiKey);
+    const html = buildBrandedNewsletterHtml({
+      locale: params.locale,
+      subject: params.subject,
+      markdownBody: params.markdownBody,
+    });
+    const result = await resend.emails.send({
+      from,
+      to: params.to.trim(),
+      subject: params.subject.trim(),
+      html,
+    });
+
+    if (result.error) {
+      return { ok: false, error: result.error.message };
+    }
+    return { ok: true, providerMessageId: result.data?.id };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "unknown" };
+  }
+}

--- a/src/lib/content-ops/newsletter-send-adapter.ts
+++ b/src/lib/content-ops/newsletter-send-adapter.ts
@@ -1,42 +1,34 @@
 import { Resend } from "resend";
+import {
+  NEWSLETTER_TEMPLATE_VERSION,
+  resolveLocaleTemplateConfig,
+} from "@/lib/content-ops/locale-template-config";
 
 type NewsletterLocaleTemplate = {
   preheader: string;
   heading: string;
-  intro: string;
-  ctaLabel: string;
 };
 
 const LOCALE_TEMPLATES: Record<string, NewsletterLocaleTemplate> = {
   en: {
     preheader: "Daily AI signal for operators",
     heading: "Elevate Daily Brief",
-    intro: "Practical AI updates curated for workflow operators.",
-    ctaLabel: "Open Elevate",
   },
   ko: {
     preheader: "운영자를 위한 일간 AI 시그널",
     heading: "Elevate 데일리 브리프",
-    intro: "실무 운영자를 위해 큐레이션한 AI 업데이트입니다.",
-    ctaLabel: "Elevate 열기",
   },
   ja: {
     preheader: "運用担当者向けの毎日AIシグナル",
     heading: "Elevate デイリーブリーフ",
-    intro: "実務オペレーター向けに厳選したAIアップデートです。",
-    ctaLabel: "Elevate を開く",
   },
   "zh-CN": {
     preheader: "面向运营者的每日 AI 信号",
     heading: "Elevate 每日简报",
-    intro: "为工作流运营者精选的 AI 更新。",
-    ctaLabel: "打开 Elevate",
   },
   "zh-TW": {
     preheader: "給營運者的每日 AI 訊號",
     heading: "Elevate 每日簡報",
-    intro: "為工作流程營運者精選的 AI 更新。",
-    ctaLabel: "開啟 Elevate",
   },
 };
 
@@ -59,6 +51,7 @@ function buildBrandedNewsletterHtml(params: {
   markdownBody: string;
 }): string {
   const t = resolveTemplate(params.locale);
+  const copy = resolveLocaleTemplateConfig(params.locale);
   const body = markdownToHtml(params.markdownBody.trim());
   return `
 <div style="background:#f7f6f3;padding:24px 0;font-family:Inter,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#181512">
@@ -66,13 +59,13 @@ function buildBrandedNewsletterHtml(params: {
     <div style="padding:18px 20px;border-bottom:1px solid #e5e2da;background:#faf9f7">
       <div style="font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:#7b7569">${t.preheader}</div>
       <h1 style="margin:10px 0 0;font-size:20px;line-height:1.35;color:#181512">${t.heading}</h1>
-      <p style="margin:8px 0 0;font-size:13px;line-height:1.6;color:#5f594f">${t.intro}</p>
+      <p style="margin:8px 0 0;font-size:13px;line-height:1.6;color:#5f594f">${copy.intro}</p>
     </div>
     <div style="padding:20px">
       <h2 style="margin:0 0 12px;font-size:18px;line-height:1.4;color:#181512">${params.subject.trim()}</h2>
       <div style="font-size:14px;line-height:1.7;color:#2a261f"><p>${body}</p></div>
       <div style="margin-top:22px">
-        <a href="https://elevate.ai.kr/dashboard" style="display:inline-block;border:1px solid #d7d0c2;background:#fdf8f0;padding:10px 14px;font-size:12px;color:#181512;text-decoration:none">${t.ctaLabel}</a>
+        <a href="${copy.ctaHref}" style="display:inline-block;border:1px solid #d7d0c2;background:#fdf8f0;padding:10px 14px;font-size:12px;color:#181512;text-decoration:none">${copy.ctaLabel}</a>
       </div>
     </div>
   </div>
@@ -84,11 +77,18 @@ export async function sendNewsletterEmail(params: {
   subject: string;
   markdownBody: string;
   locale?: string | null;
-}): Promise<{ ok: true; providerMessageId?: string } | { ok: false; error: string }> {
+}): Promise<
+  | { ok: true; providerMessageId?: string; templateVersion: string }
+  | { ok: false; error: string; templateVersion: string }
+> {
   const apiKey = process.env.RESEND_API_KEY?.trim();
   const from = process.env.RESEND_FROM_EMAIL?.trim();
   if (!apiKey || !from) {
-    return { ok: false, error: "resend_not_configured" };
+    return {
+      ok: false,
+      error: "resend_not_configured",
+      templateVersion: NEWSLETTER_TEMPLATE_VERSION,
+    };
   }
 
   try {
@@ -106,10 +106,22 @@ export async function sendNewsletterEmail(params: {
     });
 
     if (result.error) {
-      return { ok: false, error: result.error.message };
+      return {
+        ok: false,
+        error: result.error.message,
+        templateVersion: NEWSLETTER_TEMPLATE_VERSION,
+      };
     }
-    return { ok: true, providerMessageId: result.data?.id };
+    return {
+      ok: true,
+      providerMessageId: result.data?.id,
+      templateVersion: NEWSLETTER_TEMPLATE_VERSION,
+    };
   } catch (e) {
-    return { ok: false, error: e instanceof Error ? e.message : "unknown" };
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : "unknown",
+      templateVersion: NEWSLETTER_TEMPLATE_VERSION,
+    };
   }
 }

--- a/src/lib/content-ops/pipeline-runner.ts
+++ b/src/lib/content-ops/pipeline-runner.ts
@@ -1,0 +1,428 @@
+import { createHash } from "node:crypto";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { publishContentItemToBlog } from "@/lib/content-ops/blog-publish-adapter";
+import { sendNewsletterEmail } from "@/lib/content-ops/newsletter-send-adapter";
+import type { Database } from "@/types/database.types";
+
+type ContentItemRow = Database["public"]["Tables"]["content_items"]["Row"];
+type ContentSourceRow = Database["public"]["Tables"]["content_sources"]["Row"];
+type SubscriberRow = Database["public"]["Tables"]["newsletter_subscribers"]["Row"];
+
+type FeedEntry = {
+  title: string;
+  link: string;
+  publishedAt: string | null;
+};
+
+type FetchSourceResult =
+  | { ok: true; entries: FeedEntry[]; fetchUrl: string }
+  | { ok: false; entries: []; fetchUrl: string; error: string };
+
+function hashSnippet(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function stripXmlCdata(input: string): string {
+  return input
+    .replaceAll("<![CDATA[", "")
+    .replaceAll("]]>", "")
+    .trim();
+}
+
+function parseRssItems(xml: string, maxItems = 10): FeedEntry[] {
+  const matches = [...xml.matchAll(/<item>([\s\S]*?)<\/item>/g)];
+  const items: FeedEntry[] = [];
+  for (const m of matches.slice(0, maxItems)) {
+    const chunk = m[1];
+    const title = stripXmlCdata(
+      chunk.match(/<title>([\s\S]*?)<\/title>/)?.[1] ?? "Untitled",
+    );
+    const link = stripXmlCdata(
+      chunk.match(/<link>([\s\S]*?)<\/link>/)?.[1] ?? "",
+    );
+    const publishedAtRaw = stripXmlCdata(
+      chunk.match(/<pubDate>([\s\S]*?)<\/pubDate>/)?.[1] ?? "",
+    );
+    if (!link) continue;
+    const publishedAt = publishedAtRaw ? new Date(publishedAtRaw).toISOString() : null;
+    items.push({ title, link, publishedAt });
+  }
+  return items;
+}
+
+async function fetchSourceEntries(source: ContentSourceRow): Promise<FetchSourceResult> {
+  const target =
+    source.kind === "rss" ? source.rss_url?.trim() || source.base_url : source.base_url;
+  if (!target) return { ok: false, entries: [], fetchUrl: "", error: "missing_source_url" };
+
+  try {
+    const res = await fetch(target, {
+      headers: {
+        "user-agent": "ElevateContentOps/1.0 (+https://elevate.ai.kr)",
+      },
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      return {
+        ok: false,
+        entries: [],
+        fetchUrl: target,
+        error: `rss_http_${res.status}`,
+      };
+    }
+    const xml = await res.text();
+    const entries = parseRssItems(xml, 8);
+    if (entries.length === 0) {
+      return {
+        ok: false,
+        entries: [],
+        fetchUrl: target,
+        error: "rss_parse_empty_items",
+      };
+    }
+    return { ok: true, entries, fetchUrl: target };
+  } catch (e) {
+    return {
+      ok: false,
+      entries: [],
+      fetchUrl: target,
+      error: e instanceof Error ? `rss_fetch_error:${e.message}` : "rss_fetch_error",
+    };
+  }
+}
+
+export async function runIngestPipeline(runId: string): Promise<{
+  createdItems: number;
+  scannedSources: number;
+  failedSources: number;
+  failureMessages: string[];
+}> {
+  const admin = createAdminClient();
+  const { data: sources } = await admin
+    .from("content_sources")
+    .select("*")
+    .eq("is_active", true)
+    .order("trust_weight", { ascending: false })
+    .limit(25);
+
+  let createdItems = 0;
+  let scannedSources = 0;
+  let failedSources = 0;
+  const failureMessages: string[] = [];
+  for (const source of (sources ?? []) as ContentSourceRow[]) {
+    scannedSources += 1;
+    const fetchResult = await fetchSourceEntries(source);
+    if (!fetchResult.ok) {
+      failedSources += 1;
+      failureMessages.push(
+        `[${source.name}] ${fetchResult.error}${fetchResult.fetchUrl ? ` (${fetchResult.fetchUrl})` : ""}`,
+      );
+      continue;
+    }
+
+    for (const entry of fetchResult.entries) {
+      const snippetHash = hashSnippet(`${source.id}:${entry.link}:${entry.title}`);
+      const { data: exists } = await admin
+        .from("content_item_source_map")
+        .select("id")
+        .eq("snippet_hash", snippetHash)
+        .limit(1)
+        .maybeSingle();
+      if (exists?.id) continue;
+
+      const { data: created, error: createErr } = await admin
+        .from("content_items")
+        .insert({
+          type: "newsletter",
+          title: entry.title.slice(0, 200),
+          locale: source.locale || "en",
+          summary: `Ingested from ${source.name}`,
+          body_markdown: `- Source: ${source.name}\n- Link: ${entry.link}\n\nDraft note:\n${entry.title}`,
+          source_quality_score: source.trust_weight,
+          status: "draft",
+          metadata: {
+            ingest: {
+              run_id: runId,
+              source_id: source.id,
+            },
+          },
+        })
+        .select("id")
+        .single();
+
+      if (createErr || !created?.id) continue;
+
+      await admin.from("content_item_source_map").insert({
+        content_item_id: created.id,
+        source_id: source.id,
+        source_url: entry.link,
+        source_title: entry.title,
+        source_published_at: entry.publishedAt,
+        snippet_hash: snippetHash,
+      });
+      createdItems += 1;
+    }
+  }
+
+  return {
+    createdItems,
+    scannedSources,
+    failedSources,
+    failureMessages: failureMessages.slice(0, 15),
+  };
+}
+
+export async function runDraftGeneratePipeline(runId: string): Promise<{
+  createdItems: number;
+}> {
+  const admin = createAdminClient();
+  const { data: latestMaps } = await admin
+    .from("content_item_source_map")
+    .select("source_id, source_url, source_title, source_published_at")
+    .order("created_at", { ascending: false })
+    .limit(8);
+
+  if (!latestMaps || latestMaps.length === 0) {
+    return { createdItems: 0 };
+  }
+
+  const digestLines = latestMaps.map((m, index) => {
+    const title = m.source_title?.trim() || "Untitled source";
+    return `${index + 1}. [${title}](${m.source_url})`;
+  });
+
+  const digestBody = [
+    "## Daily AI Digest",
+    "",
+    "Curated updates from active sources:",
+    "",
+    ...digestLines,
+  ].join("\n");
+
+  const digestTitle = `Daily AI Digest — ${new Date().toISOString().slice(0, 10)}`;
+  const { data: newsletterItem, error: nErr } = await admin
+    .from("content_items")
+    .insert({
+      type: "newsletter",
+      title: digestTitle,
+      locale: "en",
+      summary: "Auto-generated digest draft from recent source ingest.",
+      body_markdown: digestBody,
+      status: "draft",
+      metadata: {
+        generate: {
+          run_id: runId,
+          mode: "digest",
+        },
+      },
+    })
+    .select("id")
+    .single();
+
+  if (nErr || !newsletterItem?.id) return { createdItems: 0 };
+
+  for (const map of latestMaps) {
+    await admin.from("content_item_source_map").insert({
+      content_item_id: newsletterItem.id,
+      source_id: map.source_id,
+      source_url: map.source_url,
+      source_title: map.source_title,
+      source_published_at: map.source_published_at,
+      snippet_hash: hashSnippet(
+        `generated:${newsletterItem.id}:${map.source_id}:${map.source_url}`,
+      ),
+    });
+  }
+
+  return { createdItems: 1 };
+}
+
+async function publishNewsletterItem(item: ContentItemRow): Promise<{
+  ok: boolean;
+  sentCount: number;
+  failedCount: number;
+  failedReasons: string[];
+}> {
+  const admin = createAdminClient();
+  const { data: subscribers } = await admin
+    .from("newsletter_subscribers")
+    .select("*")
+    .eq("status", "subscribed")
+    .order("created_at", { ascending: false })
+    .limit(200);
+
+  let sentCount = 0;
+  let failedCount = 0;
+  const failedReasons: string[] = [];
+  if (!subscribers || subscribers.length === 0) {
+    await admin.from("content_publications").insert({
+      content_item_id: item.id,
+      channel: "email",
+      status: "failed",
+      provider: "resend",
+      attempt_count: 0,
+      last_error: "newsletter_no_subscribers",
+      processed_at: new Date().toISOString(),
+    });
+    return {
+      ok: false,
+      sentCount,
+      failedCount: 1,
+      failedReasons: ["newsletter_no_subscribers"],
+    };
+  }
+
+  for (const subscriber of (subscribers ?? []) as SubscriberRow[]) {
+    const send = await sendNewsletterEmail({
+      to: subscriber.email,
+      subject: item.title,
+      markdownBody: item.body_markdown,
+      locale: subscriber.locale,
+    });
+    if (send.ok) {
+      sentCount += 1;
+    } else {
+      failedCount += 1;
+      failedReasons.push(send.error);
+    }
+  }
+
+  const publicationStatus = failedCount > 0 ? "failed" : "sent";
+  await admin.from("content_publications").insert({
+    content_item_id: item.id,
+    channel: "email",
+    status: publicationStatus,
+    provider: "resend",
+    attempt_count: sentCount + failedCount,
+    last_error:
+      failedCount > 0
+        ? `newsletter_send_failed:${Array.from(new Set(failedReasons)).slice(0, 3).join("|")}`
+        : null,
+    processed_at: new Date().toISOString(),
+    metadata: {
+      sent_count: sentCount,
+      failed_count: failedCount,
+      failed_reasons: Array.from(new Set(failedReasons)).slice(0, 10),
+    },
+  });
+
+  return {
+    ok: failedCount === 0,
+    sentCount,
+    failedCount,
+    failedReasons: Array.from(new Set(failedReasons)),
+  };
+}
+
+async function publishBlogItem(item: ContentItemRow): Promise<{
+  ok: boolean;
+  error?: string;
+}> {
+  const admin = createAdminClient();
+  const published = await publishContentItemToBlog({
+    locale: item.locale,
+    slug: item.slug,
+    title: item.title,
+    summary: item.summary,
+    bodyMarkdown: item.body_markdown,
+  });
+  if (!published.ok) {
+    await admin.from("content_publications").insert({
+      content_item_id: item.id,
+      channel: "blog",
+      status: "failed",
+      provider: "internal",
+      attempt_count: 1,
+      last_error: published.error,
+      processed_at: new Date().toISOString(),
+    });
+    return { ok: false, error: published.error };
+  }
+
+  await admin.from("content_items").update({ slug: published.slug }).eq("id", item.id);
+  await admin.from("content_publications").insert({
+    content_item_id: item.id,
+    channel: "blog",
+    status: "published",
+    provider: "internal",
+    attempt_count: 1,
+    processed_at: new Date().toISOString(),
+    metadata: { file_path: published.filePath },
+  });
+  return { ok: true };
+}
+
+export async function runPublishPipeline(params?: {
+  contentItemId?: string;
+}): Promise<{
+  processedCount: number;
+  failedCount: number;
+  failureMessages: string[];
+}> {
+  const admin = createAdminClient();
+  let query = admin
+    .from("content_items")
+    .select("*")
+    .in("status", ["approved", "scheduled", "publishing"])
+    .order("updated_at", { ascending: true })
+    .limit(50);
+
+  if (params?.contentItemId) {
+    query = query.eq("id", params.contentItemId);
+  }
+
+  const { data: items } = await query;
+  let processedCount = 0;
+  let failedCount = 0;
+  const failureMessages: string[] = [];
+  const now = Date.now();
+
+  for (const item of (items ?? []) as ContentItemRow[]) {
+    if (
+      !params?.contentItemId &&
+      item.status === "scheduled" &&
+      (!item.scheduled_at || new Date(item.scheduled_at).getTime() > now)
+    ) {
+      continue;
+    }
+
+    await admin
+      .from("content_items")
+      .update({ status: "publishing", updated_at: new Date().toISOString() })
+      .eq("id", item.id);
+
+    const blogResult = item.type === "blog" ? await publishBlogItem(item) : null;
+    const newsletterResult =
+      item.type === "newsletter" ? await publishNewsletterItem(item) : null;
+
+    const success = (blogResult?.ok ?? true) && (newsletterResult?.ok ?? true);
+    if (!success) {
+      if (blogResult && !blogResult.ok) {
+        failureMessages.push(`[blog:${item.id}] ${blogResult.error ?? "publish_failed"}`);
+      }
+      if (newsletterResult && !newsletterResult.ok) {
+        failureMessages.push(
+          `[newsletter:${item.id}] ${newsletterResult.failedReasons.slice(0, 3).join("|") || "send_failed"}`,
+        );
+      }
+    }
+
+    await admin
+      .from("content_items")
+      .update({
+        status: success ? "published" : "send_failed",
+        published_at: success ? new Date().toISOString() : item.published_at,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", item.id);
+
+    processedCount += 1;
+    if (!success) failedCount += 1;
+  }
+
+  return {
+    processedCount,
+    failedCount,
+    failureMessages: failureMessages.slice(0, 20),
+  };
+}

--- a/src/lib/content-ops/pipeline-runner.ts
+++ b/src/lib/content-ops/pipeline-runner.ts
@@ -2,6 +2,11 @@ import { createHash } from "node:crypto";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { publishContentItemToBlog } from "@/lib/content-ops/blog-publish-adapter";
 import { sendNewsletterEmail } from "@/lib/content-ops/newsletter-send-adapter";
+import {
+  BLOG_TEMPLATE_VERSION,
+  NEWSLETTER_TEMPLATE_VERSION,
+} from "@/lib/content-ops/locale-template-config";
+import { evaluateReviewGate } from "@/lib/content-ops/review-gate";
 import type { Database } from "@/types/database.types";
 
 type ContentItemRow = Database["public"]["Tables"]["content_items"]["Row"];
@@ -14,12 +19,121 @@ type FeedEntry = {
   publishedAt: string | null;
 };
 
+const MAX_PUBLICATION_ATTEMPTS = 3;
+const RETRY_DELAY_MINUTES = 30;
+
 type FetchSourceResult =
   | { ok: true; entries: FeedEntry[]; fetchUrl: string }
   | { ok: false; entries: []; fetchUrl: string; error: string };
 
+type PublicationChannel = "email" | "blog";
+
+type RetryState = {
+  previousAttemptCount: number;
+  nextRetryAt: string | null;
+};
+
+type PublicationAttempt = {
+  attemptCount: number;
+  shouldSkip: boolean;
+  nextRetryAt: string | null;
+};
+
 function hashSnippet(input: string): string {
   return createHash("sha256").update(input).digest("hex");
+}
+
+function classifyFailureReason(reason: string): string {
+  const normalized = reason.trim();
+  if (!normalized) return "publish_failed";
+  if (normalized === "resend_not_configured") return normalized;
+  if (normalized === "newsletter_no_subscribers") return normalized;
+  if (normalized.startsWith("rss_fetch_error:")) return normalized;
+  if (normalized.startsWith("rss_http_") || normalized === "rss_parse_empty_items") {
+    return `rss_fetch_error:${normalized}`;
+  }
+  return normalized;
+}
+
+function dedupeReasons(reasons: string[]): string[] {
+  return Array.from(new Set(reasons.map((reason) => classifyFailureReason(reason))));
+}
+
+function addMinutesIso(date: Date, minutes: number): string {
+  return new Date(date.getTime() + minutes * 60 * 1000).toISOString();
+}
+
+function parseNextRetryAt(metadata: unknown): string | null {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return null;
+  const retry = (metadata as Record<string, unknown>).retry;
+  if (!retry || typeof retry !== "object" || Array.isArray(retry)) return null;
+  const nextRetryAt = (retry as Record<string, unknown>).next_retry_at;
+  return typeof nextRetryAt === "string" && nextRetryAt.trim() ? nextRetryAt : null;
+}
+
+async function getRetryState(
+  contentItemId: string,
+  channel: PublicationChannel,
+): Promise<RetryState> {
+  const admin = createAdminClient();
+  const { data: latest } = await admin
+    .from("content_publications")
+    .select("attempt_count, metadata")
+    .eq("content_item_id", contentItemId)
+    .eq("channel", channel)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  return {
+    previousAttemptCount:
+      typeof latest?.attempt_count === "number" && Number.isFinite(latest.attempt_count)
+        ? latest.attempt_count
+        : 0,
+    nextRetryAt: parseNextRetryAt(latest?.metadata),
+  };
+}
+
+function computePublicationAttempt(
+  retryState: RetryState,
+  nowIso: string,
+  retryFailedOnly: boolean,
+): PublicationAttempt {
+  const nextAttempt = retryState.previousAttemptCount + 1;
+  const retryWindowOpen =
+    !retryState.nextRetryAt || new Date(retryState.nextRetryAt).getTime() <= Date.parse(nowIso);
+
+  if (retryFailedOnly && !retryWindowOpen) {
+    return {
+      attemptCount: retryState.previousAttemptCount,
+      shouldSkip: true,
+      nextRetryAt: retryState.nextRetryAt,
+    };
+  }
+  if (retryState.previousAttemptCount >= MAX_PUBLICATION_ATTEMPTS) {
+    return {
+      attemptCount: retryState.previousAttemptCount,
+      shouldSkip: true,
+      nextRetryAt: retryState.nextRetryAt,
+    };
+  }
+  return { attemptCount: nextAttempt, shouldSkip: false, nextRetryAt: null };
+}
+
+function buildRetryMetadata(params: {
+  attemptCount: number;
+  nowIso: string;
+  maxAttempts?: number;
+}): { max_attempts: number; next_retry_at: string | null } {
+  const maxAttempts = params.maxAttempts ?? MAX_PUBLICATION_ATTEMPTS;
+  const nextRetryAt =
+    params.attemptCount < maxAttempts
+      ? addMinutesIso(new Date(params.nowIso), RETRY_DELAY_MINUTES)
+      : null;
+  return {
+    max_attempts: maxAttempts,
+    next_retry_at: nextRetryAt,
+  };
 }
 
 function stripXmlCdata(input: string): string {
@@ -237,13 +351,112 @@ export async function runDraftGeneratePipeline(runId: string): Promise<{
   return { createdItems: 1 };
 }
 
+export async function runReviewGatePipeline(runId: string): Promise<{
+  scannedCount: number;
+  failedCount: number;
+  passedCount: number;
+  failureMessages: string[];
+}> {
+  const admin = createAdminClient();
+  const { data: candidates } = await admin
+    .from("content_items")
+    .select("id, title, body_markdown, status, metadata, updated_at")
+    .in("status", ["draft", "review_required"])
+    .order("updated_at", { ascending: false })
+    .limit(200);
+
+  let scannedCount = 0;
+  let failedCount = 0;
+  let passedCount = 0;
+  const failureMessages: string[] = [];
+
+  for (const item of candidates ?? []) {
+    scannedCount += 1;
+    const { count: sourceLinkCount } = await admin
+      .from("content_item_source_map")
+      .select("id", { count: "exact", head: true })
+      .eq("content_item_id", item.id);
+
+    const gate = evaluateReviewGate({
+      bodyMarkdown: item.body_markdown ?? "",
+      sourceLinkCount: sourceLinkCount ?? 0,
+    });
+
+    const nextMetadata = {
+      ...((item.metadata ?? {}) as Record<string, unknown>),
+      review_gate: {
+        latest: {
+          run_id: runId,
+          checked_at: new Date().toISOString(),
+          passed: gate.passed,
+          reasons: gate.reasons,
+          metrics: gate.metrics,
+        },
+      },
+    };
+
+    if (!gate.passed) {
+      failedCount += 1;
+      failureMessages.push(
+        `[${item.id}] ${gate.reasons.join("|") || "review_gate_failed"} (${item.title})`,
+      );
+      await admin
+        .from("content_items")
+        .update({
+          status: "review_required",
+          review_notes: `review_gate:${gate.reasons.join(",")}`,
+          metadata: nextMetadata,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", item.id);
+      continue;
+    }
+
+    passedCount += 1;
+    await admin
+      .from("content_items")
+      .update({
+        metadata: nextMetadata,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", item.id);
+  }
+
+  return {
+    scannedCount,
+    failedCount,
+    passedCount,
+    failureMessages: failureMessages.slice(0, 20),
+  };
+}
+
 async function publishNewsletterItem(item: ContentItemRow): Promise<{
   ok: boolean;
   sentCount: number;
   failedCount: number;
   failedReasons: string[];
+  attemptCount: number;
+  skipped: boolean;
 }> {
   const admin = createAdminClient();
+  const nowIso = new Date().toISOString();
+  const retryState = await getRetryState(item.id, "email");
+  const attempt = computePublicationAttempt(
+    retryState,
+    nowIso,
+    item.status === "send_failed",
+  );
+  if (attempt.shouldSkip) {
+    return {
+      ok: false,
+      sentCount: 0,
+      failedCount: 0,
+      failedReasons: ["retry_exhausted"],
+      attemptCount: attempt.attemptCount,
+      skipped: true,
+    };
+  }
+
   const { data: subscribers } = await admin
     .from("newsletter_subscribers")
     .select("*")
@@ -255,20 +468,31 @@ async function publishNewsletterItem(item: ContentItemRow): Promise<{
   let failedCount = 0;
   const failedReasons: string[] = [];
   if (!subscribers || subscribers.length === 0) {
+    const classified = "newsletter_no_subscribers";
+    const retry = buildRetryMetadata({ attemptCount: attempt.attemptCount, nowIso });
     await admin.from("content_publications").insert({
       content_item_id: item.id,
       channel: "email",
       status: "failed",
       provider: "resend",
-      attempt_count: 0,
-      last_error: "newsletter_no_subscribers",
-      processed_at: new Date().toISOString(),
+      attempt_count: attempt.attemptCount,
+      last_error: classified,
+      processed_at: nowIso,
+      metadata: {
+        sent_count: 0,
+        failed_count: 1,
+        failed_reasons: [classified],
+        template_version: NEWSLETTER_TEMPLATE_VERSION,
+        retry,
+      },
     });
     return {
       ok: false,
       sentCount,
       failedCount: 1,
-      failedReasons: ["newsletter_no_subscribers"],
+      failedReasons: [classified],
+      attemptCount: attempt.attemptCount,
+      skipped: false,
     };
   }
 
@@ -282,27 +506,39 @@ async function publishNewsletterItem(item: ContentItemRow): Promise<{
     if (send.ok) {
       sentCount += 1;
     } else {
+      const classified = classifyFailureReason(send.error);
       failedCount += 1;
-      failedReasons.push(send.error);
+      failedReasons.push(classified);
+      if (classified === "resend_not_configured") {
+        failedCount += subscribers.length - sentCount - failedCount;
+        break;
+      }
     }
   }
 
+  const dedupedReasons = dedupeReasons(failedReasons);
   const publicationStatus = failedCount > 0 ? "failed" : "sent";
+  const retry =
+    failedCount > 0
+      ? buildRetryMetadata({ attemptCount: attempt.attemptCount, nowIso })
+      : { max_attempts: MAX_PUBLICATION_ATTEMPTS, next_retry_at: null };
   await admin.from("content_publications").insert({
     content_item_id: item.id,
     channel: "email",
     status: publicationStatus,
     provider: "resend",
-    attempt_count: sentCount + failedCount,
+    attempt_count: attempt.attemptCount,
     last_error:
       failedCount > 0
-        ? `newsletter_send_failed:${Array.from(new Set(failedReasons)).slice(0, 3).join("|")}`
+        ? `newsletter_send_failed:${dedupedReasons.slice(0, 3).join("|")}`
         : null,
-    processed_at: new Date().toISOString(),
+    processed_at: nowIso,
     metadata: {
       sent_count: sentCount,
       failed_count: failedCount,
-      failed_reasons: Array.from(new Set(failedReasons)).slice(0, 10),
+      failed_reasons: dedupedReasons.slice(0, 10),
+      template_version: NEWSLETTER_TEMPLATE_VERSION,
+      retry,
     },
   });
 
@@ -310,15 +546,30 @@ async function publishNewsletterItem(item: ContentItemRow): Promise<{
     ok: failedCount === 0,
     sentCount,
     failedCount,
-    failedReasons: Array.from(new Set(failedReasons)),
+    failedReasons: dedupedReasons,
+    attemptCount: attempt.attemptCount,
+    skipped: false,
   };
 }
 
 async function publishBlogItem(item: ContentItemRow): Promise<{
   ok: boolean;
   error?: string;
+  attemptCount: number;
+  skipped: boolean;
 }> {
   const admin = createAdminClient();
+  const nowIso = new Date().toISOString();
+  const retryState = await getRetryState(item.id, "blog");
+  const attempt = computePublicationAttempt(
+    retryState,
+    nowIso,
+    item.status === "send_failed",
+  );
+  if (attempt.shouldSkip) {
+    return { ok: false, error: "retry_exhausted", attemptCount: attempt.attemptCount, skipped: true };
+  }
+
   const published = await publishContentItemToBlog({
     locale: item.locale,
     slug: item.slug,
@@ -327,16 +578,23 @@ async function publishBlogItem(item: ContentItemRow): Promise<{
     bodyMarkdown: item.body_markdown,
   });
   if (!published.ok) {
+    const classified = classifyFailureReason(published.error);
+    const retry = buildRetryMetadata({ attemptCount: attempt.attemptCount, nowIso });
     await admin.from("content_publications").insert({
       content_item_id: item.id,
       channel: "blog",
       status: "failed",
       provider: "internal",
-      attempt_count: 1,
-      last_error: published.error,
-      processed_at: new Date().toISOString(),
+      attempt_count: attempt.attemptCount,
+      last_error: classified,
+      processed_at: nowIso,
+      metadata: {
+        retry,
+        failed_reasons: [classified],
+        template_version: BLOG_TEMPLATE_VERSION,
+      },
     });
-    return { ok: false, error: published.error };
+    return { ok: false, error: classified, attemptCount: attempt.attemptCount, skipped: false };
   }
 
   await admin.from("content_items").update({ slug: published.slug }).eq("id", item.id);
@@ -345,25 +603,36 @@ async function publishBlogItem(item: ContentItemRow): Promise<{
     channel: "blog",
     status: "published",
     provider: "internal",
-    attempt_count: 1,
-    processed_at: new Date().toISOString(),
-    metadata: { file_path: published.filePath },
+    attempt_count: attempt.attemptCount,
+    processed_at: nowIso,
+    metadata: {
+      file_path: published.filePath,
+      template_version: BLOG_TEMPLATE_VERSION,
+      retry: { max_attempts: MAX_PUBLICATION_ATTEMPTS, next_retry_at: null },
+    },
   });
-  return { ok: true };
+  return { ok: true, attemptCount: attempt.attemptCount, skipped: false };
 }
 
 export async function runPublishPipeline(params?: {
   contentItemId?: string;
+  retryFailedOnly?: boolean;
 }): Promise<{
   processedCount: number;
   failedCount: number;
+  sentCount: number;
   failureMessages: string[];
 }> {
   const admin = createAdminClient();
   let query = admin
     .from("content_items")
     .select("*")
-    .in("status", ["approved", "scheduled", "publishing"])
+    .in(
+      "status",
+      params?.retryFailedOnly
+        ? ["send_failed", "publishing"]
+        : ["approved", "scheduled", "publishing"],
+    )
     .order("updated_at", { ascending: true })
     .limit(50);
 
@@ -374,6 +643,7 @@ export async function runPublishPipeline(params?: {
   const { data: items } = await query;
   let processedCount = 0;
   let failedCount = 0;
+  let sentCount = 0;
   const failureMessages: string[] = [];
   const now = Date.now();
 
@@ -395,14 +665,30 @@ export async function runPublishPipeline(params?: {
     const newsletterResult =
       item.type === "newsletter" ? await publishNewsletterItem(item) : null;
 
+    if (blogResult?.skipped || newsletterResult?.skipped) {
+      const skipReason = blogResult?.error ?? newsletterResult?.failedReasons[0] ?? "retry_exhausted";
+      failureMessages.push(`[${item.type}:${item.id}] ${skipReason}`);
+      await admin
+        .from("content_items")
+        .update({ status: "send_failed", updated_at: new Date().toISOString() })
+        .eq("id", item.id);
+      processedCount += 1;
+      failedCount += 1;
+      continue;
+    }
+
     const success = (blogResult?.ok ?? true) && (newsletterResult?.ok ?? true);
+    if (newsletterResult?.ok) {
+      sentCount += newsletterResult.sentCount;
+    }
     if (!success) {
       if (blogResult && !blogResult.ok) {
-        failureMessages.push(`[blog:${item.id}] ${blogResult.error ?? "publish_failed"}`);
+        failureMessages.push(`[blog:${item.id}] ${classifyFailureReason(blogResult.error ?? "publish_failed")}`);
       }
       if (newsletterResult && !newsletterResult.ok) {
+        const classified = dedupeReasons(newsletterResult.failedReasons);
         failureMessages.push(
-          `[newsletter:${item.id}] ${newsletterResult.failedReasons.slice(0, 3).join("|") || "send_failed"}`,
+          `[newsletter:${item.id}] ${classified.slice(0, 3).join("|") || "send_failed"}`,
         );
       }
     }
@@ -423,6 +709,7 @@ export async function runPublishPipeline(params?: {
   return {
     processedCount,
     failedCount,
+    sentCount,
     failureMessages: failureMessages.slice(0, 20),
   };
 }

--- a/src/lib/content-ops/review-gate.ts
+++ b/src/lib/content-ops/review-gate.ts
@@ -1,0 +1,84 @@
+export const MIN_REVIEW_BODY_CHARS = 320;
+
+export type ReviewGateInput = {
+  bodyMarkdown: string;
+  sourceLinkCount: number;
+};
+
+export type ReviewGateReason =
+  | "source_links_missing"
+  | "body_too_short"
+  | "possible_overcopy_detected";
+
+export type ReviewGateResult = {
+  passed: boolean;
+  reasons: ReviewGateReason[];
+  metrics: {
+    bodyChars: number;
+    sourceLinkCount: number;
+    longLineCount: number;
+    codeFenceLargeBlockDetected: boolean;
+    linkOnlyPatternDetected: boolean;
+  };
+};
+
+function toPlainText(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/!\[[^\]]*]\([^)]+\)/g, " ")
+    .replace(/\[[^\]]*]\([^)]+\)/g, " ")
+    .replace(/[#>*_\-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function countLongLines(markdown: string): number {
+  return markdown
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length >= 180).length;
+}
+
+function hasLargeCodeFenceBlock(markdown: string): boolean {
+  return /```[\s\S]{1200,}?```/m.test(markdown);
+}
+
+function detectLinkOnlyPattern(markdown: string, sourceLinkCount: number): boolean {
+  const linkCount = (markdown.match(/\[[^\]]+]\([^)]+\)/g) ?? []).length;
+  const plainTextChars = toPlainText(markdown).length;
+  return sourceLinkCount > 0 && linkCount >= sourceLinkCount && plainTextChars < 200;
+}
+
+export function evaluateReviewGate(input: ReviewGateInput): ReviewGateResult {
+  const reasons: ReviewGateReason[] = [];
+  const bodyChars = toPlainText(input.bodyMarkdown).length;
+  const longLineCount = countLongLines(input.bodyMarkdown);
+  const codeFenceLargeBlockDetected = hasLargeCodeFenceBlock(input.bodyMarkdown);
+  const linkOnlyPatternDetected = detectLinkOnlyPattern(
+    input.bodyMarkdown,
+    input.sourceLinkCount,
+  );
+
+  if (input.sourceLinkCount < 1) {
+    reasons.push("source_links_missing");
+  }
+  if (bodyChars < MIN_REVIEW_BODY_CHARS) {
+    reasons.push("body_too_short");
+  }
+  if (codeFenceLargeBlockDetected || longLineCount >= 4 || linkOnlyPatternDetected) {
+    reasons.push("possible_overcopy_detected");
+  }
+
+  return {
+    passed: reasons.length === 0,
+    reasons,
+    metrics: {
+      bodyChars,
+      sourceLinkCount: input.sourceLinkCount,
+      longLineCount,
+      codeFenceLargeBlockDetected,
+      linkOnlyPatternDetected,
+    },
+  };
+}

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -184,6 +184,163 @@ export type Database = {
           },
         ]
       }
+      content_item_source_map: {
+        Row: {
+          content_item_id: string
+          created_at: string
+          excerpt: string | null
+          id: string
+          metadata: Json
+          snippet_hash: string
+          source_id: string
+          source_published_at: string | null
+          source_title: string | null
+          source_url: string
+        }
+        Insert: {
+          content_item_id: string
+          created_at?: string
+          excerpt?: string | null
+          id?: string
+          metadata?: Json
+          snippet_hash: string
+          source_id: string
+          source_published_at?: string | null
+          source_title?: string | null
+          source_url: string
+        }
+        Update: {
+          content_item_id?: string
+          created_at?: string
+          excerpt?: string | null
+          id?: string
+          metadata?: Json
+          snippet_hash?: string
+          source_id?: string
+          source_published_at?: string | null
+          source_title?: string | null
+          source_url?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "content_item_source_map_content_item_id_fkey"
+            columns: ["content_item_id"]
+            isOneToOne: false
+            referencedRelation: "content_items"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "content_item_source_map_source_id_fkey"
+            columns: ["source_id"]
+            isOneToOne: false
+            referencedRelation: "content_sources"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      content_items: {
+        Row: {
+          approved_at: string | null
+          approved_by: string | null
+          body_markdown: string
+          created_at: string
+          created_by: string | null
+          cta_variant: string | null
+          fact_check_score: number | null
+          generation_model: string | null
+          generation_prompt_version: string | null
+          id: string
+          locale: string
+          metadata: Json
+          published_at: string | null
+          review_notes: string | null
+          reviewed_at: string | null
+          reviewed_by: string | null
+          scheduled_at: string | null
+          slug: string | null
+          source_quality_score: number | null
+          status: string
+          summary: string | null
+          title: string
+          type: string
+          updated_at: string
+        }
+        Insert: {
+          approved_at?: string | null
+          approved_by?: string | null
+          body_markdown?: string
+          created_at?: string
+          created_by?: string | null
+          cta_variant?: string | null
+          fact_check_score?: number | null
+          generation_model?: string | null
+          generation_prompt_version?: string | null
+          id?: string
+          locale?: string
+          metadata?: Json
+          published_at?: string | null
+          review_notes?: string | null
+          reviewed_at?: string | null
+          reviewed_by?: string | null
+          scheduled_at?: string | null
+          slug?: string | null
+          source_quality_score?: number | null
+          status?: string
+          summary?: string | null
+          title: string
+          type: string
+          updated_at?: string
+        }
+        Update: {
+          approved_at?: string | null
+          approved_by?: string | null
+          body_markdown?: string
+          created_at?: string
+          created_by?: string | null
+          cta_variant?: string | null
+          fact_check_score?: number | null
+          generation_model?: string | null
+          generation_prompt_version?: string | null
+          id?: string
+          locale?: string
+          metadata?: Json
+          published_at?: string | null
+          review_notes?: string | null
+          reviewed_at?: string | null
+          reviewed_by?: string | null
+          scheduled_at?: string | null
+          slug?: string | null
+          source_quality_score?: number | null
+          status?: string
+          summary?: string | null
+          title?: string
+          type?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "content_items_approved_by_fkey"
+            columns: ["approved_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "content_items_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "content_items_reviewed_by_fkey"
+            columns: ["reviewed_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       content_product_lemon_links: {
         Row: {
           content_product_id: string
@@ -258,6 +415,160 @@ export type Database = {
           slug?: string
           storage_object_path?: string | null
           title?: string
+        }
+        Relationships: []
+      }
+      content_publications: {
+        Row: {
+          attempt_count: number
+          channel: string
+          content_item_id: string
+          created_at: string
+          id: string
+          last_error: string | null
+          metadata: Json
+          processed_at: string | null
+          provider: string
+          provider_message_id: string | null
+          scheduled_at: string | null
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          attempt_count?: number
+          channel: string
+          content_item_id: string
+          created_at?: string
+          id?: string
+          last_error?: string | null
+          metadata?: Json
+          processed_at?: string | null
+          provider?: string
+          provider_message_id?: string | null
+          scheduled_at?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          attempt_count?: number
+          channel?: string
+          content_item_id?: string
+          created_at?: string
+          id?: string
+          last_error?: string | null
+          metadata?: Json
+          processed_at?: string | null
+          provider?: string
+          provider_message_id?: string | null
+          scheduled_at?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "content_publications_content_item_id_fkey"
+            columns: ["content_item_id"]
+            isOneToOne: false
+            referencedRelation: "content_items"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      content_runs: {
+        Row: {
+          created_at: string
+          ended_at: string | null
+          error_details: Json | null
+          error_summary: string | null
+          id: string
+          initiated_by: string | null
+          metadata: Json
+          run_type: string
+          started_at: string | null
+          status: string
+          trigger_type: string
+        }
+        Insert: {
+          created_at?: string
+          ended_at?: string | null
+          error_details?: Json | null
+          error_summary?: string | null
+          id?: string
+          initiated_by?: string | null
+          metadata?: Json
+          run_type: string
+          started_at?: string | null
+          status?: string
+          trigger_type?: string
+        }
+        Update: {
+          created_at?: string
+          ended_at?: string | null
+          error_details?: Json | null
+          error_summary?: string | null
+          id?: string
+          initiated_by?: string | null
+          metadata?: Json
+          run_type?: string
+          started_at?: string | null
+          status?: string
+          trigger_type?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "content_runs_initiated_by_fkey"
+            columns: ["initiated_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      content_sources: {
+        Row: {
+          base_url: string
+          created_at: string
+          fetch_interval_minutes: number
+          id: string
+          is_active: boolean
+          kind: string
+          locale: string | null
+          metadata: Json
+          name: string
+          rss_url: string | null
+          topic_tags: string[]
+          trust_weight: number
+          updated_at: string
+        }
+        Insert: {
+          base_url: string
+          created_at?: string
+          fetch_interval_minutes?: number
+          id?: string
+          is_active?: boolean
+          kind: string
+          locale?: string | null
+          metadata?: Json
+          name: string
+          rss_url?: string | null
+          topic_tags?: string[]
+          trust_weight?: number
+          updated_at?: string
+        }
+        Update: {
+          base_url?: string
+          created_at?: string
+          fetch_interval_minutes?: number
+          id?: string
+          is_active?: boolean
+          kind?: string
+          locale?: string | null
+          metadata?: Json
+          name?: string
+          rss_url?: string | null
+          topic_tags?: string[]
+          trust_weight?: number
+          updated_at?: string
         }
         Relationships: []
       }
@@ -399,6 +710,57 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      newsletter_subscribers: {
+        Row: {
+          consent_at: string | null
+          created_at: string
+          email: string
+          email_normalized: string | null
+          frequency_pref: string
+          id: string
+          locale: string
+          metadata: Json
+          source: string
+          source_ref: string | null
+          status: string
+          tags: string[]
+          unsubscribe_at: string | null
+          updated_at: string
+        }
+        Insert: {
+          consent_at?: string | null
+          created_at?: string
+          email: string
+          email_normalized?: string | null
+          frequency_pref?: string
+          id?: string
+          locale?: string
+          metadata?: Json
+          source?: string
+          source_ref?: string | null
+          status?: string
+          tags?: string[]
+          unsubscribe_at?: string | null
+          updated_at?: string
+        }
+        Update: {
+          consent_at?: string | null
+          created_at?: string
+          email?: string
+          email_normalized?: string | null
+          frequency_pref?: string
+          id?: string
+          locale?: string
+          metadata?: Json
+          source?: string
+          source_ref?: string | null
+          status?: string
+          tags?: string[]
+          unsubscribe_at?: string | null
+          updated_at?: string
+        }
+        Relationships: []
       }
       organization_content_entitlements: {
         Row: {
@@ -545,9 +907,9 @@ export type Database = {
           email_milestone_digest: boolean
           id: string
           loading_spinner_tempo: string
-          sidebar_icon_tone: string
           organization_id: string | null
           role: Database["public"]["Enums"]["user_role"]
+          sidebar_icon_tone: string
           ui_locale: string | null
           updated_at: string
         }
@@ -560,9 +922,9 @@ export type Database = {
           email_milestone_digest?: boolean
           id: string
           loading_spinner_tempo?: string
-          sidebar_icon_tone?: string
           organization_id?: string | null
           role?: Database["public"]["Enums"]["user_role"]
+          sidebar_icon_tone?: string
           ui_locale?: string | null
           updated_at?: string
         }
@@ -575,9 +937,9 @@ export type Database = {
           email_milestone_digest?: boolean
           id?: string
           loading_spinner_tempo?: string
-          sidebar_icon_tone?: string
           organization_id?: string | null
           role?: Database["public"]["Enums"]["user_role"]
+          sidebar_icon_tone?: string
           ui_locale?: string | null
           updated_at?: string
         }
@@ -1264,8 +1626,8 @@ export type Database = {
           notes?: string
           organization_id?: string
           pipeline_prefs?: Json
-          publish_url?: string | null
           project_id?: string | null
+          publish_url?: string | null
           status?: string
           studio_distribution_channel_id?: string | null
           studio_format_template_id?: string | null
@@ -1428,6 +1790,13 @@ export type Database = {
         }
         Relationships: [
           {
+            foreignKeyName: "studio_scheduled_posts_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "studio_scheduled_posts_episode_id_fkey"
             columns: ["episode_id"]
             isOneToOne: false
@@ -1589,89 +1958,6 @@ export type Database = {
           },
         ]
       }
-      user_blog_subscription_webhook_events: {
-        Row: {
-          event_id: string
-          event_name: string
-          lemon_squeezy_subscription_id: string | null
-          payment_provider: string | null
-          payment_subscription_id: string | null
-          payload: Json
-          processed_at: string
-        }
-        Insert: {
-          event_id: string
-          event_name: string
-          lemon_squeezy_subscription_id?: string | null
-          payment_provider?: string | null
-          payment_subscription_id?: string | null
-          payload?: Json
-          processed_at?: string
-        }
-        Update: {
-          event_id?: string
-          event_name?: string
-          lemon_squeezy_subscription_id?: string | null
-          payment_provider?: string | null
-          payment_subscription_id?: string | null
-          payload?: Json
-          processed_at?: string
-        }
-        Relationships: []
-      }
-      user_blog_subscriptions: {
-        Row: {
-          created_at: string
-          current_period_end: string | null
-          lemon_squeezy_subscription_id: string | null
-          lemon_squeezy_variant_id: number | null
-          manage_subscription_url: string | null
-          payment_product_id: string | null
-          payment_provider: string | null
-          payment_subscription_id: string | null
-          subscription_status: Database["public"]["Enums"]["blog_subscription_status"] | null
-          subscription_tier: Database["public"]["Enums"]["blog_subscription_tier"]
-          updated_at: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          current_period_end?: string | null
-          lemon_squeezy_subscription_id?: string | null
-          lemon_squeezy_variant_id?: number | null
-          manage_subscription_url?: string | null
-          payment_product_id?: string | null
-          payment_provider?: string | null
-          payment_subscription_id?: string | null
-          subscription_status?: Database["public"]["Enums"]["blog_subscription_status"] | null
-          subscription_tier?: Database["public"]["Enums"]["blog_subscription_tier"]
-          updated_at?: string
-          user_id: string
-        }
-        Update: {
-          created_at?: string
-          current_period_end?: string | null
-          lemon_squeezy_subscription_id?: string | null
-          lemon_squeezy_variant_id?: number | null
-          manage_subscription_url?: string | null
-          payment_product_id?: string | null
-          payment_provider?: string | null
-          payment_subscription_id?: string | null
-          subscription_status?: Database["public"]["Enums"]["blog_subscription_status"] | null
-          subscription_tier?: Database["public"]["Enums"]["blog_subscription_tier"]
-          updated_at?: string
-          user_id?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "user_blog_subscriptions_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: true
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       toss_payment_intents: {
         Row: {
           amount_krw: number
@@ -1735,6 +2021,95 @@ export type Database = {
             columns: ["organization_id"]
             isOneToOne: false
             referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_blog_subscription_webhook_events: {
+        Row: {
+          event_id: string
+          event_name: string
+          lemon_squeezy_subscription_id: string | null
+          payload: Json
+          payment_provider: string | null
+          payment_subscription_id: string | null
+          processed_at: string
+        }
+        Insert: {
+          event_id: string
+          event_name: string
+          lemon_squeezy_subscription_id?: string | null
+          payload?: Json
+          payment_provider?: string | null
+          payment_subscription_id?: string | null
+          processed_at?: string
+        }
+        Update: {
+          event_id?: string
+          event_name?: string
+          lemon_squeezy_subscription_id?: string | null
+          payload?: Json
+          payment_provider?: string | null
+          payment_subscription_id?: string | null
+          processed_at?: string
+        }
+        Relationships: []
+      }
+      user_blog_subscriptions: {
+        Row: {
+          created_at: string
+          current_period_end: string | null
+          lemon_squeezy_subscription_id: string | null
+          lemon_squeezy_variant_id: number | null
+          manage_subscription_url: string | null
+          payment_product_id: string | null
+          payment_provider: string | null
+          payment_subscription_id: string | null
+          subscription_status:
+            | Database["public"]["Enums"]["blog_subscription_status"]
+            | null
+          subscription_tier: Database["public"]["Enums"]["blog_subscription_tier"]
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          current_period_end?: string | null
+          lemon_squeezy_subscription_id?: string | null
+          lemon_squeezy_variant_id?: number | null
+          manage_subscription_url?: string | null
+          payment_product_id?: string | null
+          payment_provider?: string | null
+          payment_subscription_id?: string | null
+          subscription_status?:
+            | Database["public"]["Enums"]["blog_subscription_status"]
+            | null
+          subscription_tier?: Database["public"]["Enums"]["blog_subscription_tier"]
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          current_period_end?: string | null
+          lemon_squeezy_subscription_id?: string | null
+          lemon_squeezy_variant_id?: number | null
+          manage_subscription_url?: string | null
+          payment_product_id?: string | null
+          payment_provider?: string | null
+          payment_subscription_id?: string | null
+          subscription_status?:
+            | Database["public"]["Enums"]["blog_subscription_status"]
+            | null
+          subscription_tier?: Database["public"]["Enums"]["blog_subscription_tier"]
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_blog_subscriptions_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "profiles"
             referencedColumns: ["id"]
           },
         ]
@@ -1816,11 +2191,33 @@ export type Database = {
     }
     Functions: {
       claim_studio_video_assembly_job: {
-        Args: Record<PropertyKey, never>
-        Returns: Database["public"]["Tables"]["studio_video_assembly_jobs"]["Row"][]
+        Args: never
+        Returns: {
+          completed_at: string | null
+          created_at: string
+          created_by: string | null
+          episode_id: string
+          error_message: string | null
+          id: string
+          input: Json
+          max_retries: number
+          organization_id: string
+          output_artifact_id: string | null
+          processing_started_at: string | null
+          retry_count: number
+          started_at: string | null
+          status: string
+          updated_at: string
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "studio_video_assembly_jobs"
+          isOneToOne: false
+          isSetofReturn: true
+        }
       }
       reset_stale_studio_video_assembly_jobs: {
-        Args: { stale_before?: unknown }
+        Args: { stale_before?: string }
         Returns: {
           failed_count: number
           requeued_count: number

--- a/supabase/migrations/049_admin_content_ops_foundation.sql
+++ b/supabase/migrations/049_admin_content_ops_foundation.sql
@@ -1,0 +1,191 @@
+-- Foundation schema for admin-managed newsletter/blog content operations.
+-- Scope: subscriber lifecycle, content queue, source registry, run logs, publication logs.
+
+create table if not exists public.newsletter_subscribers (
+  id uuid primary key default gen_random_uuid(),
+  email text not null,
+  email_normalized text generated always as (lower(trim(email))) stored,
+  status text not null default 'subscribed' check (
+    status in ('subscribed', 'unsubscribed', 'bounced', 'complained')
+  ),
+  consent_at timestamptz,
+  unsubscribe_at timestamptz,
+  locale text not null default 'en',
+  frequency_pref text not null default 'weekly' check (
+    frequency_pref in ('daily', 'weekly')
+  ),
+  source text not null default 'manual',
+  source_ref text,
+  tags text[] not null default '{}',
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (email_normalized)
+);
+
+create index if not exists idx_newsletter_subscribers_status
+  on public.newsletter_subscribers (status);
+
+create index if not exists idx_newsletter_subscribers_frequency
+  on public.newsletter_subscribers (frequency_pref);
+
+comment on table public.newsletter_subscribers is
+  'Dedicated newsletter subscriber lifecycle table (separate from waitlist lead capture).';
+
+create table if not exists public.content_sources (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  kind text not null check (kind in ('rss', 'blog', 'api', 'manual')),
+  base_url text not null,
+  rss_url text,
+  is_active boolean not null default true,
+  trust_weight int not null default 50 check (trust_weight between 0 and 100),
+  topic_tags text[] not null default '{}',
+  locale text,
+  fetch_interval_minutes int not null default 1440,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_content_sources_active
+  on public.content_sources (is_active, trust_weight desc);
+
+comment on table public.content_sources is
+  'Registry of curated news/blog sources for automated ingest and scoring.';
+
+create table if not exists public.content_items (
+  id uuid primary key default gen_random_uuid(),
+  type text not null check (type in ('blog', 'newsletter')),
+  title text not null,
+  slug text,
+  locale text not null default 'en',
+  summary text,
+  body_markdown text not null default '',
+  source_quality_score numeric(5, 2),
+  fact_check_score numeric(5, 2),
+  status text not null default 'draft' check (
+    status in (
+      'draft',
+      'review_required',
+      'approved',
+      'rejected',
+      'scheduled',
+      'publishing',
+      'published',
+      'send_failed'
+    )
+  ),
+  review_notes text,
+  reviewed_by uuid references public.profiles (id) on delete set null,
+  reviewed_at timestamptz,
+  approved_by uuid references public.profiles (id) on delete set null,
+  approved_at timestamptz,
+  scheduled_at timestamptz,
+  published_at timestamptz,
+  generation_model text,
+  generation_prompt_version text,
+  cta_variant text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_by uuid references public.profiles (id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create unique index if not exists idx_content_items_slug_locale
+  on public.content_items (slug, locale)
+  where slug is not null;
+
+create index if not exists idx_content_items_status_updated_at
+  on public.content_items (status, updated_at desc);
+
+comment on table public.content_items is
+  'Canonical content queue items for blog and newsletter lifecycle states.';
+
+create table if not exists public.content_item_source_map (
+  id uuid primary key default gen_random_uuid(),
+  content_item_id uuid not null references public.content_items (id) on delete cascade,
+  source_id uuid not null references public.content_sources (id) on delete restrict,
+  source_url text not null,
+  source_title text,
+  source_published_at timestamptz,
+  snippet_hash text not null,
+  excerpt text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  unique (content_item_id, source_url)
+);
+
+create index if not exists idx_content_item_source_map_item
+  on public.content_item_source_map (content_item_id);
+
+create index if not exists idx_content_item_source_map_hash
+  on public.content_item_source_map (snippet_hash);
+
+comment on table public.content_item_source_map is
+  'Attribution mapping from content queue items to source documents.';
+
+create table if not exists public.content_runs (
+  id uuid primary key default gen_random_uuid(),
+  run_type text not null check (
+    run_type in ('ingest', 'draft_generate', 'review_gate', 'publish')
+  ),
+  status text not null default 'queued' check (
+    status in ('queued', 'running', 'succeeded', 'failed', 'cancelled')
+  ),
+  trigger_type text not null default 'manual' check (
+    trigger_type in ('manual', 'scheduled', 'retry', 'api')
+  ),
+  started_at timestamptz,
+  ended_at timestamptz,
+  error_summary text,
+  error_details jsonb,
+  initiated_by uuid references public.profiles (id) on delete set null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_content_runs_created_at
+  on public.content_runs (created_at desc);
+
+create index if not exists idx_content_runs_status
+  on public.content_runs (status, run_type);
+
+comment on table public.content_runs is
+  'Operational run logs for ingestion, draft generation, review gate, and publish processes.';
+
+create table if not exists public.content_publications (
+  id uuid primary key default gen_random_uuid(),
+  content_item_id uuid not null references public.content_items (id) on delete cascade,
+  channel text not null check (channel in ('blog', 'email')),
+  status text not null default 'queued' check (
+    status in ('queued', 'scheduled', 'processing', 'sent', 'published', 'failed', 'cancelled')
+  ),
+  provider text not null default 'internal',
+  provider_message_id text,
+  attempt_count int not null default 0,
+  last_error text,
+  scheduled_at timestamptz,
+  processed_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (content_item_id, channel, scheduled_at)
+);
+
+create index if not exists idx_content_publications_due
+  on public.content_publications (status, scheduled_at);
+
+create index if not exists idx_content_publications_item
+  on public.content_publications (content_item_id, channel);
+
+comment on table public.content_publications is
+  'Channel-level publication and send tracking rows for each content item.';
+
+-- Use service role/admin server actions only in MVP phase.
+alter table public.newsletter_subscribers enable row level security;
+alter table public.content_sources enable row level security;
+alter table public.content_items enable row level security;
+alter table public.content_item_source_map enable row level security;
+alter table public.content_runs enable row level security;
+alter table public.content_publications enable row level security;

--- a/tests/unit/review-gate.test.ts
+++ b/tests/unit/review-gate.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateReviewGate,
+  MIN_REVIEW_BODY_CHARS,
+} from "@/lib/content-ops/review-gate";
+
+describe("evaluateReviewGate", () => {
+  it("fails when source links are missing", () => {
+    const result = evaluateReviewGate({
+      bodyMarkdown: "This is a proper looking draft with enough text ".repeat(12),
+      sourceLinkCount: 0,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.reasons).toContain("source_links_missing");
+  });
+
+  it("fails when body is too short", () => {
+    const result = evaluateReviewGate({
+      bodyMarkdown: "short body only",
+      sourceLinkCount: 2,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.reasons).toContain("body_too_short");
+    expect(result.metrics.bodyChars).toBeLessThan(MIN_REVIEW_BODY_CHARS);
+  });
+
+  it("fails on overcopy heuristic for huge code fence", () => {
+    const codeBlock = `\`\`\`\n${"x".repeat(1500)}\n\`\`\``;
+    const result = evaluateReviewGate({
+      bodyMarkdown: `${"Meaningful intro ".repeat(30)}\n\n${codeBlock}`,
+      sourceLinkCount: 1,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.reasons).toContain("possible_overcopy_detected");
+    expect(result.metrics.codeFenceLargeBlockDetected).toBe(true);
+  });
+
+  it("passes for valid content with source and enough narrative", () => {
+    const result = evaluateReviewGate({
+      bodyMarkdown: `
+## Summary
+${"This draft summarizes trends and adds operator-focused interpretation. ".repeat(10)}
+
+## Source
+- [Example source](https://example.com/article)
+      `.trim(),
+      sourceLinkCount: 1,
+    });
+    expect(result.passed).toBe(true);
+    expect(result.reasons).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement Sprint 1 review gate hardening with rule engine, manual run integration, queue-side failure reason chips, and unit tests
- implement Sprint 2 publish retry hardening with failure classification, bounded retry metadata (`attempt_count`/`next_retry_at`), and failed-only retry actions in admin runs/queue
- implement Sprint 3 operational polish with locale template config + template version metadata, admin run summary cards, CI-safe smoke/cleanup dry-run scripts, and a content ops runbook

## Test plan
- [x] `pnpm eslint \"src/lib/content-ops/review-gate.ts\" \"src/lib/content-ops/pipeline-runner.ts\" \"src/actions/admin-content-ops.ts\" \"src/app/(admin)/admin/content-queue/page.tsx\" \"tests/unit/review-gate.test.ts\"`
- [x] `pnpm eslint \"src/lib/content-ops/locale-template-config.ts\" \"src/lib/content-ops/newsletter-send-adapter.ts\" \"src/lib/content-ops/blog-publish-adapter.ts\" \"src/lib/content-ops/pipeline-runner.ts\" \"src/app/(admin)/admin/runs/page.tsx\" \"scripts/content-ops-smoke.ts\" \"scripts/content-ops-cleanup.ts\"`
- [x] `pnpm typecheck`
- [x] `pnpm test -- tests/unit`
- [x] `pnpm content-ops:smoke:dry-run`
- [x] `pnpm content-ops:cleanup:dry-run`


Made with [Cursor](https://cursor.com)