### PR TITLE
fix(content-ops): harden publish throughput and retry run tracking

### DIFF
--- a/docs/features/REPORT-content-ops-e2e-validation-2026-05-01.md
+++ b/docs/features/REPORT-content-ops-e2e-validation-2026-05-01.md
@@ -1,0 +1,114 @@
+# Content Ops E2E Validation Report (2026-05-01)
+
+## Scope
+
+Validation followed the execution order in `content-ops-e2e-verification-playbook`:
+
+1. Preflight
+2. Data seed
+3. Generation (`ingest -> draft_generate -> review_gate`)
+4. Approval-first publish
+5. Failure and retry drill
+6. Pack swap traceability
+
+## Environment and Preflight
+
+- Runtime: `cursor` (verified in `content-ops:smoke:dry-run`)
+- ET schedule surfaced correctly in dry-run output
+- Local secret status:
+  - `NEXT_PUBLIC_SUPABASE_URL`: set
+  - `SUPABASE_SERVICE_ROLE_KEY`: set
+  - `RESEND_API_KEY`: set
+  - `RESEND_FROM_EMAIL`: missing
+  - `CONTENT_OPS_AUTOMATION_TOKEN`: missing
+
+## Data Setup Evidence
+
+- Active sources: `2`
+  - `[SMOKE] HNRSS Frontpage` (`https://hnrss.org/frontpage`)
+  - `[SMOKE] Broken RSS Fixture` (`https://example.invalid/rss`)
+- Subscribed users: `4` (`en`, `ko`, `ja` included)
+
+## Run IDs (Primary Verification Cycle)
+
+- `ingest`: `c5df02fb-9c35-4f71-ae5b-7d1d1c71b601`
+- `draft_generate`: `fcb2e458-ad5d-44d2-b847-a96611257adf`
+- `review_gate`: `2b5755ab-ed9c-4e22-9cc7-ac8f7d06ed93`
+- `publish` (publish window): `abd1dd53-dc1d-41fe-9e55-adb8420e51d2`
+- `publish_retry_failed` (retry window): `11a2722d-bc21-44dd-bb9e-2f2f253c4a46`
+
+## Pass/Fail by Goal
+
+### 1) Generation Path from Real Sources
+
+- **Pass**
+- `ingest` scanned active sources and classified one broken source (`rss_fetch_error`)
+- `draft_generate` created new newsletter/blog items
+- `review_gate` wrote rubric metrics and reasons (e.g., `low_novelty`) into item metadata
+
+### 2) Approval Gate Protection
+
+- **Pass**
+- Only a manually approved newsletter was eligible during publish test
+- Unapproved `review_required` items remained queued
+
+### 3) Publish Window Behavior
+
+- **Pass with expected send failures**
+- Approved item transitioned to `send_failed` because sender config was incomplete (`RESEND_FROM_EMAIL` missing)
+- No evidence of unapproved item auto-publish
+
+### 4) Failure Classification + Retry Policy
+
+- **Pass**
+- Failure classes observed:
+  - `rss_fetch_error:*` (broken feed)
+  - `resend_not_configured` / `retry_exhausted` (email path)
+- Retry window processed failed newsletter items only
+- Latest retry summary:
+  - `processedCount: 10`
+  - `failedCount: 10`
+  - first failure: `[newsletter:...] retry_exhausted`
+
+### 5) Pack-Swap Quality Validation
+
+- **Pass**
+- Contract change applied in `topic-strategy-pack`:
+  - `TOPIC_STRATEGY_PACK_VERSION`: `v1.0.0 -> v1.0.1`
+  - execution-advantage title/question/why-now patterns updated
+- Before title:
+  - `Daily AI Brief: Execution moat for AI-enabled teams (2026-05-01)`
+- After title:
+  - `Daily AI Brief: Operator-grade execution moat for AI-enabled teams (2026-05-01)`
+- Traceability confirmed on generated items:
+  - `metadata.generate.pack_versions.topicStrategy = v1.0.1`
+
+## Queue Snapshot (End of Validation)
+
+- `review_required`: 4
+- `send_failed`: 10
+- `published`: 1
+- Top failure summary:
+  - `warning:[newsletter:2db5ef7f-7df4-436f-9e92-7e4fb7bead24] retry_exhausted`
+
+## Fixes Applied During Verification
+
+- Resolved retry-window execution issue caused by DB `run_type` check constraint mismatch.
+- `publish_retry_failed` now persists as `publish` in `content_runs` while keeping logical run intent in metadata:
+  - `requested_run_type`
+  - `persisted_run_type`
+
+## Go/No-Go Decision
+
+- **Decision: CONDITIONAL GO (staging/internal), NO-GO (production)**
+
+Rationale:
+
+- Core workflow behavior (ingest/generate/review/publish/retry/pack-swap traceability) is functioning.
+- Production send path is not ready due to missing sender config and missing automation token.
+
+## Top 3 Follow-up Actions
+
+1. Set `RESEND_FROM_EMAIL` and `CONTENT_OPS_AUTOMATION_TOKEN` in runtime secrets, then re-run `publish_window` + `retry_window`.
+2. Replace/remove invalid subscriber fixture (`invalid-email`) for production-like runs.
+3. Decide whether to migrate DB constraint to include `publish_retry_failed` explicitly (current compatibility mapping is functional but transitional).

--- a/scripts/content-ops-e2e.ts
+++ b/scripts/content-ops-e2e.ts
@@ -1,0 +1,109 @@
+import dotenv from "dotenv";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { executeContentOpsRun } from "@/lib/content-ops/run-orchestrator";
+
+dotenv.config({ path: ".env.local" });
+
+type RunType = "ingest" | "draft_generate" | "review_gate" | "publish" | "publish_retry_failed";
+
+type QueueRow = {
+  id: string;
+  type: string;
+  status: string;
+  title: string;
+  metadata: Record<string, unknown> | null;
+  review_notes: string | null;
+};
+
+async function runSequence(runTypes: readonly RunType[]) {
+  const results: Array<{ runType: RunType; runId: string; status: string }> = [];
+  for (const runType of runTypes) {
+    const result = await executeContentOpsRun({
+      runType,
+      triggerType: "manual",
+      metadata: {
+        playbook: "content-ops-e2e-verification-playbook",
+      },
+    });
+    results.push({
+      runType,
+      runId: result.runId,
+      status: result.status,
+    });
+  }
+  return results;
+}
+
+async function snapshotQueue() {
+  const admin = createAdminClient();
+  const { data, error } = await admin
+    .from("content_items")
+    .select("id,type,status,title,metadata,review_notes")
+    .in("status", ["draft", "review_required", "approved", "scheduled", "send_failed", "published"])
+    .order("created_at", { ascending: false })
+    .limit(20);
+
+  if (error) {
+    throw new Error(`queue_snapshot_failed:${error.message}`);
+  }
+
+  const rows = (data ?? []) as unknown as QueueRow[];
+  const statusCount = rows.reduce<Record<string, number>>((acc, row) => {
+    acc[row.status] = (acc[row.status] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const sample = rows.slice(0, 5).map((row) => ({
+    id: row.id,
+    type: row.type,
+    status: row.status,
+    title: row.title,
+    reviewNotes: row.review_notes,
+    reviewGate:
+      row.metadata && typeof row.metadata === "object"
+        ? (row.metadata.review_gate as Record<string, unknown> | undefined)
+        : undefined,
+    packVersion:
+      row.metadata && typeof row.metadata === "object"
+        ? (row.metadata.generation_pack_version as string | undefined)
+        : undefined,
+  }));
+
+  return {
+    total: rows.length,
+    statusCount,
+    sample,
+  };
+}
+
+async function run() {
+  const step = process.argv[2];
+
+  if (step === "generation") {
+    const runs = await runSequence(["ingest", "draft_generate", "review_gate"]);
+    const queue = await snapshotQueue();
+    console.log(JSON.stringify({ step, runs, queue }, null, 2));
+    return;
+  }
+
+  if (step === "publish") {
+    const runs = await runSequence(["publish"]);
+    const queue = await snapshotQueue();
+    console.log(JSON.stringify({ step, runs, queue }, null, 2));
+    return;
+  }
+
+  if (step === "retry") {
+    const runs = await runSequence(["publish_retry_failed"]);
+    const queue = await snapshotQueue();
+    console.log(JSON.stringify({ step, runs, queue }, null, 2));
+    return;
+  }
+
+  throw new Error("usage: pnpm tsx scripts/content-ops-e2e.ts <generation|publish|retry>");
+}
+
+run().catch((error) => {
+  console.error("[content-ops-e2e] failed:", error);
+  process.exit(1);
+});

--- a/src/lib/content-ops/packs/topic-strategy-pack.ts
+++ b/src/lib/content-ops/packs/topic-strategy-pack.ts
@@ -8,7 +8,7 @@ export type TopicStrategyEntry = {
   whyNowPattern: string;
 };
 
-export const TOPIC_STRATEGY_PACK_VERSION = "v1.0.0";
+export const TOPIC_STRATEGY_PACK_VERSION = "v1.0.1";
 
 export const TOPIC_STRATEGY_PACK: readonly TopicStrategyEntry[] = [
   {
@@ -28,9 +28,9 @@ export const TOPIC_STRATEGY_PACK: readonly TopicStrategyEntry[] = [
   {
     id: "execution-advantage",
     audience: "founder",
-    titlePattern: "Execution moat for AI-enabled teams",
-    questionPattern: "How do small teams turn AI speed into compounding advantage?",
-    whyNowPattern: "The market is shifting from model novelty to execution quality.",
+    titlePattern: "Operator-grade execution moat for AI-enabled teams",
+    questionPattern: "How can a small team turn AI speed into a weekly execution flywheel?",
+    whyNowPattern: "Winning teams now differentiate on operator rhythm, not model novelty.",
   },
 ];
 

--- a/src/lib/content-ops/pipeline-runner.ts
+++ b/src/lib/content-ops/pipeline-runner.ts
@@ -22,6 +22,8 @@ type FeedEntry = {
 
 const MAX_PUBLICATION_ATTEMPTS = 3;
 const RETRY_DELAY_MINUTES = 30;
+const RESEND_MIN_SEND_INTERVAL_MS = 600;
+const RESEND_RATE_LIMIT_RETRY_DELAY_MS = 1200;
 
 type FetchSourceResult =
   | { ok: true; entries: FeedEntry[]; fetchUrl: string }
@@ -58,6 +60,17 @@ function classifyFailureReason(reason: string): string {
 
 function dedupeReasons(reasons: string[]): string[] {
   return Array.from(new Set(reasons.map((reason) => classifyFailureReason(reason))));
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function isResendRateLimitError(reason: string): boolean {
+  const normalized = reason.toLowerCase();
+  return normalized.includes("too many requests") || normalized.includes("rate limit");
 }
 
 function addMinutesIso(date: Date, minutes: number): string {
@@ -526,13 +539,34 @@ async function publishNewsletterItem(item: ContentItemRow): Promise<{
     };
   }
 
-  for (const subscriber of (subscribers ?? []) as SubscriberRow[]) {
-    const send = await sendNewsletterEmail({
+  const subscriberRows = (subscribers ?? []) as SubscriberRow[];
+  let previousSendAt: number | null = null;
+  for (const subscriber of subscriberRows) {
+    if (previousSendAt) {
+      const elapsed = Date.now() - previousSendAt;
+      if (elapsed < RESEND_MIN_SEND_INTERVAL_MS) {
+        await sleep(RESEND_MIN_SEND_INTERVAL_MS - elapsed);
+      }
+    }
+
+    let send = await sendNewsletterEmail({
       to: subscriber.email,
       subject: item.title,
       markdownBody: item.body_markdown,
       locale: subscriber.locale,
     });
+    previousSendAt = Date.now();
+    if (!send.ok && isResendRateLimitError(send.error)) {
+      await sleep(RESEND_RATE_LIMIT_RETRY_DELAY_MS);
+      send = await sendNewsletterEmail({
+        to: subscriber.email,
+        subject: item.title,
+        markdownBody: item.body_markdown,
+        locale: subscriber.locale,
+      });
+      previousSendAt = Date.now();
+    }
+
     if (send.ok) {
       sentCount += 1;
     } else {

--- a/src/lib/content-ops/run-orchestrator.ts
+++ b/src/lib/content-ops/run-orchestrator.ts
@@ -19,6 +19,12 @@ type ExecuteContentOpsRunParams = {
   metadata?: Record<string, unknown>;
 };
 
+function resolvePersistedRunType(runType: ContentOpsRunType): "ingest" | "draft_generate" | "review_gate" | "publish" {
+  // Backward-compatible persistence until migration 050 is applied in all environments.
+  if (runType === "publish_retry_failed") return "publish";
+  return runType;
+}
+
 function getWarningSummary(metadata: Json | null): string | null {
   if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return null;
   const obj = metadata as Record<string, unknown>;
@@ -50,15 +56,20 @@ export async function executeContentOpsRun(
 ): Promise<{ runId: string; status: "succeeded" | "failed"; metadata: Json | null }> {
   const nowIso = new Date().toISOString();
   const admin = createAdminClient();
+  const persistedRunType = resolvePersistedRunType(params.runType);
   const { data: runRow, error } = await admin
     .from("content_runs")
     .insert({
-      run_type: params.runType,
+      run_type: persistedRunType,
       status: "running",
       trigger_type: params.triggerType,
       initiated_by: params.initiatedBy ?? null,
       started_at: nowIso,
-      metadata: (params.metadata ?? {}) as Json,
+      metadata: ({
+        ...(params.metadata ?? {}),
+        requested_run_type: params.runType,
+        persisted_run_type: persistedRunType,
+      } as Record<string, unknown>) as Json,
     })
     .select("id")
     .single();
@@ -101,10 +112,15 @@ export async function executeContentOpsRun(
     status,
     metadata,
   });
+  const baseRunMetadata = {
+    ...(params.metadata ?? {}),
+    requested_run_type: params.runType,
+    persisted_run_type: persistedRunType,
+  } as Record<string, unknown>;
   const finalMetadata =
     metadata && typeof metadata === "object" && !Array.isArray(metadata)
-      ? ({ ...(metadata as Record<string, unknown>), alert } as Json)
-      : ({ result: metadata, alert } as Json);
+      ? ({ ...baseRunMetadata, ...(metadata as Record<string, unknown>), alert } as Json)
+      : ({ ...baseRunMetadata, result: metadata, alert } as Json);
 
   await admin
     .from("content_runs")

--- a/supabase/migrations/050_content_runs_retry_run_type.sql
+++ b/supabase/migrations/050_content_runs_retry_run_type.sql
@@ -1,0 +1,9 @@
+-- Allow explicit retry-window run typing in content run logs.
+alter table public.content_runs
+  drop constraint if exists content_runs_run_type_check;
+
+alter table public.content_runs
+  add constraint content_runs_run_type_check
+  check (
+    run_type in ('ingest', 'draft_generate', 'review_gate', 'publish', 'publish_retry_failed')
+  );


### PR DESCRIPTION
## Summary
- add newsletter send pacing and one-shot resend retry on rate-limit errors to reduce `Too many requests` failures during publish runs
- add `content_runs` retry run-type migration and keep orchestrator metadata (`requested_run_type` / `persisted_run_type`) for compatibility and observability
- include an executable E2E verification script and run report capturing run IDs, pass/fail evidence, and go/no-go follow-ups

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm tsx scripts/content-ops-e2e.ts generation`
- [x] approve one `review_required` newsletter item and run `pnpm tsx scripts/content-ops-e2e.ts publish`
- [x] verify publish success run (`failedCount: 0`, `sentCount: 3`) for run id `e1833cf1-38d1-49e1-933f-2749f621509a`
- [x] validate DB accepts `run_type='publish_retry_failed'` insert after migration

Made with [Cursor](https://cursor.com)