### PR TITLE
feat(content-ops): add agentic runtime orchestration and quality packs

### DIFF
--- a/.github/workflows/blog-autopublish.yml
+++ b/.github/workflows/blog-autopublish.yml
@@ -23,6 +23,8 @@ jobs:
       pull-requests: write
     env:
       BLOG_AUTOPUBLISH_ENABLED: "true"
+      CONTENT_OPS_AUTOMATION_RUNTIME: ${{ vars.CONTENT_OPS_AUTOMATION_RUNTIME || 'cursor' }}
+      CONTENT_OPS_AUTOMATION_TOKEN: ${{ secrets.CONTENT_OPS_AUTOMATION_TOKEN }}
       BLOG_AUTOPUBLISH_TOPICS_PATH: docs/blog/automation/topics.json
       BLOG_AUTOPUBLISH_STATUS_PATH: artifacts/blog-autopublish-status.json
       BLOG_QUALITY_GATE_STATUS_PATH: artifacts/blog-quality-gate.json

--- a/docs/features/INIT-agentic-content-ops-automation.md
+++ b/docs/features/INIT-agentic-content-ops-automation.md
@@ -1,0 +1,124 @@
+# INIT — Agentic Content Ops Automation (Cursor API Key)
+
+## Request Summary
+
+Prepare an operations-ready automation layer where:
+
+- newsletter/blog drafts are generated automatically on schedule
+- human admin approval remains mandatory before publish
+- unapproved items accumulate in queue (daily/weekly cadence)
+- content quality is meaningfully high (not short filler drafts)
+- prompts/templates can be replaced later without refactoring core pipeline
+
+This INIT does **not** implement runtime automation yet; it locks execution strategy for the next BUILD.
+
+## Fixed Decisions (SoT)
+
+1. **Human approval remains mandatory** before external publish.
+2. **Agent automation target is ingest + draft + review pre-check**, not bypassing editorial approval.
+3. **Queue-first behavior**: if admin does not approve, content remains in `draft/review_required` and accumulates.
+4. **Quality strategy is template-driven** with audience/persona-aware prompt packs.
+5. **Prompt/template config must be hot-swappable by code** (replace files/constants without schema churn).
+6. **Cursor API Key is managed as secret** in scheduler runtime (GitHub Actions or equivalent), never in source.
+
+## Why This Direction
+
+- Existing content-ops foundation is implemented (`ingest`/`draft_generate`/`review_gate`/`publish` + admin queue).
+- Missing value is orchestration reliability and quality governance, not base CRUD/workflow.
+- Hard separation between generation and approval preserves trust/compliance while allowing scale.
+- Prompt packs as first-class config give fast quality iteration after live feedback.
+
+## Current Codebase Anchors
+
+- Pipeline runs: `src/lib/content-ops/pipeline-runner.ts`
+- Admin run actions: `src/actions/admin-content-ops.ts`
+- Admin views: `src/app/(admin)/admin/runs/page.tsx`, `src/app/(admin)/admin/content-queue/page.tsx`
+- Quality gate: `src/lib/content-ops/review-gate.ts`
+- Locale template base: `src/lib/content-ops/locale-template-config.ts`
+- Operational runbook: `docs/features/RUNBOOK-content-ops.md`
+
+## Scope (INIT -> PLAN input)
+
+### In Scope
+
+- Agent scheduler topology using Cursor API Key (secure secret model)
+- Run orchestration policy:
+  - daily: `ingest` -> `draft_generate` -> `review_gate`
+  - publish window: approved/scheduled only
+  - retry failed only window
+- Quality architecture:
+  - topic selection policy by audience intent
+  - prompt pack system (newsletter/blog)
+  - template registry and versioning policy
+- Editorial governance:
+  - queue accumulation behavior
+  - approval SLA and backlog thresholds
+  - "must-review" escalation conditions
+- Operability:
+  - failure alerting requirements
+  - minimum health metrics
+  - run-level audit and rollback behavior
+
+### Out of Scope (this INIT)
+
+- shipping production cron runner code
+- replacing all current draft generation prompts immediately
+- introducing non-admin CMS editor
+- advanced personalization/recommendation engine
+
+## Quality Objective (Business)
+
+Content must drive a visible user reaction, not "placeholder text".
+
+MVP quality intent:
+
+- each piece has a clear audience pain/curiosity hook
+- actionable insight density is measurable (checklist, examples, contrast)
+- source-grounded claims with explicit references
+- CTA alignment with product intent (operator workflow adoption)
+
+## Prompt/Template Swap Contract
+
+Prompt and template quality must be replaceable in one place.
+
+Planned contract:
+
+- `prompt-pack` (topic strategy + structure + tone + guardrails)
+- `template-pack` (locale copy + CTA + framing sections)
+- `version metadata` attached to generated/published records
+- runtime resolver uses active version key; swapping key changes output behavior
+
+No hard dependency on DB migration for first iteration; file/config-first replacement is acceptable.
+
+## Suggested Build Slices (next phase)
+
+1. **B1 — Agent scheduler wiring**
+   - secure env handling (`CURSOR_API_KEY`)
+   - deterministic run schedule
+   - lock/idempotency to avoid duplicate run storms
+2. **B2 — Prompt pack system**
+   - audience/topic matrix
+   - newsletter/blog generation contracts
+   - fallback pack rules
+3. **B3 — Quality scorecard + gates**
+   - enrich review gate beyond minimum checks
+   - score metadata persisted per item
+4. **B4 — Editorial ops policy**
+   - backlog SLA thresholds + alerts
+   - "publish window" and "manual override" policy
+5. **B5 — Operability hardening**
+   - run summary metrics
+   - failure taxonomy dashboard fields
+   - retry/rollback runbook completion
+
+## Success Criteria (for next BUILD)
+
+- automated generation runs execute on schedule without manual trigger
+- unapproved content safely accumulates in queue (no accidental send)
+- approved content publishes in configured windows
+- prompt/template version can be swapped by editing code config only
+- first-week quality feedback loop can update packs in < 1 day
+
+## Next Mode
+
+`PLAN` — lock architecture, schedule policy, prompt pack schema, and quality score rubric before BUILD.

--- a/docs/features/PLAN-agentic-content-quality-packs.md
+++ b/docs/features/PLAN-agentic-content-quality-packs.md
@@ -1,0 +1,98 @@
+# PLAN Draft — Agentic Content Quality Packs
+
+## Goal
+
+Define a replaceable quality system for newsletter/blog generation so operators can tune content quality by swapping prompt/template packs in code.
+
+## Pack Model
+
+### 1) Topic Strategy Pack
+
+Fields:
+
+- `audience_segment` (operator, team lead, founder, etc.)
+- `problem_space` (automation reliability, cost, velocity, governance)
+- `curiosity_hook_patterns` (question, contrarian, benchmark, teardown)
+- `disallowed_topics` (off-brand or low-trust themes)
+
+### 2) Generation Prompt Pack
+
+Fields:
+
+- `content_type`: `newsletter` | `blog`
+- `format_contract` (required sections/headings)
+- `tone_contract` (clarity, specificity, confidence)
+- `evidence_contract` (min source references, no unsupported claims)
+- `engagement_contract` (must include contrast/example/checklist/action)
+- `cta_contract` (product-aligned and locale-safe)
+
+### 3) Template Pack
+
+Fields:
+
+- locale framing copy (intro/bridge/cta)
+- brand-safe phrasing variants
+- section labels and fallback copy
+
+Current base anchor:
+
+- `src/lib/content-ops/locale-template-config.ts`
+
+## Resolution Policy
+
+- `activePackVersion` keys resolve generation behavior.
+- priority:
+  1) explicit run override
+  2) default active version
+  3) stable fallback version
+- always persist `pack_version` in metadata for audit.
+
+## Minimal File Layout (proposal)
+
+- `src/lib/content-ops/packs/topic-strategy-pack.ts`
+- `src/lib/content-ops/packs/newsletter-prompt-pack.ts`
+- `src/lib/content-ops/packs/blog-prompt-pack.ts`
+- `src/lib/content-ops/packs/pack-registry.ts`
+
+## Quality Rubric (v1)
+
+Score each draft 0-5 on:
+
+1. **Relevance**: does it match target operator pain now?
+2. **Novelty**: does it add non-obvious value?
+3. **Specificity**: concrete examples/steps vs generic statements
+4. **Evidence**: source-grounded claims and links
+5. **Actionability**: clear next action for reader
+
+Policy:
+
+- `< 12/25`: force `review_required` with reason tags
+- `12-18`: manual review required
+- `>= 19`: eligible for approval queue
+
+## Run Integration
+
+During `draft_generate`:
+
+- resolve active topic + prompt + template packs
+- generate body with structure contract
+- write `metadata.generation.pack_version` and rubric hints
+
+During `review_gate`:
+
+- evaluate rubric + hard checks
+- write `metadata.review_gate.latest.quality_score`
+
+## Operational Tuning Loop
+
+Weekly:
+
+- inspect top performing topics by open/click/reply proxy
+- inspect low-performing drafts and map failed rubric dimensions
+- release next pack version (`vX.Y.Z`) and keep rollback path
+
+## Non-goals (this plan draft)
+
+- model fine-tuning infrastructure
+- personalization by individual subscriber profile
+- external GUI prompt editor

--- a/docs/features/RUNBOOK-content-ops.md
+++ b/docs/features/RUNBOOK-content-ops.md
@@ -7,6 +7,24 @@ This runbook covers daily operation of the content pipeline:
 - `ingest` -> `draft_generate` -> `review_gate` -> `publish`
 - Admin dashboards: `/admin/content-queue`, `/admin/runs`, `/admin/news-sources`, `/admin/subscribers`
 
+## Automation Runtime (A/B)
+
+- Primary runtime: `cursor` (`CONTENT_OPS_AUTOMATION_RUNTIME=cursor`)
+- Fallback runtime: `vercel-cron` (`CONTENT_OPS_AUTOMATION_RUNTIME=vercel-cron`)
+- Trigger endpoint: `/api/content-ops/automation-run`
+
+Required secrets/env:
+
+- `CONTENT_OPS_AUTOMATION_TOKEN` (API trigger token for non-Vercel callers)
+- `CONTENT_OPS_ALERT_WEBHOOK_URL` (optional alert hook)
+- `CURSOR_API_KEY` (for Cursor automation workflows)
+
+US ET schedule source-of-truth:
+
+- Daily generation: 08:30 `ingest`, 08:40 `draft_generate`, 08:50 `review_gate`
+- Publish window: 11:00 `publish`
+- Retry window: 14:30 `publish_retry_failed`
+
 ## Daily Operation Order
 
 1. Open `/admin/runs` and check latest run summary cards.
@@ -34,6 +52,17 @@ This runbook covers daily operation of the content pipeline:
    - Ensure new run is `성공` or `부분실패` with expected warning only.
    - Confirm queue items move from `send_failed` to `published`.
 
+## Escalation Ownership / Response Window
+
+- Primary owner: Content Ops on-call (admin operator)
+- Secondary owner: Engineering on-call (automation reliability)
+
+SLA:
+
+- `review_required` queue item older than 24h: acknowledge within 4h
+- alert webhook failure events: acknowledge within 1h
+- repeated `resend_not_configured`: fix or disable publish window same business day
+
 ## Minimum Checklist
 
 - [ ] `ingest` completed today (or intentionally skipped)
@@ -43,6 +72,7 @@ This runbook covers daily operation of the content pipeline:
 - [ ] `/admin/runs` top failure reason acknowledged
 - [ ] No repeated `resend_not_configured` warnings
 - [ ] No stale `send_failed` item older than 24h without owner
+- [ ] No `review_required` backlog over threshold without escalation note
 
 ## CI / Script Operations
 

--- a/scripts/content-ops-cleanup.ts
+++ b/scripts/content-ops-cleanup.ts
@@ -1,4 +1,8 @@
 import dotenv from "dotenv";
+import {
+  CONTENT_OPS_RUNTIME,
+  CONTENT_OPS_US_ET_SCHEDULE,
+} from "@/lib/content-ops/automation-config";
 import { createAdminClient } from "@/lib/supabase/admin";
 
 dotenv.config({ path: ".env.local" });
@@ -97,6 +101,8 @@ async function cleanupSmokeFixtures() {
         {
           mode: "dry-run",
           check: "content-ops-cleanup",
+          runtime: CONTENT_OPS_RUNTIME,
+          etSchedule: CONTENT_OPS_US_ET_SCHEDULE,
           wouldDelete: {
             deletedSources: sourceRows.count ?? 0,
             deletedMapRows: mappedRows.count ?? 0,

--- a/scripts/content-ops-smoke.ts
+++ b/scripts/content-ops-smoke.ts
@@ -1,4 +1,8 @@
 import dotenv from "dotenv";
+import {
+  CONTENT_OPS_RUNTIME,
+  CONTENT_OPS_US_ET_SCHEDULE,
+} from "@/lib/content-ops/automation-config";
 import { createAdminClient } from "@/lib/supabase/admin";
 import {
   runDraftGeneratePipeline,
@@ -156,6 +160,8 @@ async function main() {
           check: "content-ops-smoke",
           seedInfo,
           plannedRuns: ["ingest", "draft_generate", "publish"],
+          runtime: CONTENT_OPS_RUNTIME,
+          etSchedule: CONTENT_OPS_US_ET_SCHEDULE,
           note: "No DB writes or email sends were executed.",
         },
         null,

--- a/src/actions/admin-content-ops.ts
+++ b/src/actions/admin-content-ops.ts
@@ -5,11 +5,14 @@ import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { canAccessElevateServiceAdmin } from "@/lib/auth/platform-admin";
 import {
-  runDraftGeneratePipeline,
-  runIngestPipeline,
-  runPublishPipeline,
-  runReviewGatePipeline,
-} from "@/lib/content-ops/pipeline-runner";
+  CONTENT_OPS_RUN_SEQUENCE,
+  type ContentOpsRunType,
+} from "@/lib/content-ops/automation-config";
+import { runPublishPipeline } from "@/lib/content-ops/pipeline-runner";
+import {
+  executeContentOpsRun,
+  runContentOpsScenario,
+} from "@/lib/content-ops/run-orchestrator";
 import type { Json } from "@/types/database.types";
 
 const EMAIL_RE =
@@ -25,6 +28,8 @@ export type AdminContentItemRow = {
   fact_check_score: number | null;
   scheduled_at: string | null;
   metadata: Json | null;
+  review_notes: string | null;
+  created_at: string;
   updated_at: string;
 };
 
@@ -63,8 +68,6 @@ export type AdminNewsletterSubscriberRow = {
   created_at: string;
 };
 
-const RUN_SEQUENCE = ["ingest", "draft_generate", "publish"] as const;
-
 async function assertPlatformAdmin(): Promise<
   { ok: true } | { ok: false; error: string }
 > {
@@ -94,7 +97,7 @@ export async function listAdminContentQueue(filters?: {
     let query = admin
       .from("content_items")
       .select(
-        "id, type, title, locale, status, source_quality_score, fact_check_score, scheduled_at, metadata, updated_at",
+        "id, type, title, locale, status, source_quality_score, fact_check_score, scheduled_at, metadata, review_notes, created_at, updated_at",
       )
       .order("updated_at", { ascending: false })
       .limit(300);
@@ -267,82 +270,17 @@ export async function createManualContentRun(formData: FormData): Promise<void> 
   const gate = await assertPlatformAdmin();
   if (!gate.ok) return;
 
-  const runType = String(formData.get("run_type") ?? "").trim();
+  const runType = String(formData.get("run_type") ?? "").trim() as ContentOpsRunType;
   if (!runType) return;
   await executeAdminRunType(runType);
 }
 
-async function executeAdminRunType(runType: string): Promise<void> {
+async function executeAdminRunType(runType: ContentOpsRunType): Promise<void> {
   try {
-    const nowIso = new Date().toISOString();
-    const admin = createAdminClient();
-    const { data: runRow, error } = await admin
-      .from("content_runs")
-      .insert({
-        run_type: runType,
-        status: "running",
-        trigger_type: "manual",
-        started_at: nowIso,
-      })
-      .select("id")
-      .single();
-    if (error || !runRow?.id) return;
-
-    let status: "succeeded" | "failed" = "succeeded";
-    let metadata: Json | null = null;
-    let errorSummary: string | null = null;
-
-    try {
-      if (runType === "ingest") {
-        metadata = await runIngestPipeline(runRow.id);
-      } else if (runType === "draft_generate") {
-        metadata = await runDraftGeneratePipeline(runRow.id);
-      } else if (runType === "publish") {
-        metadata = await runPublishPipeline();
-      } else if (runType === "publish_retry_failed") {
-        metadata = await runPublishPipeline({ retryFailedOnly: true });
-      } else if (runType === "review_gate") {
-        metadata = await runReviewGatePipeline(runRow.id);
-      } else {
-        metadata = { skipped: true, reason: "unknown_run_type" };
-      }
-    } catch (e) {
-      status = "failed";
-      errorSummary = e instanceof Error ? e.message : "unknown";
-    }
-
-    if (!errorSummary && metadata && typeof metadata === "object" && !Array.isArray(metadata)) {
-      if (
-        (runType === "publish" || runType === "publish_retry_failed") &&
-        typeof (metadata as Record<string, unknown>).failedCount === "number" &&
-        ((metadata as Record<string, unknown>).failedCount as number) > 0
-      ) {
-        status = "failed";
-      }
-      const maybeFailures = (metadata as Record<string, unknown>).failureMessages;
-      if (Array.isArray(maybeFailures) && maybeFailures.length > 0) {
-        const first = maybeFailures.find((v) => typeof v === "string");
-        errorSummary = typeof first === "string" ? `warning:${first}` : "warning:partial_failures";
-      }
-      const maybeFailedSources = (metadata as Record<string, unknown>).failedSources;
-      if (!errorSummary && typeof maybeFailedSources === "number" && maybeFailedSources > 0) {
-        errorSummary = `warning:${maybeFailedSources}_sources_failed`;
-      }
-      const maybeFailedCount = (metadata as Record<string, unknown>).failedCount;
-      if (!errorSummary && typeof maybeFailedCount === "number" && maybeFailedCount > 0) {
-        errorSummary = `warning:${maybeFailedCount}_items_failed`;
-      }
-    }
-
-    await admin
-      .from("content_runs")
-      .update({
-        status,
-        ended_at: new Date().toISOString(),
-        metadata: (metadata ?? {}) as Json,
-        error_summary: errorSummary,
-      })
-      .eq("id", runRow.id);
+    await executeContentOpsRun({
+      runType,
+      triggerType: "manual",
+    });
 
     revalidatePath("/admin/runs");
     revalidatePath("/admin/content-queue");
@@ -358,9 +296,10 @@ export async function runAdminContentOpsScenario(): Promise<void> {
   if (!gate.ok) return;
 
   try {
-    for (const runType of RUN_SEQUENCE) {
-      await executeAdminRunType(runType);
-    }
+    await runContentOpsScenario({
+      triggerType: "manual",
+      sequence: CONTENT_OPS_RUN_SEQUENCE,
+    });
   } catch (e) {
     console.error("[runAdminContentOpsScenario] failed", e);
   }

--- a/src/app/(admin)/admin/content-queue/page.tsx
+++ b/src/app/(admin)/admin/content-queue/page.tsx
@@ -44,6 +44,8 @@ export default async function AdminContentQueuePage(props: {
     status: statusFilter,
   });
   const rows = listRes.ok ? listRes.rows : [];
+  const nowMs = new Date().getTime();
+  const queueSummary = summarizeQueue(rows, nowMs);
 
   return (
     <div className="min-h-screen bg-paper-50">
@@ -65,6 +67,11 @@ export default async function AdminContentQueuePage(props: {
           Review generated blog/newsletter drafts and move approved items to schedule
           or immediate publish.
         </p>
+        <div className="grid gap-2 md:grid-cols-3">
+          <QueueSummaryCard label="Pending approval" value={queueSummary.pendingApproval} />
+          <QueueSummaryCard label="Stale >24h" value={queueSummary.staleOver24h} tone="warning" />
+          <QueueSummaryCard label="Must-review now" value={queueSummary.mustReviewNow} tone="danger" />
+        </div>
 
         <form className="flex flex-wrap items-end gap-3 border border-ink-100 bg-paper-0 p-3">
           <div className="space-y-1">
@@ -130,6 +137,7 @@ export default async function AdminContentQueuePage(props: {
                   <th className="p-2 font-medium text-ink-700">Status</th>
                   <th className="p-2 font-medium text-ink-700">Quality</th>
                   <th className="p-2 font-medium text-ink-700">Gate</th>
+                  <th className="p-2 font-medium text-ink-700">Ops signal</th>
                   <th className="p-2 font-medium text-ink-700">Updated</th>
                   <th className="p-2 font-medium text-ink-700">Actions</th>
                 </tr>
@@ -148,6 +156,15 @@ export default async function AdminContentQueuePage(props: {
                     </td>
                     <td className="p-2 text-ink-700">
                       <ReviewGateCell metadata={row.metadata} />
+                    </td>
+                    <td className="p-2 text-ink-700">
+                      <OpsSignalCell
+                        status={row.status}
+                        createdAt={row.created_at}
+                        nowMs={nowMs}
+                        metadata={row.metadata}
+                        reviewNotes={row.review_notes}
+                      />
                     </td>
                     <td className="p-2 whitespace-nowrap text-ink-500">
                       {new Date(row.updated_at).toISOString().replace("T", " ").slice(0, 19)} UTC
@@ -217,6 +234,29 @@ export default async function AdminContentQueuePage(props: {
   );
 }
 
+function QueueSummaryCard({
+  label,
+  value,
+  tone = "neutral",
+}: {
+  label: string;
+  value: number;
+  tone?: "neutral" | "warning" | "danger";
+}) {
+  const toneClass =
+    tone === "warning"
+      ? "text-amber-700"
+      : tone === "danger"
+        ? "text-danger"
+        : "text-ink-900";
+  return (
+    <div className="border border-ink-100 bg-paper-0 p-3">
+      <p className="text-[11px] uppercase tracking-wide text-ink-500">{label}</p>
+      <p className={`mt-1 text-sm font-medium ${toneClass}`}>{value}</p>
+    </div>
+  );
+}
+
 function ReviewGateCell({ metadata }: { metadata: Json | null }) {
   const latest = readLatestReviewGate(metadata);
   if (!latest) {
@@ -252,6 +292,7 @@ function ReviewGateCell({ metadata }: { metadata: Json | null }) {
 function readLatestReviewGate(metadata: Json | null): {
   passed: boolean;
   reasons: string[];
+  qualityScore: number;
 } | null {
   if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return null;
   const reviewGate = (metadata as Record<string, unknown>).review_gate;
@@ -262,10 +303,85 @@ function readLatestReviewGate(metadata: Json | null): {
   if (!latest || typeof latest !== "object" || Array.isArray(latest)) return null;
   const passed = (latest as Record<string, unknown>).passed;
   const reasons = (latest as Record<string, unknown>).reasons;
+  const metrics = (latest as Record<string, unknown>).metrics;
+  const qualityScore =
+    metrics && typeof metrics === "object" && !Array.isArray(metrics)
+      ? Number((metrics as Record<string, unknown>).qualityScore ?? 0)
+      : 0;
   return {
     passed: passed === true,
     reasons: Array.isArray(reasons)
       ? reasons.filter((v): v is string => typeof v === "string")
       : [],
+    qualityScore: Number.isFinite(qualityScore) ? qualityScore : 0,
   };
+}
+
+function summarizeQueue(
+  rows: Array<{ status: string; created_at: string; metadata: Json | null; review_notes: string | null }>,
+  nowMs: number,
+) {
+  let pendingApproval = 0;
+  let staleOver24h = 0;
+  let mustReviewNow = 0;
+  for (const row of rows) {
+    const isPending = row.status === "draft" || row.status === "review_required";
+    if (isPending) pendingApproval += 1;
+    if (isPending && nowMs - new Date(row.created_at).getTime() >= 24 * 60 * 60 * 1000) {
+      staleOver24h += 1;
+    }
+    if (isMustReviewNow(row, nowMs)) {
+      mustReviewNow += 1;
+    }
+  }
+  return { pendingApproval, staleOver24h, mustReviewNow };
+}
+
+function isMustReviewNow(row: {
+  status: string;
+  created_at: string;
+  metadata: Json | null;
+  review_notes: string | null;
+}, nowMs: number): boolean {
+  if (row.status !== "review_required") return false;
+  const latest = readLatestReviewGate(row.metadata);
+  const oldEnough = nowMs - new Date(row.created_at).getTime() >= 24 * 60 * 60 * 1000;
+  if (oldEnough) return true;
+  if (!latest) return true;
+  if (latest.qualityScore < 12) return true;
+  if (latest.reasons.some((reason) => reason.startsWith("low_"))) return true;
+  return Boolean(row.review_notes?.includes("review_gate:"));
+}
+
+function OpsSignalCell({
+  status,
+  createdAt,
+  nowMs,
+  metadata,
+  reviewNotes,
+}: {
+  status: string;
+  createdAt: string;
+  nowMs: number;
+  metadata: Json | null;
+  reviewNotes: string | null;
+}) {
+  if (status !== "review_required") {
+    return <span className="text-ink-500">-</span>;
+  }
+
+  const latest = readLatestReviewGate(metadata);
+  const ageHours = Math.floor((nowMs - new Date(createdAt).getTime()) / (60 * 60 * 1000));
+  const isSlaRisk = ageHours >= 24;
+  const hasLowQuality = latest ? latest.qualityScore < 12 : true;
+  const label = isSlaRisk ? `SLA risk (${ageHours}h)` : hasLowQuality ? "Quality rework" : "Review needed";
+  const details = latest?.reasons.join(",") || reviewNotes || "manual_review_required";
+  return (
+    <span
+      className={`inline-flex border border-ink-100 bg-paper-50 px-2 py-0.5 text-[11px] font-medium ${isSlaRisk ? "text-danger" : "text-amber-700"}`}
+      title={details}
+    >
+      {label}
+    </span>
+  );
 }

--- a/src/app/(admin)/admin/runs/page.tsx
+++ b/src/app/(admin)/admin/runs/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { Activity } from "lucide-react";
 import {
   createManualContentRun,
+  listAdminContentQueue,
   listAdminContentRuns,
   runAdminContentOpsScenario,
   runRetryFailedPublishOnly,
@@ -15,8 +16,11 @@ export const metadata: Metadata = {
 
 export default async function AdminRunsPage() {
   const listRes = await listAdminContentRuns();
+  const queueRes = await listAdminContentQueue({ status: "review_required" });
   const rows = listRes.ok ? listRes.rows : [];
+  const reviewQueueRows = queueRes.ok ? queueRes.rows : [];
   const summary = buildRunSummary(rows);
+  const ops = buildOpsSummary(reviewQueueRows);
 
   return (
     <div className="min-h-screen bg-paper-50">
@@ -46,6 +50,11 @@ export default async function AdminRunsPage() {
             value={summary.topFailureReason ?? "-"}
             tone="warning"
           />
+        </div>
+        <div className="grid gap-2 md:grid-cols-3">
+          <SummaryCard label="Review queue" value={ops.reviewQueueCount} tone="neutral" />
+          <SummaryCard label="Must-review now" value={ops.mustReviewCount} tone="danger" />
+          <SummaryCard label="Oldest review age (h)" value={ops.oldestReviewAgeHours} tone="warning" />
         </div>
         <div className="border border-ink-100 bg-paper-0 p-3 text-xs leading-relaxed text-ink-700">
           <p className="font-medium text-ink-900">Recommended 1-pass scenario</p>
@@ -374,4 +383,34 @@ function parseFailureReasons(
     }
   }
   return parsed;
+}
+
+function buildOpsSummary(rows: Array<{ created_at: string; metadata: Json | null }>) {
+  let mustReviewCount = 0;
+  let oldestReviewAgeHours = 0;
+  for (const row of rows) {
+    const ageHours = Math.floor((Date.now() - new Date(row.created_at).getTime()) / (60 * 60 * 1000));
+    if (ageHours > oldestReviewAgeHours) oldestReviewAgeHours = ageHours;
+    const qualityScore = readQualityScore(row.metadata);
+    if (ageHours >= 24 || qualityScore < 12) {
+      mustReviewCount += 1;
+    }
+  }
+  return {
+    reviewQueueCount: rows.length,
+    mustReviewCount,
+    oldestReviewAgeHours,
+  };
+}
+
+function readQualityScore(metadata: Json | null): number {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return 0;
+  const gate = (metadata as Record<string, unknown>).review_gate;
+  if (!gate || typeof gate !== "object" || Array.isArray(gate)) return 0;
+  const latest = (gate as Record<string, unknown>).latest;
+  if (!latest || typeof latest !== "object" || Array.isArray(latest)) return 0;
+  const metrics = (latest as Record<string, unknown>).metrics;
+  if (!metrics || typeof metrics !== "object" || Array.isArray(metrics)) return 0;
+  const raw = Number((metrics as Record<string, unknown>).qualityScore ?? 0);
+  return Number.isFinite(raw) ? raw : 0;
 }

--- a/src/app/api/content-ops/automation-run/route.ts
+++ b/src/app/api/content-ops/automation-run/route.ts
@@ -1,0 +1,170 @@
+import { NextResponse } from "next/server";
+import {
+  CONTENT_OPS_RUN_SEQUENCE,
+  CONTENT_OPS_RUNTIME,
+  type ContentOpsRunType,
+  isRuntimeEnabledForSource,
+} from "@/lib/content-ops/automation-config";
+import {
+  executeContentOpsRun,
+  runContentOpsScenario,
+} from "@/lib/content-ops/run-orchestrator";
+
+type AutomationRunRequest = {
+  runType?: ContentOpsRunType;
+  scenario?: "daily_generation" | "publish_window" | "retry_window" | "full_sequence";
+  source?: "cursor" | "vercel-cron";
+};
+
+function isValidRunType(value: unknown): value is ContentOpsRunType {
+  return (
+    value === "ingest" ||
+    value === "draft_generate" ||
+    value === "review_gate" ||
+    value === "publish" ||
+    value === "publish_retry_failed"
+  );
+}
+
+function resolveScenarioSequence(
+  scenario: AutomationRunRequest["scenario"],
+): readonly ContentOpsRunType[] {
+  if (scenario === "daily_generation") {
+    return ["ingest", "draft_generate", "review_gate"];
+  }
+  if (scenario === "publish_window") {
+    return ["publish"];
+  }
+  if (scenario === "retry_window") {
+    return ["publish_retry_failed"];
+  }
+  return CONTENT_OPS_RUN_SEQUENCE;
+}
+
+export async function POST(req: Request) {
+  const automationToken = process.env.CONTENT_OPS_AUTOMATION_TOKEN?.trim();
+  if (!automationToken) {
+    return NextResponse.json(
+      { ok: false, error: "automation_token_not_configured" },
+      { status: 500 },
+    );
+  }
+
+  const auth = req.headers.get("authorization")?.trim() ?? "";
+  if (auth !== `Bearer ${automationToken}`) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+
+  const body = (await req.json().catch(() => ({}))) as AutomationRunRequest;
+  const source = body.source ?? "cursor";
+  if (!isRuntimeEnabledForSource(source)) {
+    return NextResponse.json({
+      ok: true,
+      skipped: true,
+      reason: `runtime_mismatch:${CONTENT_OPS_RUNTIME}`,
+    });
+  }
+
+  if (body.runType && !isValidRunType(body.runType)) {
+    return NextResponse.json({ ok: false, error: "invalid_run_type" }, { status: 400 });
+  }
+
+  try {
+    if (body.runType) {
+      const result = await executeContentOpsRun({
+        runType: body.runType,
+        triggerType: "api",
+        metadata: {
+          automation_source: source,
+          runtime: CONTENT_OPS_RUNTIME,
+        },
+      });
+      return NextResponse.json({ ok: true, mode: "single", result });
+    }
+
+    const scenario = body.scenario ?? "full_sequence";
+    const sequence = resolveScenarioSequence(scenario);
+    await runContentOpsScenario({
+      triggerType: "api",
+      sequence,
+      metadata: {
+        automation_source: source,
+        runtime: CONTENT_OPS_RUNTIME,
+        scenario,
+      },
+    });
+    return NextResponse.json({ ok: true, mode: "scenario", scenario, sequence });
+  } catch (e) {
+    return NextResponse.json(
+      { ok: false, error: e instanceof Error ? e.message : "unknown" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function GET(req: Request) {
+  const automationToken = process.env.CONTENT_OPS_AUTOMATION_TOKEN?.trim();
+
+  const url = new URL(req.url);
+  const runTypeRaw = url.searchParams.get("runType");
+  const scenarioRaw = url.searchParams.get("scenario");
+  const sourceRaw = url.searchParams.get("source");
+  const source = sourceRaw === "vercel-cron" ? "vercel-cron" : "cursor";
+  const cronHeader = req.headers.get("x-vercel-cron");
+  const token = url.searchParams.get("token")?.trim() ?? "";
+  const tokenAuthorized = automationToken ? token === automationToken : false;
+  const isTrustedVercelCron = source === "vercel-cron" && Boolean(cronHeader);
+  if (!tokenAuthorized && !isTrustedVercelCron) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+
+  if (!isRuntimeEnabledForSource(source)) {
+    return NextResponse.json({
+      ok: true,
+      skipped: true,
+      reason: `runtime_mismatch:${CONTENT_OPS_RUNTIME}`,
+    });
+  }
+
+  try {
+    if (runTypeRaw) {
+      if (!isValidRunType(runTypeRaw)) {
+        return NextResponse.json({ ok: false, error: "invalid_run_type" }, { status: 400 });
+      }
+      const result = await executeContentOpsRun({
+        runType: runTypeRaw,
+        triggerType: "scheduled",
+        metadata: {
+          automation_source: source,
+          runtime: CONTENT_OPS_RUNTIME,
+        },
+      });
+      return NextResponse.json({ ok: true, mode: "single", result });
+    }
+
+    const scenario = (
+      scenarioRaw === "daily_generation" ||
+      scenarioRaw === "publish_window" ||
+      scenarioRaw === "retry_window" ||
+      scenarioRaw === "full_sequence"
+        ? scenarioRaw
+        : "full_sequence"
+    ) as AutomationRunRequest["scenario"];
+    const sequence = resolveScenarioSequence(scenario);
+    await runContentOpsScenario({
+      triggerType: "scheduled",
+      sequence,
+      metadata: {
+        automation_source: source,
+        runtime: CONTENT_OPS_RUNTIME,
+        scenario,
+      },
+    });
+    return NextResponse.json({ ok: true, mode: "scenario", scenario, sequence });
+  } catch (e) {
+    return NextResponse.json(
+      { ok: false, error: e instanceof Error ? e.message : "unknown" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/content-ops/alerting.ts
+++ b/src/lib/content-ops/alerting.ts
@@ -1,0 +1,82 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { Json } from "@/types/database.types";
+
+const FAILED_COUNT_ALERT_THRESHOLD = Number.parseInt(
+  process.env.CONTENT_OPS_ALERT_FAILED_COUNT_THRESHOLD ?? "3",
+  10,
+);
+const REVIEW_BACKLOG_ALERT_THRESHOLD = Number.parseInt(
+  process.env.CONTENT_OPS_ALERT_REVIEW_BACKLOG_THRESHOLD ?? "20",
+  10,
+);
+
+type AlertPayload = {
+  runId: string;
+  runType: string;
+  status: "succeeded" | "failed";
+  failedCount: number;
+  reviewBacklogCount: number;
+  reasons: string[];
+  triggeredAt: string;
+};
+
+function extractFailedCount(metadata: Json | null): number {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return 0;
+  const failedCount = (metadata as Record<string, unknown>).failedCount;
+  return typeof failedCount === "number" && Number.isFinite(failedCount) ? failedCount : 0;
+}
+
+function extractReasons(metadata: Json | null): string[] {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return [];
+  const failures = (metadata as Record<string, unknown>).failureMessages;
+  if (!Array.isArray(failures)) return [];
+  return failures.filter((v): v is string => typeof v === "string").slice(0, 10);
+}
+
+async function getReviewBacklogCount(): Promise<number> {
+  const admin = createAdminClient();
+  const { count } = await admin
+    .from("content_items")
+    .select("id", { count: "exact", head: true })
+    .eq("status", "review_required");
+  return count ?? 0;
+}
+
+async function notifyWebhook(payload: AlertPayload): Promise<void> {
+  const webhookUrl = process.env.CONTENT_OPS_ALERT_WEBHOOK_URL?.trim();
+  if (!webhookUrl) return;
+  await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function maybeEmitContentOpsAlert(params: {
+  runId: string;
+  runType: string;
+  status: "succeeded" | "failed";
+  metadata: Json | null;
+}): Promise<{ emitted: boolean; payload?: AlertPayload }> {
+  const failedCount = extractFailedCount(params.metadata);
+  const reviewBacklogCount = await getReviewBacklogCount();
+  const reasons = extractReasons(params.metadata);
+  const shouldAlert =
+    params.status === "failed" ||
+    failedCount >= FAILED_COUNT_ALERT_THRESHOLD ||
+    reviewBacklogCount >= REVIEW_BACKLOG_ALERT_THRESHOLD;
+
+  if (!shouldAlert) return { emitted: false };
+
+  const payload: AlertPayload = {
+    runId: params.runId,
+    runType: params.runType,
+    status: params.status,
+    failedCount,
+    reviewBacklogCount,
+    reasons,
+    triggeredAt: new Date().toISOString(),
+  };
+  await notifyWebhook(payload);
+  return { emitted: true, payload };
+}

--- a/src/lib/content-ops/automation-config.ts
+++ b/src/lib/content-ops/automation-config.ts
@@ -1,0 +1,35 @@
+export type ContentOpsAutomationRuntime = "cursor" | "vercel-cron";
+
+export type ContentOpsRunType =
+  | "ingest"
+  | "draft_generate"
+  | "review_gate"
+  | "publish"
+  | "publish_retry_failed";
+
+export const CONTENT_OPS_RUNTIME: ContentOpsAutomationRuntime =
+  process.env.CONTENT_OPS_AUTOMATION_RUNTIME === "vercel-cron"
+    ? "vercel-cron"
+    : "cursor";
+
+export const CONTENT_OPS_RUN_SEQUENCE: readonly ContentOpsRunType[] = [
+  "ingest",
+  "draft_generate",
+  "publish",
+];
+
+export const CONTENT_OPS_US_ET_SCHEDULE = {
+  timezone: "America/New_York",
+  dailyGeneration: ["08:30:00", "08:40:00", "08:50:00"],
+  publishWindow: "11:00:00",
+  retryWindow: "14:30:00",
+  weeklyLongformBoostDays: ["Tue", "Thu"] as const,
+  weeklyLongformBoostTime: "10:00:00",
+} as const;
+
+export function isRuntimeEnabledForSource(source: "cursor" | "vercel-cron"): boolean {
+  if (CONTENT_OPS_RUNTIME === "cursor") {
+    return source === "cursor";
+  }
+  return source === "vercel-cron";
+}

--- a/src/lib/content-ops/packs/blog-prompt-pack.ts
+++ b/src/lib/content-ops/packs/blog-prompt-pack.ts
@@ -1,0 +1,51 @@
+import type { TopicStrategyEntry } from "@/lib/content-ops/packs/topic-strategy-pack";
+
+export const BLOG_PROMPT_PACK_VERSION = "v1.0.0";
+
+export function buildBlogDraftFromPack(params: {
+  topic: TopicStrategyEntry;
+  sourceBullets: string[];
+}): { title: string; summary: string; bodyMarkdown: string } {
+  const title = `${params.topic.titlePattern}: from signal to operating advantage`;
+  const summary =
+    "Practical long-form breakdown for operators who need reliable AI execution, not hype.";
+
+  const sourceSection =
+    params.sourceBullets.length > 0
+      ? params.sourceBullets.join("\n")
+      : "- No source items were ingested in this cycle.";
+
+  const bodyMarkdown = [
+    "## Context",
+    params.topic.whyNowPattern,
+    "",
+    "## Core question",
+    params.topic.questionPattern,
+    "",
+    "## What the latest signals suggest",
+    sourceSection,
+    "",
+    "## Decision framework for teams",
+    "### 1) Reliability before scale",
+    "- If a workflow lacks clear rollback, do not increase automation frequency.",
+    "- Make failure classes visible before optimization.",
+    "",
+    "### 2) Cost guardrails with ownership",
+    "- Pair cost limits with named owners and escalation windows.",
+    "- Review retry policy together with business priority, not in isolation.",
+    "",
+    "### 3) Editorial and ops loop",
+    "- Separate generation from approval for trust-critical channels.",
+    "- Keep templates versioned so quality can improve without rewiring the pipeline.",
+    "",
+    "## Execution checklist (this week)",
+    "1. Pick one pipeline stage to harden and define SLO.",
+    "2. Add one observable metric for quality and one for reliability.",
+    "3. Capture one reusable lesson in the runbook.",
+    "",
+    "## Sources",
+    sourceSection,
+  ].join("\n");
+
+  return { title, summary, bodyMarkdown };
+}

--- a/src/lib/content-ops/packs/newsletter-prompt-pack.ts
+++ b/src/lib/content-ops/packs/newsletter-prompt-pack.ts
@@ -1,0 +1,43 @@
+import type { TopicStrategyEntry } from "@/lib/content-ops/packs/topic-strategy-pack";
+
+export const NEWSLETTER_PROMPT_PACK_VERSION = "v1.0.0";
+
+export function buildNewsletterDraftFromPack(params: {
+  topic: TopicStrategyEntry;
+  sourceBullets: string[];
+}): { title: string; summary: string; bodyMarkdown: string } {
+  const today = new Date().toISOString().slice(0, 10);
+  const title = `Daily AI Brief: ${params.topic.titlePattern} (${today})`;
+  const summary = `${params.topic.questionPattern} Focused digest for workflow operators.`;
+
+  const sourceSection =
+    params.sourceBullets.length > 0
+      ? params.sourceBullets.join("\n")
+      : "- No source items were ingested in this window.";
+
+  const bodyMarkdown = [
+    "## Hook",
+    params.topic.questionPattern,
+    "",
+    "## Why this matters now",
+    params.topic.whyNowPattern,
+    "",
+    "## What changed in the last 24h",
+    sourceSection,
+    "",
+    "## Operator lens",
+    "- Identify one workflow where failure cost is non-trivial.",
+    "- Add one guardrail that catches high-impact mistakes early.",
+    "- Assign one owner for retry and rollback decisions.",
+    "",
+    "## This week action checklist",
+    "1. Audit one fragile automation path end-to-end.",
+    "2. Add run-level visibility for failure classes.",
+    "3. Define manual override policy before scaling frequency.",
+    "",
+    "## Sources",
+    sourceSection,
+  ].join("\n");
+
+  return { title, summary, bodyMarkdown };
+}

--- a/src/lib/content-ops/packs/pack-registry.ts
+++ b/src/lib/content-ops/packs/pack-registry.ts
@@ -1,0 +1,43 @@
+import {
+  BLOG_PROMPT_PACK_VERSION,
+  buildBlogDraftFromPack,
+} from "@/lib/content-ops/packs/blog-prompt-pack";
+import {
+  NEWSLETTER_PROMPT_PACK_VERSION,
+  buildNewsletterDraftFromPack,
+} from "@/lib/content-ops/packs/newsletter-prompt-pack";
+import {
+  TOPIC_STRATEGY_PACK_VERSION,
+  resolveTopicStrategyByWeekday,
+} from "@/lib/content-ops/packs/topic-strategy-pack";
+
+export const ACTIVE_CONTENT_PACK_VERSION = "v1.0.0";
+
+export function resolveActiveContentPacks(date = new Date()) {
+  const topic = resolveTopicStrategyByWeekday(date);
+  return {
+    activeVersion: ACTIVE_CONTENT_PACK_VERSION,
+    versions: {
+      topicStrategy: TOPIC_STRATEGY_PACK_VERSION,
+      newsletterPrompt: NEWSLETTER_PROMPT_PACK_VERSION,
+      blogPrompt: BLOG_PROMPT_PACK_VERSION,
+    },
+    topic,
+  };
+}
+
+export function buildDraftsFromActivePacks(params: {
+  sourceBullets: string[];
+  date?: Date;
+}) {
+  const resolved = resolveActiveContentPacks(params.date ?? new Date());
+  const newsletter = buildNewsletterDraftFromPack({
+    topic: resolved.topic,
+    sourceBullets: params.sourceBullets,
+  });
+  const blog = buildBlogDraftFromPack({
+    topic: resolved.topic,
+    sourceBullets: params.sourceBullets,
+  });
+  return { resolved, newsletter, blog };
+}

--- a/src/lib/content-ops/packs/topic-strategy-pack.ts
+++ b/src/lib/content-ops/packs/topic-strategy-pack.ts
@@ -1,0 +1,40 @@
+export type AudienceSegment = "operator" | "team_lead" | "founder";
+
+export type TopicStrategyEntry = {
+  id: string;
+  audience: AudienceSegment;
+  titlePattern: string;
+  questionPattern: string;
+  whyNowPattern: string;
+};
+
+export const TOPIC_STRATEGY_PACK_VERSION = "v1.0.0";
+
+export const TOPIC_STRATEGY_PACK: readonly TopicStrategyEntry[] = [
+  {
+    id: "ops-reliability",
+    audience: "operator",
+    titlePattern: "AI automation reliability playbook",
+    questionPattern: "What can break first when teams automate too quickly?",
+    whyNowPattern: "Model/tool release velocity is increasing faster than ops safeguards.",
+  },
+  {
+    id: "cost-control",
+    audience: "team_lead",
+    titlePattern: "AI cost control without delivery slowdown",
+    questionPattern: "Where does hidden AI spend usually leak first?",
+    whyNowPattern: "Teams are scaling usage before unit economics are stabilized.",
+  },
+  {
+    id: "execution-advantage",
+    audience: "founder",
+    titlePattern: "Execution moat for AI-enabled teams",
+    questionPattern: "How do small teams turn AI speed into compounding advantage?",
+    whyNowPattern: "The market is shifting from model novelty to execution quality.",
+  },
+];
+
+export function resolveTopicStrategyByWeekday(date = new Date()): TopicStrategyEntry {
+  const index = date.getUTCDay() % TOPIC_STRATEGY_PACK.length;
+  return TOPIC_STRATEGY_PACK[index] ?? TOPIC_STRATEGY_PACK[0];
+}

--- a/src/lib/content-ops/pipeline-runner.ts
+++ b/src/lib/content-ops/pipeline-runner.ts
@@ -6,6 +6,7 @@ import {
   BLOG_TEMPLATE_VERSION,
   NEWSLETTER_TEMPLATE_VERSION,
 } from "@/lib/content-ops/locale-template-config";
+import { buildDraftsFromActivePacks } from "@/lib/content-ops/packs/pack-registry";
 import { evaluateReviewGate } from "@/lib/content-ops/review-gate";
 import type { Database } from "@/types/database.types";
 
@@ -305,28 +306,23 @@ export async function runDraftGeneratePipeline(runId: string): Promise<{
     return `${index + 1}. [${title}](${m.source_url})`;
   });
 
-  const digestBody = [
-    "## Daily AI Digest",
-    "",
-    "Curated updates from active sources:",
-    "",
-    ...digestLines,
-  ].join("\n");
-
-  const digestTitle = `Daily AI Digest — ${new Date().toISOString().slice(0, 10)}`;
+  const generated = buildDraftsFromActivePacks({ sourceBullets: digestLines });
   const { data: newsletterItem, error: nErr } = await admin
     .from("content_items")
     .insert({
       type: "newsletter",
-      title: digestTitle,
+      title: generated.newsletter.title,
       locale: "en",
-      summary: "Auto-generated digest draft from recent source ingest.",
-      body_markdown: digestBody,
+      summary: generated.newsletter.summary,
+      body_markdown: generated.newsletter.bodyMarkdown,
       status: "draft",
       metadata: {
         generate: {
           run_id: runId,
-          mode: "digest",
+          mode: "pack_registry",
+          pack_version: generated.resolved.activeVersion,
+          pack_versions: generated.resolved.versions,
+          topic_strategy_id: generated.resolved.topic.id,
         },
       },
     })
@@ -334,6 +330,28 @@ export async function runDraftGeneratePipeline(runId: string): Promise<{
     .single();
 
   if (nErr || !newsletterItem?.id) return { createdItems: 0 };
+
+  const { data: blogItem, error: bErr } = await admin
+    .from("content_items")
+    .insert({
+      type: "blog",
+      title: generated.blog.title,
+      locale: "en",
+      summary: generated.blog.summary,
+      body_markdown: generated.blog.bodyMarkdown,
+      status: "draft",
+      metadata: {
+        generate: {
+          run_id: runId,
+          mode: "pack_registry",
+          pack_version: generated.resolved.activeVersion,
+          pack_versions: generated.resolved.versions,
+          topic_strategy_id: generated.resolved.topic.id,
+        },
+      },
+    })
+    .select("id")
+    .single();
 
   for (const map of latestMaps) {
     await admin.from("content_item_source_map").insert({
@@ -346,9 +364,21 @@ export async function runDraftGeneratePipeline(runId: string): Promise<{
         `generated:${newsletterItem.id}:${map.source_id}:${map.source_url}`,
       ),
     });
+    if (!bErr && blogItem?.id) {
+      await admin.from("content_item_source_map").insert({
+        content_item_id: blogItem.id,
+        source_id: map.source_id,
+        source_url: map.source_url,
+        source_title: map.source_title,
+        source_published_at: map.source_published_at,
+        snippet_hash: hashSnippet(
+          `generated:${blogItem.id}:${map.source_id}:${map.source_url}`,
+        ),
+      });
+    }
   }
 
-  return { createdItems: 1 };
+  return { createdItems: bErr || !blogItem?.id ? 1 : 2 };
 }
 
 export async function runReviewGatePipeline(runId: string): Promise<{

--- a/src/lib/content-ops/review-gate.ts
+++ b/src/lib/content-ops/review-gate.ts
@@ -1,4 +1,5 @@
 export const MIN_REVIEW_BODY_CHARS = 320;
+export const MIN_REVIEW_QUALITY_SCORE = 12;
 
 export type ReviewGateInput = {
   bodyMarkdown: string;
@@ -8,7 +9,20 @@ export type ReviewGateInput = {
 export type ReviewGateReason =
   | "source_links_missing"
   | "body_too_short"
-  | "possible_overcopy_detected";
+  | "possible_overcopy_detected"
+  | "low_relevance"
+  | "low_novelty"
+  | "low_specificity"
+  | "low_evidence"
+  | "low_actionability";
+
+export type ReviewGateRubric = {
+  relevance: number;
+  novelty: number;
+  specificity: number;
+  evidence: number;
+  actionability: number;
+};
 
 export type ReviewGateResult = {
   passed: boolean;
@@ -19,6 +33,8 @@ export type ReviewGateResult = {
     longLineCount: number;
     codeFenceLargeBlockDetected: boolean;
     linkOnlyPatternDetected: boolean;
+    qualityScore: number;
+    rubric: ReviewGateRubric;
   };
 };
 
@@ -50,6 +66,44 @@ function detectLinkOnlyPattern(markdown: string, sourceLinkCount: number): boole
   return sourceLinkCount > 0 && linkCount >= sourceLinkCount && plainTextChars < 200;
 }
 
+function countMatches(text: string, regex: RegExp): number {
+  return (text.match(regex) ?? []).length;
+}
+
+function scoreRubric(markdown: string, sourceLinkCount: number): ReviewGateRubric {
+  const normalized = markdown.toLowerCase();
+  const plainText = toPlainText(markdown).toLowerCase();
+  const headingCount = countMatches(markdown, /^##\s+/gm);
+  const listCount = countMatches(markdown, /^\s*[-*]\s+/gm);
+  const numberedCount = countMatches(markdown, /^\s*\d+\.\s+/gm);
+  const comparisonSignals = countMatches(
+    normalized,
+    /\b(vs|versus|trade-off|tradeoff|compare|comparison)\b/g,
+  );
+  const evidenceSignals = countMatches(plainText, /\b(source|according|report|data)\b/g);
+  const actionSignals = countMatches(
+    plainText,
+    /\b(checklist|next step|action|implement|do this|owner)\b/g,
+  );
+
+  const relevance = Math.min(
+    5,
+    1 + (headingCount >= 3 ? 1 : 0) + (plainText.includes("operator") ? 1 : 0) + (actionSignals > 0 ? 2 : 0),
+  );
+  const novelty = Math.min(5, 1 + (comparisonSignals >= 1 ? 2 : 0) + (plainText.includes("why now") ? 2 : 0));
+  const specificity = Math.min(
+    5,
+    1 + (listCount >= 3 ? 2 : 0) + (numberedCount >= 2 ? 2 : 0),
+  );
+  const evidence = Math.min(5, 1 + (sourceLinkCount >= 2 ? 2 : sourceLinkCount >= 1 ? 1 : 0) + (evidenceSignals >= 1 ? 2 : 0));
+  const actionability = Math.min(
+    5,
+    1 + (actionSignals >= 2 ? 2 : actionSignals >= 1 ? 1 : 0) + (numberedCount >= 2 ? 2 : 0),
+  );
+
+  return { relevance, novelty, specificity, evidence, actionability };
+}
+
 export function evaluateReviewGate(input: ReviewGateInput): ReviewGateResult {
   const reasons: ReviewGateReason[] = [];
   const bodyChars = toPlainText(input.bodyMarkdown).length;
@@ -59,6 +113,13 @@ export function evaluateReviewGate(input: ReviewGateInput): ReviewGateResult {
     input.bodyMarkdown,
     input.sourceLinkCount,
   );
+  const rubric = scoreRubric(input.bodyMarkdown, input.sourceLinkCount);
+  const qualityScore =
+    rubric.relevance +
+    rubric.novelty +
+    rubric.specificity +
+    rubric.evidence +
+    rubric.actionability;
 
   if (input.sourceLinkCount < 1) {
     reasons.push("source_links_missing");
@@ -68,6 +129,14 @@ export function evaluateReviewGate(input: ReviewGateInput): ReviewGateResult {
   }
   if (codeFenceLargeBlockDetected || longLineCount >= 4 || linkOnlyPatternDetected) {
     reasons.push("possible_overcopy_detected");
+  }
+  if (rubric.relevance < 2) reasons.push("low_relevance");
+  if (rubric.novelty < 2) reasons.push("low_novelty");
+  if (rubric.specificity < 2) reasons.push("low_specificity");
+  if (rubric.evidence < 2) reasons.push("low_evidence");
+  if (rubric.actionability < 2) reasons.push("low_actionability");
+  if (qualityScore < MIN_REVIEW_QUALITY_SCORE) {
+    if (!reasons.includes("low_specificity")) reasons.push("low_specificity");
   }
 
   return {
@@ -79,6 +148,8 @@ export function evaluateReviewGate(input: ReviewGateInput): ReviewGateResult {
       longLineCount,
       codeFenceLargeBlockDetected,
       linkOnlyPatternDetected,
+      qualityScore,
+      rubric,
     },
   };
 }

--- a/src/lib/content-ops/run-orchestrator.ts
+++ b/src/lib/content-ops/run-orchestrator.ts
@@ -1,0 +1,137 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  runDraftGeneratePipeline,
+  runIngestPipeline,
+  runPublishPipeline,
+  runReviewGatePipeline,
+} from "@/lib/content-ops/pipeline-runner";
+import {
+  CONTENT_OPS_RUN_SEQUENCE,
+  type ContentOpsRunType,
+} from "@/lib/content-ops/automation-config";
+import { maybeEmitContentOpsAlert } from "@/lib/content-ops/alerting";
+import type { Json } from "@/types/database.types";
+
+type ExecuteContentOpsRunParams = {
+  runType: ContentOpsRunType;
+  triggerType: "manual" | "scheduled" | "api";
+  initiatedBy?: string | null;
+  metadata?: Record<string, unknown>;
+};
+
+function getWarningSummary(metadata: Json | null): string | null {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return null;
+  const obj = metadata as Record<string, unknown>;
+  const maybeFailures = obj.failureMessages;
+  if (Array.isArray(maybeFailures) && maybeFailures.length > 0) {
+    const first = maybeFailures.find((v) => typeof v === "string");
+    return typeof first === "string" ? `warning:${first}` : "warning:partial_failures";
+  }
+  const maybeFailedSources = obj.failedSources;
+  if (typeof maybeFailedSources === "number" && maybeFailedSources > 0) {
+    return `warning:${maybeFailedSources}_sources_failed`;
+  }
+  const maybeFailedCount = obj.failedCount;
+  if (typeof maybeFailedCount === "number" && maybeFailedCount > 0) {
+    return `warning:${maybeFailedCount}_items_failed`;
+  }
+  return null;
+}
+
+function shouldForceFailedStatus(runType: ContentOpsRunType, metadata: Json | null): boolean {
+  if (runType !== "publish" && runType !== "publish_retry_failed") return false;
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return false;
+  const failedCount = (metadata as Record<string, unknown>).failedCount;
+  return typeof failedCount === "number" && failedCount > 0;
+}
+
+export async function executeContentOpsRun(
+  params: ExecuteContentOpsRunParams,
+): Promise<{ runId: string; status: "succeeded" | "failed"; metadata: Json | null }> {
+  const nowIso = new Date().toISOString();
+  const admin = createAdminClient();
+  const { data: runRow, error } = await admin
+    .from("content_runs")
+    .insert({
+      run_type: params.runType,
+      status: "running",
+      trigger_type: params.triggerType,
+      initiated_by: params.initiatedBy ?? null,
+      started_at: nowIso,
+      metadata: (params.metadata ?? {}) as Json,
+    })
+    .select("id")
+    .single();
+
+  if (error || !runRow?.id) {
+    throw new Error(`run_create_failed:${error?.message ?? "unknown"}`);
+  }
+
+  let status: "succeeded" | "failed" = "succeeded";
+  let metadata: Json | null = null;
+  let errorSummary: string | null = null;
+
+  try {
+    if (params.runType === "ingest") {
+      metadata = await runIngestPipeline(runRow.id);
+    } else if (params.runType === "draft_generate") {
+      metadata = await runDraftGeneratePipeline(runRow.id);
+    } else if (params.runType === "review_gate") {
+      metadata = await runReviewGatePipeline(runRow.id);
+    } else if (params.runType === "publish") {
+      metadata = await runPublishPipeline();
+    } else if (params.runType === "publish_retry_failed") {
+      metadata = await runPublishPipeline({ retryFailedOnly: true });
+    }
+  } catch (e) {
+    status = "failed";
+    errorSummary = e instanceof Error ? e.message : "unknown";
+  }
+
+  if (!errorSummary) {
+    errorSummary = getWarningSummary(metadata);
+  }
+  if (shouldForceFailedStatus(params.runType, metadata)) {
+    status = "failed";
+  }
+
+  const alert = await maybeEmitContentOpsAlert({
+    runId: runRow.id,
+    runType: params.runType,
+    status,
+    metadata,
+  });
+  const finalMetadata =
+    metadata && typeof metadata === "object" && !Array.isArray(metadata)
+      ? ({ ...(metadata as Record<string, unknown>), alert } as Json)
+      : ({ result: metadata, alert } as Json);
+
+  await admin
+    .from("content_runs")
+    .update({
+      status,
+      ended_at: new Date().toISOString(),
+      metadata: finalMetadata,
+      error_summary: errorSummary,
+    })
+    .eq("id", runRow.id);
+
+  return { runId: runRow.id, status, metadata: finalMetadata };
+}
+
+export async function runContentOpsScenario(params: {
+  triggerType: "manual" | "scheduled" | "api";
+  initiatedBy?: string | null;
+  metadata?: Record<string, unknown>;
+  sequence?: readonly ContentOpsRunType[];
+}): Promise<void> {
+  const sequence = params.sequence ?? (CONTENT_OPS_RUN_SEQUENCE as readonly ContentOpsRunType[]);
+  for (const runType of sequence) {
+    await executeContentOpsRun({
+      runType,
+      triggerType: params.triggerType,
+      initiatedBy: params.initiatedBy ?? null,
+      metadata: params.metadata,
+    });
+  }
+}

--- a/tests/unit/content-packs.test.ts
+++ b/tests/unit/content-packs.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACTIVE_CONTENT_PACK_VERSION,
+  buildDraftsFromActivePacks,
+  resolveActiveContentPacks,
+} from "@/lib/content-ops/packs/pack-registry";
+
+describe("content ops pack registry", () => {
+  it("resolves active versions and topic strategy", () => {
+    const resolved = resolveActiveContentPacks(new Date("2026-05-01T00:00:00.000Z"));
+    expect(resolved.activeVersion).toBe(ACTIVE_CONTENT_PACK_VERSION);
+    expect(resolved.versions.blogPrompt).toMatch(/^v/);
+    expect(resolved.topic.id.length).toBeGreaterThan(0);
+  });
+
+  it("builds newsletter and blog drafts with source section", () => {
+    const drafts = buildDraftsFromActivePacks({
+      sourceBullets: ["1. [Alpha](https://example.com/a)", "2. [Beta](https://example.com/b)"],
+      date: new Date("2026-05-01T00:00:00.000Z"),
+    });
+    expect(drafts.newsletter.bodyMarkdown).toContain("## Sources");
+    expect(drafts.newsletter.bodyMarkdown).toContain("[Alpha]");
+    expect(drafts.blog.bodyMarkdown).toContain("## Execution checklist (this week)");
+    expect(drafts.blog.title.length).toBeGreaterThan(20);
+  });
+});

--- a/tests/unit/review-gate.test.ts
+++ b/tests/unit/review-gate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   evaluateReviewGate,
   MIN_REVIEW_BODY_CHARS,
+  MIN_REVIEW_QUALITY_SCORE,
 } from "@/lib/content-ops/review-gate";
 
 describe("evaluateReviewGate", () => {
@@ -38,8 +39,16 @@ describe("evaluateReviewGate", () => {
   it("passes for valid content with source and enough narrative", () => {
     const result = evaluateReviewGate({
       bodyMarkdown: `
-## Summary
-${"This draft summarizes trends and adds operator-focused interpretation. ".repeat(10)}
+## Why now
+${"This draft summarizes trends and adds operator-focused interpretation for workflow operators. ".repeat(8)}
+
+## Comparison
+Teams usually optimize speed first vs reliability. This post highlights the trade-off.
+
+## Action checklist
+1. Add one rollback owner.
+2. Add one failure-class dashboard.
+3. Implement one weekly review ritual.
 
 ## Source
 - [Example source](https://example.com/article)
@@ -48,5 +57,17 @@ ${"This draft summarizes trends and adds operator-focused interpretation. ".repe
     });
     expect(result.passed).toBe(true);
     expect(result.reasons).toEqual([]);
+    expect(result.metrics.qualityScore).toBeGreaterThanOrEqual(MIN_REVIEW_QUALITY_SCORE);
+    expect(result.metrics.rubric.actionability).toBeGreaterThan(1);
+  });
+
+  it("fails when rubric quality is too low even with links", () => {
+    const result = evaluateReviewGate({
+      bodyMarkdown: "## Note\n\n- [Source](https://example.com)\n\nThis happened.",
+      sourceLinkCount: 1,
+    });
+    expect(result.passed).toBe(false);
+    expect(result.metrics.qualityScore).toBeLessThan(MIN_REVIEW_QUALITY_SCORE);
+    expect(result.reasons).toContain("low_specificity");
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "crons": [
+    {
+      "path": "/api/content-ops/automation-run?scenario=daily_generation&source=vercel-cron",
+      "schedule": "30 12 * * 1-5"
+    },
+    {
+      "path": "/api/content-ops/automation-run?scenario=publish_window&source=vercel-cron",
+      "schedule": "0 15 * * 1-5"
+    },
+    {
+      "path": "/api/content-ops/automation-run?scenario=retry_window&source=vercel-cron",
+      "schedule": "30 18 * * 1-5"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add content-ops runtime orchestration for scheduled execution with Cursor-first mode, Vercel cron fallback, and secured automation run endpoint
- introduce versioned topic/prompt/template pack registry and connect `draft_generate` to produce newsletter + blog drafts with generation metadata
- upgrade review/ops reliability with rubric-based gate scoring, queue SLA signals, alerting hooks, and runbook/dry-run updates

## Test plan
- [x] `pnpm eslint \"src/lib/content-ops/automation-config.ts\" \"src/lib/content-ops/run-orchestrator.ts\" \"src/app/api/content-ops/automation-run/route.ts\" \"src/lib/content-ops/packs/topic-strategy-pack.ts\" \"src/lib/content-ops/packs/newsletter-prompt-pack.ts\" \"src/lib/content-ops/packs/blog-prompt-pack.ts\" \"src/lib/content-ops/packs/pack-registry.ts\" \"src/lib/content-ops/review-gate.ts\" \"src/lib/content-ops/pipeline-runner.ts\" \"src/lib/content-ops/alerting.ts\" \"src/actions/admin-content-ops.ts\" \"src/app/(admin)/admin/content-queue/page.tsx\" \"src/app/(admin)/admin/runs/page.tsx\" \"scripts/content-ops-smoke.ts\" \"scripts/content-ops-cleanup.ts\" \"tests/unit/review-gate.test.ts\" \"tests/unit/content-packs.test.ts\"`
- [x] `pnpm typecheck`
- [x] `pnpm test -- tests/unit/review-gate.test.ts tests/unit/content-packs.test.ts`
- [x] `pnpm content-ops:smoke:dry-run && pnpm content-ops:cleanup:dry-run`


Made with [Cursor](https://cursor.com)