### PR TITLE
feat(ops): harden autoloop production guardrails

### DIFF
--- a/docs/features/POC-continuous-improvement-autoloop-2026-05.md
+++ b/docs/features/POC-continuous-improvement-autoloop-2026-05.md
@@ -18,10 +18,11 @@ without touching critical product behavior unsafely.
 
 2. `scripts/continuous-improvement-loop.ts`
    - Bounded loop runner with hard stops.
+   - Supports explicit mode split: `rehearsal` vs `production`.
    - Runs required checks (`clean tree`, `typecheck`, `test:i18n`) plus optional quality checks.
    - Writes per-cycle JSON reports to `reports/autoloop/`.
-   - Stops immediately when required checks fail.
-   - Supports dry-run mode for safe rehearsal.
+   - Stops immediately when required checks fail or policy hard-stop conditions are met.
+   - Supports lock file for concurrent-run blocking.
 
 ## Safety Contract
 
@@ -29,21 +30,67 @@ without touching critical product behavior unsafely.
   - No destructive git command.
   - No force push.
   - No merge without explicit confirmation.
+  - No merge in `rehearsal` mode.
   - No infinite unbounded loop by default.
 - Required checks are blocking.
+- `low-risk` label policy is required for any automated merge candidate.
+- Base branch is fixed to `main`.
+- Allowlist paths are enforced before merge:
+  - `docs/**`
+  - `messages/**`
+  - `memory-bank/**`
+  - `tests/unit/admin-i18n-hardcoded.test.ts`
 - Any regression turns loop into "stop and report" mode.
+- Emergency stop switch file is supported (`reports/autoloop/.automerge-stop` by default).
 
 ## Run Commands
 
 ```bash
-# 1) Dry-run rehearsal (safe local rehearsal while editing)
-pnpm autoloop:poc --dry-run --allow-dirty-tree --max-cycles=3 --max-hours=1 --interval-minutes=5
+# 1) Rehearsal mode (safe local rehearsal while editing)
+pnpm autoloop:rehearsal
 
 # 2) Real bounded run (example: 24h window, 48 cycles, 30m interval)
-pnpm autoloop:poc --max-cycles=48 --max-hours=24 --interval-minutes=30
+pnpm autoloop:production
 
 # 3) Safe PR merge helper
 pnpm pr:automerge:safe --pr=123 --method=merge --confirm
+```
+
+If you want production mode to auto-merge low-risk candidates:
+
+```bash
+pnpm autoloop:poc \
+  --mode=production \
+  --max-cycles=48 \
+  --max-hours=24 \
+  --interval-minutes=30 \
+  --required-secrets=CONTENT_OPS_AUTOMATION_TOKEN \
+  --merge-enabled=true
+```
+
+## Cursor Automations Contract (Primary Scheduler)
+
+Use bounded invocations rather than a single infinite process.
+
+- Rehearsal slot: once daily.
+- Production slot: weekdays, 2-4 runs/day.
+- Required execution payload fields:
+  - `command`: one of the standardized `pnpm autoloop:*` commands
+  - `cursorRunId`: unique execution id (forwarded with `--cursor-run-id=...`)
+  - `mode`: `rehearsal` or `production`
+  - `mergeEnabled`: `false` by default
+
+Recommended production command template:
+
+```bash
+pnpm autoloop:poc \
+  --mode=production \
+  --cursor-run-id=${RUN_ID} \
+  --max-cycles=8 \
+  --max-hours=4 \
+  --interval-minutes=30 \
+  --required-secrets=CONTENT_OPS_AUTOMATION_TOKEN \
+  --merge-enabled=false
 ```
 
 ## 24h Continuous Operation Preparation
@@ -56,6 +103,21 @@ Recommended rollout:
 2. Enable real check loop for 1 day (still no auto-merge).
 3. Enable `pr-automerge-safe` only for a narrow label scope (e.g., docs/i18n).
 4. Expand scope after observing zero critical incidents.
+
+## Stop Conditions
+
+Hard-stop conditions:
+
+- required check failure (`typecheck`, `test:i18n`, or clean-tree requirement in production)
+- missing required secret(s)
+- policy/merge gate failure (`low-risk` label, allowlist, base mismatch, failed checks)
+- emergency stop switch file exists (`reports/autoloop/.automerge-stop`)
+
+Soft-stop conditions:
+
+- optional quality checks fail:
+  - merge is disabled for the cycle
+  - cycle writes warning report and stops
 
 ## Non-POC (Intentional Exclusions)
 

--- a/docs/features/RUNBOOK-content-ops.md
+++ b/docs/features/RUNBOOK-content-ops.md
@@ -139,3 +139,86 @@ Live scripts (write mode):
 
 - `pnpm content-ops:smoke`
 - `pnpm content-ops:cleanup`
+
+## Autoloop Operations (Cursor Automations Primary)
+
+Autoloop objective:
+
+- continuously validate repo health and content quality signals
+- optionally merge only policy-safe PR candidates
+- fail closed when any critical condition is violated
+
+Execution modes:
+
+- `rehearsal`: no merge/write actions, safe rehearsal
+- `production`: bounded checks with optional low-risk auto-merge
+
+Standard commands:
+
+- Rehearsal:
+  - `pnpm autoloop:rehearsal`
+- Production (merge disabled):
+  - `pnpm autoloop:production`
+- Production (low-risk auto-merge enabled):
+  - `pnpm autoloop:poc --mode=production --max-cycles=48 --max-hours=24 --interval-minutes=30 --required-secrets=CONTENT_OPS_AUTOMATION_TOKEN --merge-enabled=true`
+
+Policy gate for automated merge:
+
+- required label: `low-risk`
+- base branch: `main`
+- allowlist paths only:
+  - `docs/**`
+  - `messages/**`
+  - `memory-bank/**`
+  - `tests/unit/admin-i18n-hardcoded.test.ts`
+
+### Cursor Automations schedule contract
+
+Recommended schedule:
+
+- rehearsal: once per day
+- production: weekdays 2-4 times/day (bounded 30-60 minutes per invocation)
+
+Each run should pass a unique run id:
+
+- `--cursor-run-id=<automation_run_id>`
+
+Concurrency guard:
+
+- lock file path: `reports/autoloop/.lock`
+- if lock exists, run must fail fast and report lock owner metadata
+
+### Stop Conditions (Fail-Closed)
+
+Hard stop:
+
+- required check failure (`clean-tree`, `typecheck`, `test:i18n`)
+- missing required secrets (default: `CONTENT_OPS_AUTOMATION_TOKEN` in production)
+- policy/merge gate failure for candidate PR
+- emergency stop switch file present (`reports/autoloop/.automerge-stop`)
+
+Soft stop:
+
+- optional quality checks fail (`content-packs`, `quality-monitor`)
+- merge is disabled for that cycle and loop halts with warning report
+
+### Emergency stop switch
+
+To immediately pause merge-capable runs:
+
+1. create file `reports/autoloop/.automerge-stop`
+2. rerun or wait for next autoloop invocation (it will halt with stop reason)
+3. remove the file only after issue triage is complete
+
+### Report interpretation
+
+Autoloop report path:
+
+- `reports/autoloop/*.json`
+
+Key report fields:
+
+- `runMode`, `policyVersion`, `cursorRunId`
+- `candidatePrs`, `mergedPrs`
+- `stopReason`, `elapsedMs`
+- `steps[]` with `ok/skipped/error`

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "content-ops:quality:monitor": "pnpm tsx scripts/content-ops-quality-monitor.ts",
     "pr:automerge:safe": "pnpm tsx scripts/pr-automerge-safe.ts",
     "autoloop:poc": "pnpm tsx scripts/continuous-improvement-loop.ts",
+    "autoloop:rehearsal": "pnpm autoloop:poc --mode=rehearsal --allow-dirty-tree --max-cycles=3 --max-hours=1 --interval-minutes=5",
+    "autoloop:production": "pnpm autoloop:poc --mode=production --max-cycles=48 --max-hours=24 --interval-minutes=30 --required-secrets=CONTENT_OPS_AUTOMATION_TOKEN --merge-enabled=false",
     "worker:assembly": "tsx workers/video-assembly/run.ts",
     "prepare": "husky"
   },

--- a/scripts/continuous-improvement-loop.ts
+++ b/scripts/continuous-improvement-loop.ts
@@ -1,11 +1,25 @@
 import { execSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_LOCK_FILE = "reports/autoloop/.lock";
+const DEFAULT_STOP_SWITCH_FILE = "reports/autoloop/.automerge-stop";
+const DEFAULT_POLICY_VERSION = "v1-low-risk";
+const DEFAULT_REQUIRED_LABEL = "low-risk";
+const DEFAULT_BASE_BRANCH = "main";
+const DEFAULT_ALLOWED_PATH_PATTERNS = [
+  "docs/**",
+  "messages/**",
+  "memory-bank/**",
+  "tests/unit/admin-i18n-hardcoded.test.ts",
+];
 
 type LoopStep = {
   id: string;
   command: string;
   required: boolean;
+  optionalCategory?: "quality";
 };
 
 type StepResult = {
@@ -14,16 +28,55 @@ type StepResult = {
   command: string;
   output: string;
   error?: string;
+  skipped?: boolean;
 };
 
 type CycleReport = {
   cycle: number;
+  runMode: "rehearsal" | "production";
+  policyVersion: string;
+  cursorRunId?: string;
   startedAt: string;
   endedAt: string;
   ok: boolean;
+  stopReason?: string;
+  elapsedMs: number;
+  candidatePrs: number[];
+  mergedPrs: number[];
   steps: StepResult[];
   recommendations: string[];
 };
+
+type ParsedArgs = {
+  mode: "rehearsal" | "production";
+  maxCycles: number;
+  maxHours: number;
+  intervalMinutes: number;
+  allowDirtyTree: boolean;
+  mergeEnabled: boolean;
+  timeoutMs: number;
+  lockFile: string;
+  stopSwitchPath: string;
+  policyVersion: string;
+  requiredSecrets: string[];
+  requiredLabel: string;
+  base: string;
+  allowedPaths: string[];
+  prLimit: number;
+  deleteMergedBranch: boolean;
+  cursorRunId?: string;
+};
+
+function fail(message: string): never {
+  throw new Error(`[autoloop] ${message}`);
+}
+
+function parseBool(value: string | undefined, fallback: boolean): boolean {
+  if (!value) return fallback;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  fail(`invalid boolean value: ${value}`);
+}
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -32,26 +85,101 @@ function parseArgs() {
   const intervalMinutes = Number(
     args.find((arg) => arg.startsWith("--interval-minutes="))?.split("=")[1] ?? "10",
   );
+  const explicitMode = args.find((arg) => arg.startsWith("--mode="))?.split("=")[1];
   const dryRun = args.includes("--dry-run");
+  const mode: "rehearsal" | "production" =
+    explicitMode === "production" ? "production" : dryRun ? "rehearsal" : "rehearsal";
   const allowDirtyTree = args.includes("--allow-dirty-tree");
-  return {
+  const mergeEnabled = parseBool(
+    args.find((arg) => arg.startsWith("--merge-enabled="))?.split("=")[1],
+    false,
+  );
+  const timeoutMs = Number(
+    args.find((arg) => arg.startsWith("--timeout-ms="))?.split("=")[1] ?? String(DEFAULT_TIMEOUT_MS),
+  );
+  const lockFile = args.find((arg) => arg.startsWith("--lock-file="))?.split("=")[1] ?? DEFAULT_LOCK_FILE;
+  const stopSwitchPath =
+    args.find((arg) => arg.startsWith("--stop-switch-path="))?.split("=")[1] ?? DEFAULT_STOP_SWITCH_FILE;
+  const policyVersion =
+    args.find((arg) => arg.startsWith("--policy-version="))?.split("=")[1] ?? DEFAULT_POLICY_VERSION;
+  const requiredSecretsRaw = args.find((arg) => arg.startsWith("--required-secrets="))?.split("=")[1] ?? "";
+  const requiredSecrets = requiredSecretsRaw
+    .split(",")
+    .map((secret) => secret.trim())
+    .filter((secret) => secret.length > 0);
+  const requiredLabel =
+    args.find((arg) => arg.startsWith("--required-label="))?.split("=")[1] ?? DEFAULT_REQUIRED_LABEL;
+  const base = args.find((arg) => arg.startsWith("--base="))?.split("=")[1] ?? DEFAULT_BASE_BRANCH;
+  const allowedPathsRaw = args.find((arg) => arg.startsWith("--allowed-paths="))?.split("=")[1];
+  const allowedPaths = allowedPathsRaw
+    ? allowedPathsRaw
+        .split(",")
+        .map((pattern) => pattern.trim())
+        .filter((pattern) => pattern.length > 0)
+    : DEFAULT_ALLOWED_PATH_PATTERNS;
+  const prLimit = Number(args.find((arg) => arg.startsWith("--pr-limit="))?.split("=")[1] ?? "5");
+  const deleteMergedBranch = parseBool(
+    args.find((arg) => arg.startsWith("--delete-merged-branch="))?.split("=")[1],
+    true,
+  );
+  const cursorRunId = args.find((arg) => arg.startsWith("--cursor-run-id="))?.split("=")[1];
+
+  const parsed: ParsedArgs = {
+    mode,
     maxCycles: Number.isFinite(maxCycles) && maxCycles > 0 ? maxCycles : 3,
     maxHours: Number.isFinite(maxHours) && maxHours > 0 ? maxHours : 1,
     intervalMinutes: Number.isFinite(intervalMinutes) && intervalMinutes >= 0 ? intervalMinutes : 10,
-    dryRun,
     allowDirtyTree,
+    mergeEnabled,
+    timeoutMs: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_TIMEOUT_MS,
+    lockFile,
+    stopSwitchPath,
+    policyVersion,
+    requiredSecrets,
+    requiredLabel,
+    base,
+    allowedPaths,
+    prLimit: Number.isFinite(prLimit) && prLimit > 0 ? prLimit : 5,
+    deleteMergedBranch,
+    cursorRunId,
   };
+  if (parsed.mode === "production" && parsed.allowDirtyTree) {
+    fail("--allow-dirty-tree is not allowed in production mode.");
+  }
+  if (parsed.mode !== "production" && parsed.mergeEnabled) {
+    fail("--merge-enabled=true is only allowed in production mode.");
+  }
+  if (parsed.allowedPaths.length === 0) {
+    fail("allowed path patterns cannot be empty.");
+  }
+  return parsed;
 }
 
-function runCommand(command: string): { ok: boolean; output: string; error?: string } {
+function runCommand(
+  command: string,
+  timeoutMs: number,
+  required = false,
+): { ok: boolean; output: string; error?: string } {
   try {
-    const output = execSync(command, { stdio: "pipe", encoding: "utf8" }).trim();
+    const output = execSync(command, {
+      stdio: "pipe",
+      encoding: "utf8",
+      timeout: timeoutMs,
+    }).trim();
     return { ok: true, output };
   } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    if (required) {
+      return {
+        ok: false,
+        output: "",
+        error: detail,
+      };
+    }
     return {
       ok: false,
       output: "",
-      error: error instanceof Error ? error.message : String(error),
+      error: detail,
     };
   }
 }
@@ -85,87 +213,251 @@ function buildRecommendations(steps: StepResult[]): string[] {
   return recommendations;
 }
 
+function nowIsoForFileName() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function assertRequiredSecrets(requiredSecrets: string[]) {
+  const missing = requiredSecrets.filter((secret) => !process.env[secret]);
+  if (missing.length > 0) {
+    fail(`missing required secrets: ${missing.join(", ")}`);
+  }
+}
+
+function acquireLock(lockFilePath: string): { release: () => void } {
+  mkdirSync(join(process.cwd(), "reports", "autoloop"), { recursive: true });
+  let fd: number;
+  try {
+    fd = openSync(lockFilePath, "wx");
+  } catch {
+    const lockBody = existsSync(lockFilePath) ? readFileSync(lockFilePath, "utf8") : "<unknown lock owner>";
+    fail(`lock already exists at ${lockFilePath}. lock body: ${lockBody}`);
+  }
+  const payload = {
+    pid: process.pid,
+    startedAt: new Date().toISOString(),
+  };
+  writeFileSync(lockFilePath, `${JSON.stringify(payload)}\n`, "utf8");
+  return {
+    release: () => {
+      closeSync(fd);
+      if (existsSync(lockFilePath)) {
+        unlinkSync(lockFilePath);
+      }
+    },
+  };
+}
+
+function listLowRiskCandidates(base: string, requiredLabel: string, limit: number, timeoutMs: number): number[] {
+  const result = runCommand(
+    `gh pr list --state open --base ${base} --label ${requiredLabel} --limit ${limit} --json number`,
+    timeoutMs,
+    true,
+  );
+  if (!result.ok) {
+    fail(`cannot list candidate PRs: ${result.error ?? "unknown error"}`);
+  }
+  const parsed = JSON.parse(result.output) as Array<{ number?: number }>;
+  return parsed
+    .map((row) => row.number ?? 0)
+    .filter((number) => Number.isFinite(number) && number > 0);
+}
+
+function tryMergeCandidates(args: ParsedArgs, candidatePrs: number[]): { mergedPrs: number[]; stopReason?: string } {
+  if (!args.mergeEnabled || args.mode !== "production") {
+    return { mergedPrs: [] };
+  }
+
+  const mergedPrs: number[] = [];
+  const allowedPathsArg = args.allowedPaths.join(",");
+  for (const pr of candidatePrs) {
+    const mergeAttempt = runCommand(
+      [
+        "pnpm pr:automerge:safe",
+        `--pr=${pr}`,
+        "--confirm",
+        "--method=merge",
+        `--timeout-ms=${args.timeoutMs}`,
+        `--required-label=${args.requiredLabel}`,
+        `--base=${args.base}`,
+        `--allowed-paths=${allowedPathsArg}`,
+        `--delete-branch=${args.deleteMergedBranch ? "true" : "false"}`,
+      ].join(" "),
+      args.timeoutMs,
+    );
+    if (!mergeAttempt.ok) {
+      return {
+        mergedPrs,
+        stopReason: `policy_violation_or_merge_failure:pr_${pr}`,
+      };
+    }
+    mergedPrs.push(pr);
+  }
+  return { mergedPrs };
+}
+
 async function main() {
-  const { maxCycles, maxHours, intervalMinutes, dryRun, allowDirtyTree } = parseArgs();
+  const args = parseArgs();
+  const {
+    mode,
+    maxCycles,
+    maxHours,
+    intervalMinutes,
+    allowDirtyTree,
+    mergeEnabled,
+    timeoutMs,
+    lockFile,
+    stopSwitchPath,
+    policyVersion,
+    requiredSecrets,
+    requiredLabel,
+    base,
+    prLimit,
+    cursorRunId,
+  } = args;
   const startedAt = Date.now();
   const reportDir = join(process.cwd(), "reports", "autoloop");
   mkdirSync(reportDir, { recursive: true });
+  const lock = acquireLock(join(process.cwd(), lockFile));
 
-  const steps: LoopStep[] = [
-    {
-      id: "health.clean-tree",
-      command: "git diff --quiet && git diff --cached --quiet",
-      required: !allowDirtyTree,
-    },
-    { id: "health.typecheck", command: "pnpm typecheck", required: true },
-    { id: "health.i18n", command: "pnpm test:i18n", required: true },
-    { id: "health.content-packs", command: "pnpm vitest run tests/unit/content-packs.test.ts", required: false },
-    { id: "health.quality-monitor", command: "pnpm content-ops:quality:monitor", required: false },
-  ];
-
-  console.log(
-    `[autoloop] start (maxCycles=${maxCycles}, maxHours=${maxHours}, intervalMinutes=${intervalMinutes}, dryRun=${dryRun}, allowDirtyTree=${allowDirtyTree})`,
-  );
-
-  for (let cycle = 1; cycle <= maxCycles; cycle += 1) {
-    const elapsedHours = (Date.now() - startedAt) / (1000 * 60 * 60);
-    if (elapsedHours > maxHours) {
-      console.log(`[autoloop] stopping: maxHours exceeded (${elapsedHours.toFixed(2)}h).`);
-      break;
+  try {
+    if (mode === "production") {
+      assertRequiredSecrets(requiredSecrets);
+      if (mergeEnabled && !(process.env.GITHUB_TOKEN || process.env.GH_TOKEN)) {
+        fail("merge-enabled production mode requires GITHUB_TOKEN or GH_TOKEN.");
+      }
     }
 
-    const cycleStart = new Date().toISOString();
-    const stepResults: StepResult[] = [];
-    let cycleOk = true;
+    const steps: LoopStep[] = [
+      {
+        id: "health.clean-tree",
+        command: "git diff --quiet && git diff --cached --quiet",
+        required: !allowDirtyTree,
+      },
+      { id: "health.typecheck", command: "pnpm typecheck", required: true },
+      { id: "health.i18n", command: "pnpm test:i18n", required: true },
+      {
+        id: "health.content-packs",
+        command: "pnpm vitest run tests/unit/content-packs.test.ts",
+        required: false,
+        optionalCategory: "quality",
+      },
+      {
+        id: "health.quality-monitor",
+        command: "pnpm content-ops:quality:monitor",
+        required: false,
+        optionalCategory: "quality",
+      },
+    ];
 
-    for (const step of steps) {
-      if (dryRun && step.id !== "health.clean-tree") {
-        stepResults.push({
-          id: step.id,
-          ok: true,
-          command: step.command,
-          output: "[dry-run] skipped command execution",
-        });
-        continue;
+    console.log(
+      `[autoloop] start (mode=${mode}, maxCycles=${maxCycles}, maxHours=${maxHours}, intervalMinutes=${intervalMinutes}, mergeEnabled=${mergeEnabled})`,
+    );
+
+    for (let cycle = 1; cycle <= maxCycles; cycle += 1) {
+      const elapsedHours = (Date.now() - startedAt) / (1000 * 60 * 60);
+      if (elapsedHours > maxHours) {
+        console.log(`[autoloop] stopping: maxHours exceeded (${elapsedHours.toFixed(2)}h).`);
+        break;
       }
 
-      const result = runCommand(step.command);
-      stepResults.push({
-        id: step.id,
-        ok: result.ok,
-        command: step.command,
-        output: result.output,
-        error: result.error,
-      });
-      if (step.required && !result.ok) {
+      const cycleStartMs = Date.now();
+      const cycleStart = new Date(cycleStartMs).toISOString();
+      const stepResults: StepResult[] = [];
+      let cycleOk = true;
+      let stopReason: string | undefined;
+      let mergeEnabledThisCycle = mode === "production" && mergeEnabled;
+
+      if (existsSync(join(process.cwd(), stopSwitchPath))) {
         cycleOk = false;
+        stopReason = "automerge_stop_switch_present";
+      }
+
+      if (!stopReason) {
+        for (const step of steps) {
+          if (mode === "rehearsal" && step.id !== "health.clean-tree") {
+            stepResults.push({
+              id: step.id,
+              ok: true,
+              command: step.command,
+              output: "[rehearsal] skipped command execution",
+              skipped: true,
+            });
+            continue;
+          }
+
+          const result = runCommand(step.command, timeoutMs, step.required);
+          stepResults.push({
+            id: step.id,
+            ok: result.ok,
+            command: step.command,
+            output: result.output,
+            error: result.error,
+          });
+          if (step.required && !result.ok) {
+            cycleOk = false;
+            stopReason = `required_step_failed:${step.id}`;
+          }
+
+          if (!step.required && !result.ok && step.optionalCategory === "quality") {
+            mergeEnabledThisCycle = false;
+            cycleOk = false;
+            stopReason = `soft_stop_optional_failure:${step.id}`;
+            break;
+          }
+        }
+      }
+
+      const candidatePrs = mode === "production" ? listLowRiskCandidates(base, requiredLabel, prLimit, timeoutMs) : [];
+      let mergedPrs: number[] = [];
+      if (!stopReason && mergeEnabledThisCycle) {
+        const mergeResult = tryMergeCandidates(args, candidatePrs);
+        mergedPrs = mergeResult.mergedPrs;
+        if (mergeResult.stopReason) {
+          cycleOk = false;
+          stopReason = mergeResult.stopReason;
+        }
+      }
+
+      const recommendations = buildRecommendations(stepResults);
+      const cycleEndMs = Date.now();
+      const cycleEnd = new Date(cycleEndMs).toISOString();
+      const report: CycleReport = {
+        cycle,
+        runMode: mode,
+        policyVersion,
+        cursorRunId,
+        startedAt: cycleStart,
+        endedAt: cycleEnd,
+        ok: cycleOk,
+        stopReason,
+        elapsedMs: cycleEndMs - cycleStartMs,
+        candidatePrs,
+        mergedPrs,
+        steps: stepResults,
+        recommendations,
+      };
+
+      const fileName = `${nowIsoForFileName()}-cycle-${cycle}.json`;
+      const reportPath = join(reportDir, fileName);
+      writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+      console.log(
+        `[autoloop] cycle ${cycle} -> ${cycleOk ? "ok" : "halted"} (${reportPath})${
+          stopReason ? ` reason=${stopReason}` : ""
+        }`,
+      );
+
+      if (!cycleOk) {
+        console.log("[autoloop] stopping due to policy/quality/required-check stop condition.");
+        break;
+      }
+
+      if (cycle < maxCycles && intervalMinutes > 0) {
+        await sleep(intervalMinutes * 60 * 1000);
       }
     }
-
-    const recommendations = buildRecommendations(stepResults);
-    const cycleEnd = new Date().toISOString();
-    const report: CycleReport = {
-      cycle,
-      startedAt: cycleStart,
-      endedAt: cycleEnd,
-      ok: cycleOk,
-      steps: stepResults,
-      recommendations,
-    };
-
-    const fileName = `${new Date().toISOString().replace(/[:.]/g, "-")}-cycle-${cycle}.json`;
-    const reportPath = join(reportDir, fileName);
-    writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
-    console.log(`[autoloop] cycle ${cycle} -> ${cycleOk ? "ok" : "failed"} (${reportPath})`);
-
-    if (!cycleOk) {
-      console.log("[autoloop] stopping due to required check failure.");
-      break;
-    }
-
-    if (cycle < maxCycles && intervalMinutes > 0) {
-      await sleep(intervalMinutes * 60 * 1000);
-    }
+  } finally {
+    lock.release();
   }
 }
 

--- a/scripts/pr-automerge-safe.ts
+++ b/scripts/pr-automerge-safe.ts
@@ -1,5 +1,15 @@
 import { execSync } from "node:child_process";
 
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_BASE_BRANCH = "main";
+const DEFAULT_REQUIRED_LABEL = "low-risk";
+const DEFAULT_ALLOWED_PATH_PATTERNS = [
+  "docs/**",
+  "messages/**",
+  "memory-bank/**",
+  "tests/unit/admin-i18n-hardcoded.test.ts",
+];
+
 type PrStatusCheck =
   | {
       __typename: "CheckRun";
@@ -18,28 +28,72 @@ type PrView = {
   number: number;
   isDraft: boolean;
   state: string;
+  baseRefName: string;
   mergeStateStatus: string;
   reviewDecision?: string | null;
+  labels?: Array<{ name?: string }> | null;
+  files?: Array<{ path?: string }> | null;
   statusCheckRollup?: PrStatusCheck[] | null;
 };
 
-function run(command: string): string {
-  return execSync(command, { stdio: "pipe", encoding: "utf8" }).trim();
+type ParsedArgs = {
+  pr: number;
+  method: "merge" | "squash" | "rebase";
+  timeoutMs: number;
+  base: string;
+  requiredLabel: string;
+  allowedPaths: string[];
+  deleteBranch: boolean;
+};
+
+function run(command: string, timeoutMs = DEFAULT_TIMEOUT_MS): string {
+  return execSync(command, {
+    stdio: "pipe",
+    encoding: "utf8",
+    timeout: timeoutMs,
+  }).trim();
 }
 
 function fail(message: string): never {
   throw new Error(`[pr-automerge-safe] ${message}`);
 }
 
-function parseArgs() {
+function parseBool(value: string | undefined, fallback: boolean): boolean {
+  if (!value) return fallback;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  fail(`invalid boolean value: ${value}`);
+}
+
+function parseArgs(): ParsedArgs {
   const args = process.argv.slice(2);
   const pr = Number(args.find((arg) => arg.startsWith("--pr="))?.split("=")[1] ?? "0");
   const confirm = args.includes("--confirm");
   const mergeMethodRaw = args.find((arg) => arg.startsWith("--method="))?.split("=")[1] ?? "merge";
   const method = mergeMethodRaw === "squash" || mergeMethodRaw === "rebase" ? mergeMethodRaw : "merge";
+  const timeoutMs = Number(
+    args.find((arg) => arg.startsWith("--timeout-ms="))?.split("=")[1] ?? String(DEFAULT_TIMEOUT_MS),
+  );
+  const base = args.find((arg) => arg.startsWith("--base="))?.split("=")[1] ?? DEFAULT_BASE_BRANCH;
+  const requiredLabel =
+    args.find((arg) => arg.startsWith("--required-label="))?.split("=")[1] ?? DEFAULT_REQUIRED_LABEL;
+  const allowedPathsRaw = args.find((arg) => arg.startsWith("--allowed-paths="))?.split("=")[1];
+  const deleteBranchRaw = args.find((arg) => arg.startsWith("--delete-branch="))?.split("=")[1];
+  const deleteBranch = parseBool(deleteBranchRaw, true);
+  const allowedPaths = allowedPathsRaw
+    ? allowedPathsRaw
+        .split(",")
+        .map((pattern) => pattern.trim())
+        .filter((pattern) => pattern.length > 0)
+    : DEFAULT_ALLOWED_PATH_PATTERNS;
+
   if (!Number.isFinite(pr) || pr <= 0) fail("missing or invalid --pr=<number>.");
   if (!confirm) fail("refusing to merge without --confirm flag.");
-  return { pr, method };
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) fail("invalid --timeout-ms value.");
+  if (!base) fail("invalid --base value.");
+  if (!requiredLabel) fail("invalid --required-label value.");
+  if (allowedPaths.length === 0) fail("allowed path patterns cannot be empty.");
+  return { pr, method, timeoutMs, base, requiredLabel, allowedPaths, deleteBranch };
 }
 
 function allChecksSucceeded(checks: PrStatusCheck[] | null | undefined): boolean {
@@ -52,16 +106,42 @@ function allChecksSucceeded(checks: PrStatusCheck[] | null | undefined): boolean
   });
 }
 
+function matchesPattern(path: string, pattern: string): boolean {
+  if (pattern.endsWith("/**")) {
+    const prefix = pattern.slice(0, -3);
+    return path.startsWith(prefix);
+  }
+  return path === pattern;
+}
+
+function filePathsWithinAllowedPatterns(
+  files: Array<{ path?: string }> | null | undefined,
+  allowedPatterns: string[],
+): { ok: boolean; disallowedPaths: string[] } {
+  const paths = (files ?? []).map((file) => file.path ?? "").filter((path) => path.length > 0);
+  if (paths.length === 0) {
+    return { ok: false, disallowedPaths: ["<no changed files returned by gh pr view>"] };
+  }
+  const disallowedPaths = paths.filter(
+    (path) => !allowedPatterns.some((pattern) => matchesPattern(path, pattern)),
+  );
+  return { ok: disallowedPaths.length === 0, disallowedPaths };
+}
+
 function main() {
-  const { pr, method } = parseArgs();
+  const { pr, method, timeoutMs, base, requiredLabel, allowedPaths, deleteBranch } = parseArgs();
 
   const raw = run(
-    `gh pr view ${pr} --json number,isDraft,state,mergeStateStatus,reviewDecision,statusCheckRollup`,
+    `gh pr view ${pr} --json number,isDraft,state,baseRefName,mergeStateStatus,reviewDecision,labels,files,statusCheckRollup`,
+    timeoutMs,
   );
   const view = JSON.parse(raw) as PrView;
 
   if (view.state !== "OPEN") fail(`PR #${pr} is not open (state=${view.state}).`);
   if (view.isDraft) fail(`PR #${pr} is draft.`);
+  if (view.baseRefName !== base) {
+    fail(`PR #${pr} targets '${view.baseRefName}', expected base '${base}'.`);
+  }
   if (view.mergeStateStatus !== "CLEAN") {
     fail(`PR #${pr} is not merge-clean (mergeStateStatus=${view.mergeStateStatus}).`);
   }
@@ -72,8 +152,25 @@ function main() {
     fail(`PR #${pr} has incomplete or failing checks.`);
   }
 
-  run(`gh pr merge ${pr} --${method} --delete-branch`);
-  console.log(`[pr-automerge-safe] merged PR #${pr} with method=${method}.`);
+  const labels = (view.labels ?? []).map((label) => label.name ?? "").filter((label) => label.length > 0);
+  if (!labels.includes(requiredLabel)) {
+    fail(`PR #${pr} is missing required label '${requiredLabel}'.`);
+  }
+
+  const allowlistCheck = filePathsWithinAllowedPatterns(view.files, allowedPaths);
+  if (!allowlistCheck.ok) {
+    fail(
+      `PR #${pr} touches disallowed paths: ${allowlistCheck.disallowedPaths.join(
+        ", ",
+      )}. Allowed patterns: ${allowedPaths.join(", ")}`,
+    );
+  }
+
+  const deleteBranchFlag = deleteBranch ? "--delete-branch" : "";
+  run(`gh pr merge ${pr} --${method} ${deleteBranchFlag}`.trim(), timeoutMs);
+  console.log(
+    `[pr-automerge-safe] merged PR #${pr} with method=${method}, base=${base}, requiredLabel=${requiredLabel}.`,
+  );
 }
 
 main();


### PR DESCRIPTION
## Summary
- harden `pr-automerge-safe` with low-risk label policy gates (required label, base=main, allowlist path checks, timeout, optional delete-branch)
- upgrade `continuous-improvement-loop` to production-ready mode controls (`rehearsal|production`), fail-closed stop conditions, lock-based concurrency guard, and enriched cycle reports
- add standardized autoloop scripts and update POC/Runbook docs for Cursor Automations scheduling, emergency stop switch, and operational interpretation

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:i18n`
- [x] `pnpm autoloop:poc --mode=rehearsal --allow-dirty-tree --max-cycles=1 --max-hours=1 --interval-minutes=0`

## Operational notes
- production default keeps auto-merge disabled (`--merge-enabled=false`)
- enabling merge in production requires policy-compliant low-risk PRs and explicit runtime flags

Made with [Cursor](https://cursor.com)