### PR TITLE
feat(content-ops): strengthen relevance filtering and fresh quality monitoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "content-ops:smoke:dry-run": "pnpm tsx scripts/content-ops-smoke.ts --dry-run",
     "content-ops:cleanup": "pnpm tsx scripts/content-ops-cleanup.ts",
     "content-ops:cleanup:dry-run": "pnpm tsx scripts/content-ops-cleanup.ts --dry-run",
+    "content-ops:quality:monitor": "pnpm tsx scripts/content-ops-quality-monitor.ts",
     "worker:assembly": "tsx workers/video-assembly/run.ts",
     "prepare": "husky"
   },

--- a/scripts/content-ops-quality-monitor.ts
+++ b/scripts/content-ops-quality-monitor.ts
@@ -1,0 +1,43 @@
+import dotenv from "dotenv";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { buildContentQualitySnapshot } from "@/lib/content-ops/quality-monitor";
+
+dotenv.config({ path: ".env.local" });
+
+async function main() {
+  const admin = createAdminClient();
+  const windowDays = Number.parseInt(process.argv[2] ?? "7", 10) || 7;
+
+  const [itemsRes, runsRes] = await Promise.all([
+    admin
+      .from("content_items")
+      .select("id,type,title,status,created_at,updated_at,review_notes,metadata")
+      .order("created_at", { ascending: false })
+      .limit(500),
+    admin
+      .from("content_runs")
+      .select("run_type,status,created_at,error_summary,metadata")
+      .order("created_at", { ascending: false })
+      .limit(500),
+  ]);
+
+  if (itemsRes.error) {
+    throw new Error(`content_items_query_failed:${itemsRes.error.message}`);
+  }
+  if (runsRes.error) {
+    throw new Error(`content_runs_query_failed:${runsRes.error.message}`);
+  }
+
+  const snapshot = buildContentQualitySnapshot({
+    items: (itemsRes.data ?? []) as never[],
+    runs: (runsRes.data ?? []) as never[],
+    windowDays,
+  });
+  console.log(JSON.stringify(snapshot, null, 2));
+}
+
+main().catch((error) => {
+  console.error("[content-ops-quality-monitor] failed:", error);
+  process.exit(1);
+});
+

--- a/src/app/(admin)/admin/content-quality/page.tsx
+++ b/src/app/(admin)/admin/content-quality/page.tsx
@@ -1,0 +1,257 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { Sparkles } from "lucide-react";
+import {
+  listAdminContentQueue,
+  listAdminContentRuns,
+} from "@/actions/admin-content-ops";
+import { buildContentQualitySnapshot } from "@/lib/content-ops/quality-monitor";
+import type { Json } from "@/types/database.types";
+
+export const metadata: Metadata = {
+  title: "Admin | Content Quality Monitor",
+};
+
+export default async function AdminContentQualityPage() {
+  const queueRes = await listAdminContentQueue({ type: "all", status: "all" });
+  const runsRes = await listAdminContentRuns();
+
+  const items = queueRes.ok ? queueRes.rows : [];
+  const runs = runsRes.ok ? runsRes.rows : [];
+  const snapshot = buildContentQualitySnapshot({
+    items,
+    runs,
+    windowDays: 7,
+    freshWindowHours: 24,
+  });
+  const lowQualityItems = buildLowQualityItems(items).slice(0, 12);
+
+  return (
+    <div className="min-h-screen bg-paper-50">
+      <div className="sticky top-0 z-30 flex h-12 items-center justify-between border-b border-ink-100 bg-paper-50 px-6">
+        <div className="flex min-w-0 items-center gap-2">
+          <Sparkles className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+          <h1 className="truncate text-sm font-medium text-ink-900">Content Quality Monitor</h1>
+        </div>
+        <div className="flex items-center gap-3">
+          <Link href="/admin/runs" className="text-xs text-ink-700 transition-colors hover:text-ink-900">
+            Runs
+          </Link>
+          <Link href="/admin" className="text-xs text-vermilion-600 transition-colors hover:text-vermilion-700">
+            Back to admin
+          </Link>
+        </div>
+      </div>
+
+      <div className="max-w-6xl space-y-5 p-6">
+        <p className="text-sm leading-relaxed text-ink-700">
+          주간 품질/발송 지표를 기반으로 생성-검수-개선 루프를 운영합니다. 이 화면을 기준으로
+          팩 수정, 리뷰 우선순위, 발행 안정화 액션을 결정하세요.
+        </p>
+
+        <div className="grid gap-2 md:grid-cols-5">
+          <MetricCard label="7d generated" value={snapshot.generatedCount} tone="neutral" />
+          <MetricCard label="7d published" value={snapshot.publishedCount} tone="success" />
+          <MetricCard label="7d review_required" value={snapshot.reviewRequiredCount} tone="warning" />
+          <MetricCard label="7d send_failed" value={snapshot.sendFailedCount} tone="danger" />
+          <MetricCard
+            label="avg quality score"
+            value={`${snapshot.avgQualityScore} / 25`}
+            tone="neutral"
+          />
+        </div>
+
+        <div className="grid gap-2 md:grid-cols-5">
+          <MetricCard label="24h generated" value={snapshot.freshGeneratedCount} tone="neutral" />
+          <MetricCard label="24h reviewed" value={snapshot.freshReviewedCount} tone="success" />
+          <MetricCard
+            label="24h review_required"
+            value={snapshot.freshReviewRequiredCount}
+            tone="warning"
+          />
+          <MetricCard
+            label="24h avg quality"
+            value={`${snapshot.freshAvgQualityScore} / 25`}
+            tone="neutral"
+          />
+          <MetricCard
+            label="24h min quality"
+            value={snapshot.freshMinQualityScore}
+            tone={snapshot.freshMinQualityScore < 12 ? "danger" : "success"}
+          />
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <section className="border border-ink-100 bg-paper-0 p-4">
+            <h2 className="text-xs font-medium uppercase tracking-wide text-ink-700">
+              Top Quality Issues (7d)
+            </h2>
+            {snapshot.topQualityIssues.length === 0 ? (
+              <p className="mt-2 text-xs text-ink-500">No quality issues detected in this window.</p>
+            ) : (
+              <ul className="mt-2 space-y-1 text-xs text-ink-700">
+                {snapshot.topQualityIssues.map((issue) => (
+                  <li key={issue.reason} className="flex items-center justify-between gap-3">
+                    <span>{issue.reason}</span>
+                    <span className="text-ink-500">{issue.count}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section className="border border-ink-100 bg-paper-0 p-4">
+            <h2 className="text-xs font-medium uppercase tracking-wide text-ink-700">
+              Top Publish Failures (7d)
+            </h2>
+            {snapshot.topPublishFailureReasons.length === 0 ? (
+              <p className="mt-2 text-xs text-ink-500">No publish failures detected in this window.</p>
+            ) : (
+              <ul className="mt-2 space-y-1 text-xs text-ink-700">
+                {snapshot.topPublishFailureReasons.map((issue) => (
+                  <li key={issue.reason} className="flex items-center justify-between gap-3">
+                    <span className="truncate">{issue.reason}</span>
+                    <span className="shrink-0 text-ink-500">{issue.count}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+
+        <section className="border border-ink-100 bg-paper-0 p-4">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-ink-700">
+            Top Quality Issues (Fresh 24h only)
+          </h2>
+          {snapshot.freshTopQualityIssues.length === 0 ? (
+            <p className="mt-2 text-xs text-ink-500">No quality issues detected in fresh generated content.</p>
+          ) : (
+            <ul className="mt-2 space-y-1 text-xs text-ink-700">
+              {snapshot.freshTopQualityIssues.map((issue) => (
+                <li key={issue.reason} className="flex items-center justify-between gap-3">
+                  <span>{issue.reason}</span>
+                  <span className="text-ink-500">{issue.count}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="border border-ink-100 bg-paper-0 p-4">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-ink-700">
+            Improvement Focus (Auto Suggestions)
+          </h2>
+          <ul className="mt-2 space-y-1 text-xs leading-relaxed text-ink-700">
+            {snapshot.improvementFocus.map((focus) => (
+              <li key={focus}>- {focus}</li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="overflow-x-auto border border-ink-100">
+          <table className="w-full text-left text-xs">
+            <thead>
+              <tr className="border-b border-ink-100 bg-paper-50">
+                <th className="p-2 font-medium text-ink-700">Type</th>
+                <th className="p-2 font-medium text-ink-700">Status</th>
+                <th className="p-2 font-medium text-ink-700">Quality</th>
+                <th className="p-2 font-medium text-ink-700">Reasons</th>
+                <th className="p-2 font-medium text-ink-700">Title</th>
+              </tr>
+            </thead>
+            <tbody>
+              {lowQualityItems.length === 0 ? (
+                <tr>
+                  <td className="p-3 text-ink-500" colSpan={5}>
+                    Low-quality candidates not found.
+                  </td>
+                </tr>
+              ) : (
+                lowQualityItems.map((item) => (
+                  <tr key={item.id} className="border-b border-ink-100/80">
+                    <td className="p-2 text-ink-900">{item.type}</td>
+                    <td className="p-2 text-ink-700">{item.status}</td>
+                    <td className="p-2 text-ink-700">{item.qualityScore}</td>
+                    <td className="p-2 text-ink-700">{item.reasons.join(", ") || "-"}</td>
+                    <td className="p-2 text-ink-900">{item.title}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function MetricCard({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string | number;
+  tone: "neutral" | "success" | "warning" | "danger";
+}) {
+  const toneClass =
+    tone === "success"
+      ? "text-emerald-700"
+      : tone === "warning"
+        ? "text-amber-700"
+        : tone === "danger"
+          ? "text-danger"
+          : "text-ink-900";
+  return (
+    <div className="border border-ink-100 bg-paper-0 p-3">
+      <p className="text-[11px] uppercase tracking-wide text-ink-500">{label}</p>
+      <p className={`mt-1 text-sm font-medium ${toneClass}`}>{String(value)}</p>
+    </div>
+  );
+}
+
+function buildLowQualityItems(
+  rows: Array<{
+    id: string;
+    type: "blog" | "newsletter";
+    status: string;
+    title: string;
+    metadata: Json | null;
+  }>,
+) {
+  const out: Array<{
+    id: string;
+    type: "blog" | "newsletter";
+    status: string;
+    title: string;
+    qualityScore: number;
+    reasons: string[];
+  }> = [];
+  for (const row of rows) {
+    const gate = asObject(asObject(row.metadata)?.review_gate);
+    const latest = asObject(gate?.latest);
+    const metrics = asObject(latest?.metrics);
+    const qualityScore = Number(metrics?.qualityScore ?? NaN);
+    const reasonsRaw = latest?.reasons;
+    const reasons = Array.isArray(reasonsRaw)
+      ? reasonsRaw.filter((v): v is string => typeof v === "string")
+      : [];
+    if (!Number.isFinite(qualityScore)) continue;
+    if (qualityScore >= 20 && reasons.length === 0) continue;
+    out.push({
+      id: row.id,
+      type: row.type,
+      status: row.status,
+      title: row.title,
+      qualityScore,
+      reasons,
+    });
+  }
+  return out.sort((a, b) => a.qualityScore - b.qualityScore);
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,6 +1,16 @@
 import Link from "next/link";
 import type { Metadata } from "next";
-import { Activity, BookOpen, Cable, ListChecks, Mail, Newspaper, Shield, Users } from "lucide-react";
+import {
+  Activity,
+  BookOpen,
+  Cable,
+  ListChecks,
+  Mail,
+  Newspaper,
+  Shield,
+  Sparkles,
+  Users,
+} from "lucide-react";
 import { getTranslations } from "next-intl/server";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -53,6 +63,12 @@ export default async function ElevateServiceAdminHomePage() {
       title: "Automation runs",
       desc: "Inspect run logs and queue manual ingest/generate/publish runs.",
       icon: Activity,
+    },
+    {
+      href: "/admin/content-quality",
+      title: "Content quality monitor",
+      desc: "Track quality signals, failure trends, and improvement focus in one place.",
+      icon: Sparkles,
     },
     {
       href: "/admin/subscribers",

--- a/src/lib/content-ops/packs/blog-prompt-pack.ts
+++ b/src/lib/content-ops/packs/blog-prompt-pack.ts
@@ -1,6 +1,6 @@
 import type { TopicStrategyEntry } from "@/lib/content-ops/packs/topic-strategy-pack";
 
-export const BLOG_PROMPT_PACK_VERSION = "v1.0.0";
+export const BLOG_PROMPT_PACK_VERSION = "v1.1.0";
 
 export function buildBlogDraftFromPack(params: {
   topic: TopicStrategyEntry;
@@ -22,6 +22,13 @@ export function buildBlogDraftFromPack(params: {
     "## Core question",
     params.topic.questionPattern,
     "",
+    "## Compare two paths (vs)",
+    params.topic.comparisonPattern,
+    "",
+    "## Contrarian view",
+    params.topic.contrarianPattern,
+    "- Why this contrarian view changes decision quality for operators.",
+    "",
     "## What the latest signals suggest",
     sourceSection,
     "",
@@ -40,8 +47,9 @@ export function buildBlogDraftFromPack(params: {
     "",
     "## Execution checklist (this week)",
     "1. Pick one pipeline stage to harden and define SLO.",
-    "2. Add one observable metric for quality and one for reliability.",
-    "3. Capture one reusable lesson in the runbook.",
+    "2. Run a side-by-side comparison vs the current baseline process.",
+    "3. Add one observable metric for quality and one for reliability.",
+    "4. Capture one reusable lesson in the runbook.",
     "",
     "## Sources",
     sourceSection,

--- a/src/lib/content-ops/packs/newsletter-prompt-pack.ts
+++ b/src/lib/content-ops/packs/newsletter-prompt-pack.ts
@@ -1,6 +1,6 @@
 import type { TopicStrategyEntry } from "@/lib/content-ops/packs/topic-strategy-pack";
 
-export const NEWSLETTER_PROMPT_PACK_VERSION = "v1.0.0";
+export const NEWSLETTER_PROMPT_PACK_VERSION = "v1.1.0";
 
 export function buildNewsletterDraftFromPack(params: {
   topic: TopicStrategyEntry;
@@ -22,6 +22,14 @@ export function buildNewsletterDraftFromPack(params: {
     "## Why this matters now",
     params.topic.whyNowPattern,
     "",
+    "## Trade-off vs default approach",
+    params.topic.comparisonPattern,
+    "- Compare the short-term win against long-term operational drag.",
+    "- Name one trade-off your team is currently underestimating.",
+    "",
+    "## Counter-signal (what most teams miss)",
+    params.topic.contrarianPattern,
+    "",
     "## What changed in the last 24h",
     sourceSection,
     "",
@@ -32,8 +40,9 @@ export function buildNewsletterDraftFromPack(params: {
     "",
     "## This week action checklist",
     "1. Audit one fragile automation path end-to-end.",
-    "2. Add run-level visibility for failure classes.",
-    "3. Define manual override policy before scaling frequency.",
+    "2. Compare current process vs safer alternative and document trade-offs.",
+    "3. Add run-level visibility for failure classes.",
+    "4. Define manual override policy before scaling frequency.",
     "",
     "## Sources",
     sourceSection,

--- a/src/lib/content-ops/packs/pack-registry.ts
+++ b/src/lib/content-ops/packs/pack-registry.ts
@@ -11,7 +11,7 @@ import {
   resolveTopicStrategyByWeekday,
 } from "@/lib/content-ops/packs/topic-strategy-pack";
 
-export const ACTIVE_CONTENT_PACK_VERSION = "v1.0.0";
+export const ACTIVE_CONTENT_PACK_VERSION = "v1.1.0";
 
 export function resolveActiveContentPacks(date = new Date()) {
   const topic = resolveTopicStrategyByWeekday(date);

--- a/src/lib/content-ops/packs/topic-strategy-pack.ts
+++ b/src/lib/content-ops/packs/topic-strategy-pack.ts
@@ -6,9 +6,11 @@ export type TopicStrategyEntry = {
   titlePattern: string;
   questionPattern: string;
   whyNowPattern: string;
+  comparisonPattern: string;
+  contrarianPattern: string;
 };
 
-export const TOPIC_STRATEGY_PACK_VERSION = "v1.0.1";
+export const TOPIC_STRATEGY_PACK_VERSION = "v1.1.0";
 
 export const TOPIC_STRATEGY_PACK: readonly TopicStrategyEntry[] = [
   {
@@ -17,6 +19,9 @@ export const TOPIC_STRATEGY_PACK: readonly TopicStrategyEntry[] = [
     titlePattern: "AI automation reliability playbook",
     questionPattern: "What can break first when teams automate too quickly?",
     whyNowPattern: "Model/tool release velocity is increasing faster than ops safeguards.",
+    comparisonPattern: "Speed-first rollout vs guardrail-first rollout: which fails slower and recovers faster?",
+    contrarianPattern:
+      "Most teams think retries solve reliability. In practice, weak rollback ownership causes larger outages.",
   },
   {
     id: "cost-control",
@@ -24,6 +29,9 @@ export const TOPIC_STRATEGY_PACK: readonly TopicStrategyEntry[] = [
     titlePattern: "AI cost control without delivery slowdown",
     questionPattern: "Where does hidden AI spend usually leak first?",
     whyNowPattern: "Teams are scaling usage before unit economics are stabilized.",
+    comparisonPattern: "Token caps vs workflow redesign: which option protects margin without slowing shipping?",
+    contrarianPattern:
+      "Many teams cut model quality first. Better gains often come from reducing low-value invocation volume.",
   },
   {
     id: "execution-advantage",
@@ -31,6 +39,10 @@ export const TOPIC_STRATEGY_PACK: readonly TopicStrategyEntry[] = [
     titlePattern: "Operator-grade execution moat for AI-enabled teams",
     questionPattern: "How can a small team turn AI speed into a weekly execution flywheel?",
     whyNowPattern: "Winning teams now differentiate on operator rhythm, not model novelty.",
+    comparisonPattern:
+      "Model novelty vs execution cadence: which one compounds into a durable moat over 90 days?",
+    contrarianPattern:
+      "Most founders chase faster generation output. The stronger moat usually comes from tighter review loops.",
   },
 ];
 

--- a/src/lib/content-ops/pipeline-runner.ts
+++ b/src/lib/content-ops/pipeline-runner.ts
@@ -24,6 +24,10 @@ const MAX_PUBLICATION_ATTEMPTS = 3;
 const RETRY_DELAY_MINUTES = 30;
 const RESEND_MIN_SEND_INTERVAL_MS = 600;
 const RESEND_RATE_LIMIT_RETRY_DELAY_MS = 1200;
+const INGEST_MIN_TRUST_WEIGHT = 60;
+const INGEST_MAX_SOURCES = 15;
+const DRAFT_MIN_TRUST_WEIGHT = 70;
+const DRAFT_MAX_SOURCE_BULLETS = 8;
 
 type FetchSourceResult =
   | { ok: true; entries: FeedEntry[]; fetchUrl: string }
@@ -219,6 +223,15 @@ async function fetchSourceEntries(source: ContentSourceRow): Promise<FetchSource
   }
 }
 
+function pickSourcesForIngest(sources: ContentSourceRow[]): ContentSourceRow[] {
+  const sorted = [...sources].sort((a, b) => (b.trust_weight ?? 0) - (a.trust_weight ?? 0));
+  const preferred = sorted.filter((source) => (source.trust_weight ?? 0) >= INGEST_MIN_TRUST_WEIGHT);
+  if (preferred.length > 0) {
+    return preferred.slice(0, INGEST_MAX_SOURCES);
+  }
+  return sorted.slice(0, Math.min(INGEST_MAX_SOURCES, sorted.length));
+}
+
 export async function runIngestPipeline(runId: string): Promise<{
   createdItems: number;
   scannedSources: number;
@@ -231,13 +244,15 @@ export async function runIngestPipeline(runId: string): Promise<{
     .select("*")
     .eq("is_active", true)
     .order("trust_weight", { ascending: false })
-    .limit(25);
+    .limit(40);
+
+  const selectedSources = pickSourcesForIngest((sources ?? []) as ContentSourceRow[]);
 
   let createdItems = 0;
   let scannedSources = 0;
   let failedSources = 0;
   const failureMessages: string[] = [];
-  for (const source of (sources ?? []) as ContentSourceRow[]) {
+  for (const source of selectedSources) {
     scannedSources += 1;
     const fetchResult = await fetchSourceEntries(source);
     if (!fetchResult.ok) {
@@ -304,11 +319,33 @@ export async function runDraftGeneratePipeline(runId: string): Promise<{
   createdItems: number;
 }> {
   const admin = createAdminClient();
-  const { data: latestMaps } = await admin
+  const { data: highTrustSources } = await admin
+    .from("content_sources")
+    .select("id")
+    .eq("is_active", true)
+    .gte("trust_weight", DRAFT_MIN_TRUST_WEIGHT)
+    .order("trust_weight", { ascending: false })
+    .limit(40);
+  const highTrustIds = (highTrustSources ?? []).map((source) => source.id);
+
+  let latestMapsQuery = admin
     .from("content_item_source_map")
     .select("source_id, source_url, source_title, source_published_at")
     .order("created_at", { ascending: false })
-    .limit(8);
+    .limit(DRAFT_MAX_SOURCE_BULLETS);
+
+  if (highTrustIds.length > 0) {
+    latestMapsQuery = latestMapsQuery.in("source_id", highTrustIds);
+  }
+  let { data: latestMaps } = await latestMapsQuery;
+  if (!latestMaps || latestMaps.length === 0) {
+    const fallback = await admin
+      .from("content_item_source_map")
+      .select("source_id, source_url, source_title, source_published_at")
+      .order("created_at", { ascending: false })
+      .limit(DRAFT_MAX_SOURCE_BULLETS);
+    latestMaps = fallback.data ?? [];
+  }
 
   if (!latestMaps || latestMaps.length === 0) {
     return { createdItems: 0 };
@@ -336,6 +373,11 @@ export async function runDraftGeneratePipeline(runId: string): Promise<{
           pack_version: generated.resolved.activeVersion,
           pack_versions: generated.resolved.versions,
           topic_strategy_id: generated.resolved.topic.id,
+          source_policy: {
+            min_trust_weight: DRAFT_MIN_TRUST_WEIGHT,
+            source_bullets: latestMaps.length,
+            high_trust_filter_applied: highTrustIds.length > 0,
+          },
         },
       },
     })
@@ -360,6 +402,11 @@ export async function runDraftGeneratePipeline(runId: string): Promise<{
           pack_version: generated.resolved.activeVersion,
           pack_versions: generated.resolved.versions,
           topic_strategy_id: generated.resolved.topic.id,
+          source_policy: {
+            min_trust_weight: DRAFT_MIN_TRUST_WEIGHT,
+            source_bullets: latestMaps.length,
+            high_trust_filter_applied: highTrustIds.length > 0,
+          },
         },
       },
     })

--- a/src/lib/content-ops/quality-monitor.ts
+++ b/src/lib/content-ops/quality-monitor.ts
@@ -1,0 +1,222 @@
+import type { Json } from "@/types/database.types";
+
+type MonitorContentItem = {
+  id: string;
+  type: "blog" | "newsletter";
+  title: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  review_notes: string | null;
+  metadata: Json | null;
+};
+
+type MonitorRun = {
+  run_type: string;
+  status: string;
+  created_at: string;
+  error_summary: string | null;
+  metadata: Json | null;
+};
+
+type FailureReasonCount = { reason: string; count: number };
+type QualityReasonCount = { reason: string; count: number };
+
+export type ContentQualitySnapshot = {
+  windowDays: number;
+  freshWindowHours: number;
+  generatedCount: number;
+  publishedCount: number;
+  reviewRequiredCount: number;
+  sendFailedCount: number;
+  avgQualityScore: number;
+  minQualityScore: number;
+  topQualityIssues: QualityReasonCount[];
+  topPublishFailureReasons: FailureReasonCount[];
+  freshGeneratedCount: number;
+  freshReviewedCount: number;
+  freshReviewRequiredCount: number;
+  freshAvgQualityScore: number;
+  freshMinQualityScore: number;
+  freshTopQualityIssues: QualityReasonCount[];
+  improvementFocus: string[];
+};
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function extractQualityScore(metadata: Json | null): number | null {
+  const gate = asObject(asObject(metadata)?.review_gate);
+  const latest = asObject(gate?.latest);
+  const metrics = asObject(latest?.metrics);
+  const score = Number(metrics?.qualityScore ?? NaN);
+  return Number.isFinite(score) ? score : null;
+}
+
+function extractQualityReasons(metadata: Json | null): string[] {
+  const gate = asObject(asObject(metadata)?.review_gate);
+  const latest = asObject(gate?.latest);
+  const raw = latest?.reasons;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((v): v is string => typeof v === "string" && v.trim().length > 0);
+}
+
+function extractRunPayload(metadata: Json | null): Record<string, unknown> {
+  const root = asObject(metadata);
+  const nested = asObject(root?.result);
+  return nested ?? root ?? {};
+}
+
+function parseFailureReasons(run: MonitorRun): string[] {
+  const payload = extractRunPayload(run.metadata);
+  const failureMessages = payload.failureMessages;
+  const out: string[] = [];
+  if (run.error_summary?.trim()) {
+    out.push(run.error_summary.replace(/^warning:/, "").trim());
+  }
+  if (Array.isArray(failureMessages)) {
+    for (const message of failureMessages) {
+      if (typeof message !== "string") continue;
+      out.push(message.replace(/^\[[^\]]+\]\s*/, "").trim());
+    }
+  }
+  return out.filter(Boolean);
+}
+
+function toCountList(source: Map<string, number>, limit = 5): Array<{ reason: string; count: number }> {
+  return Array.from(source.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([reason, count]) => ({ reason, count }));
+}
+
+export function buildContentQualitySnapshot(params: {
+  items: MonitorContentItem[];
+  runs: MonitorRun[];
+  nowMs?: number;
+  windowDays?: number;
+  freshWindowHours?: number;
+}): ContentQualitySnapshot {
+  const nowMs = params.nowMs ?? Date.now();
+  const windowDays = params.windowDays ?? 7;
+  const freshWindowHours = params.freshWindowHours ?? 24;
+  const cutoffMs = nowMs - windowDays * 24 * 60 * 60 * 1000;
+  const freshCutoffMs = nowMs - freshWindowHours * 60 * 60 * 1000;
+
+  const scopedItems = params.items.filter((item) => {
+    const createdMs = new Date(item.created_at).getTime();
+    return Number.isFinite(createdMs) && createdMs >= cutoffMs;
+  });
+  const scopedRuns = params.runs.filter((run) => {
+    const createdMs = new Date(run.created_at).getTime();
+    return Number.isFinite(createdMs) && createdMs >= cutoffMs;
+  });
+  const freshItems = scopedItems.filter((item) => {
+    const createdMs = new Date(item.created_at).getTime();
+    return Number.isFinite(createdMs) && createdMs >= freshCutoffMs;
+  });
+
+  const qualityScores: number[] = [];
+  const qualityReasonCounts = new Map<string, number>();
+  for (const item of scopedItems) {
+    const score = extractQualityScore(item.metadata);
+    if (typeof score === "number") qualityScores.push(score);
+    for (const reason of extractQualityReasons(item.metadata)) {
+      qualityReasonCounts.set(reason, (qualityReasonCounts.get(reason) ?? 0) + 1);
+    }
+  }
+
+  let generatedCount = 0;
+  const publishFailureCounts = new Map<string, number>();
+  for (const run of scopedRuns) {
+    const payload = extractRunPayload(run.metadata);
+    const createdItems = Number(payload.createdItems ?? NaN);
+    if (run.run_type === "draft_generate" && Number.isFinite(createdItems)) {
+      generatedCount += createdItems;
+    }
+    if (run.run_type === "publish" || run.run_type === "publish_retry_failed") {
+      for (const reason of parseFailureReasons(run)) {
+        publishFailureCounts.set(reason, (publishFailureCounts.get(reason) ?? 0) + 1);
+      }
+    }
+  }
+
+  const publishedCount = scopedItems.filter((item) => item.status === "published").length;
+  const reviewRequiredCount = scopedItems.filter((item) => item.status === "review_required").length;
+  const sendFailedCount = scopedItems.filter((item) => item.status === "send_failed").length;
+  const avgQualityScore =
+    qualityScores.length > 0
+      ? Number((qualityScores.reduce((sum, score) => sum + score, 0) / qualityScores.length).toFixed(1))
+      : 0;
+  const minQualityScore = qualityScores.length > 0 ? Math.min(...qualityScores) : 0;
+
+  const topQualityIssues = toCountList(qualityReasonCounts);
+  const topPublishFailureReasons = toCountList(publishFailureCounts);
+  const freshQualityScores: number[] = [];
+  const freshQualityReasonCounts = new Map<string, number>();
+  for (const item of freshItems) {
+    const score = extractQualityScore(item.metadata);
+    if (typeof score === "number") freshQualityScores.push(score);
+    for (const reason of extractQualityReasons(item.metadata)) {
+      freshQualityReasonCounts.set(reason, (freshQualityReasonCounts.get(reason) ?? 0) + 1);
+    }
+  }
+  const freshGeneratedCount = freshItems.filter((item) => asObject(item.metadata)?.generate).length;
+  const freshReviewedCount = freshItems.filter((item) => asObject(asObject(item.metadata)?.review_gate)?.latest).length;
+  const freshReviewRequiredCount = freshItems.filter((item) => item.status === "review_required").length;
+  const freshAvgQualityScore =
+    freshQualityScores.length > 0
+      ? Number(
+          (
+            freshQualityScores.reduce((sum, score) => sum + score, 0) /
+            freshQualityScores.length
+          ).toFixed(1),
+        )
+      : 0;
+  const freshMinQualityScore =
+    freshQualityScores.length > 0 ? Math.min(...freshQualityScores) : 0;
+  const freshTopQualityIssues = toCountList(freshQualityReasonCounts);
+
+  const improvementFocus: string[] = [];
+  if (freshTopQualityIssues.some((issue) => issue.reason === "low_novelty")) {
+    improvementFocus.push("topic-strategy-pack에서 반례/비교 프레임을 늘려 novelty 점수를 끌어올리세요.");
+  }
+  if (freshTopQualityIssues.some((issue) => issue.reason === "low_relevance")) {
+    improvementFocus.push("source trust_weight 상위 소스만 우선 사용하도록 ingest 필터를 강화하세요.");
+  }
+  if (freshTopQualityIssues.some((issue) => issue.reason === "body_too_short")) {
+    improvementFocus.push("draft_generate에서 최소 본문 길이 계약을 늘리고, source bullet을 3개 이상 강제하세요.");
+  }
+  if (sendFailedCount > 0 || topPublishFailureReasons.length > 0) {
+    improvementFocus.push("publish 배치 간격과 retry 윈도우를 운영 트래픽에 맞게 조정하세요.");
+  }
+  if (reviewRequiredCount >= 5) {
+    improvementFocus.push("review_required backlog SLA를 설정하고 must-review 항목을 우선 처리하세요.");
+  }
+  if (improvementFocus.length === 0) {
+    improvementFocus.push("현재 품질/발송 지표가 안정적입니다. 주 1회 팩 실험만 유지하세요.");
+  }
+
+  return {
+    windowDays,
+    freshWindowHours,
+    generatedCount,
+    publishedCount,
+    reviewRequiredCount,
+    sendFailedCount,
+    avgQualityScore,
+    minQualityScore,
+    topQualityIssues,
+    topPublishFailureReasons,
+    freshGeneratedCount,
+    freshReviewedCount,
+    freshReviewRequiredCount,
+    freshAvgQualityScore,
+    freshMinQualityScore,
+    freshTopQualityIssues,
+    improvementFocus,
+  };
+}
+


### PR DESCRIPTION
## Summary
- prioritize higher-trust sources in ingest and draft generation, with fallback behavior, to improve content relevance and reduce low-relevance/body-too-short drift
- add a dedicated quality monitor module, admin quality dashboard (`/admin/content-quality`), and CLI monitor command for ongoing quality operations
- upgrade prompt packs to v1.1.0 with comparison/contrarian scaffolding and expose fresh-window metrics (24h) to separate new generation quality from historical backlog noise

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm vitest run tests/unit/content-packs.test.ts tests/unit/review-gate.test.ts`
- [x] `pnpm tsx scripts/content-ops-e2e.ts generation`
- [x] `pnpm content-ops:quality:monitor`
- [x] confirm fresh generated drafts pass review gate without `low_novelty` in latest run outputs

Made with [Cursor](https://cursor.com)