### PR TITLE
feat(admin): add morning ops playbook operator console

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -904,6 +904,7 @@
         "runs": "Runs",
         "subscribers": "Subscribers",
         "contentQuality": "Content quality",
+        "morningOps": "Morning Ops Playbook",
         "waitlist": "Waitlist",
         "purchaseAllowlist": "Checkout allowlist",
         "promptStudioAllowlist": "Prompt Studio beta"
@@ -1107,6 +1108,10 @@
         "contentQuality": {
           "title": "Content quality monitor",
           "desc": "Track quality signals, failure trends, and improvement focus in one place."
+        },
+        "morningOps": {
+          "title": "Morning Ops Playbook",
+          "desc": "Daily operator guide to review overnight work and issue direction pivots."
         },
         "subscribers": {
           "title": "Subscribers",
@@ -1417,6 +1422,78 @@
         "publishing": "Publishing",
         "published": "Published",
         "sendFailed": "Send failed"
+      }
+    },
+    "adminMorningOps": {
+      "metaTitle": "Morning Ops Playbook",
+      "title": "Morning Ops Playbook",
+      "backToAdmin": "Back to admin",
+      "intro": "Use this page as your daily operator console: review overnight automation, decide go/adjust/stop, and send clear direction templates to the automation agent.",
+      "quickLinks": {
+        "title": "Quick navigation",
+        "runs": "Open runs",
+        "contentQuality": "Open content quality",
+        "contentQueue": "Open content queue",
+        "newsSources": "Open news sources",
+        "subscribers": "Open subscribers"
+      },
+      "morningRoutine": {
+        "title": "10-minute morning routine",
+        "step1": "Check /admin/runs for success/partial-failure/failure and first failure reason.",
+        "step2": "Check /admin/content-quality for freshAvgQualityScore and top recurring issues.",
+        "step3": "Check /admin/content-queue for review_required backlog and low-quality drafts.",
+        "step4": "Choose go, adjust, or stop and issue direction to the automation agent."
+      },
+      "decision": {
+        "title": "Decision matrix",
+        "go": {
+          "title": "Go",
+          "desc": "No critical failures and quality trend is stable or improving."
+        },
+        "adjust": {
+          "title": "Adjust",
+          "desc": "Runs are mostly healthy but quality issues are rising or output is unsatisfying."
+        },
+        "stop": {
+          "title": "Stop",
+          "desc": "Repeated failures, policy violations, or suspicious behavior; pause automation first."
+        }
+      },
+      "templates": {
+        "title": "Direction templates",
+        "newsletter": {
+          "title": "Template A - Newsletter quality improvement",
+          "body": "Based on last night's results, prioritize newsletter quality improvement.\\nGoals:\\n- reduce low_novelty\\n- increase evidence density\\n- improve customer actionability\\n\\nConstraints:\\n- keep low-risk policy\\n- keep auto-merge disabled\\n- make impact visible in /admin/content-quality within 24h\\n\\nExecute:\\n- tune pack/prompt\\n- run one full cycle\\n- report before/after metrics and change summary"
+        },
+        "blogPivot": {
+          "title": "Template B - Blog-first pivot",
+          "body": "Today, pivot toward blog quality and CTA impact over newsletter volume.\\nSuccess criteria:\\n- freshAvgQualityScore up\\n- no regression in freshReviewRequiredCount\\n- reduce body_too_short frequency\\n\\nReturn:\\n- what changed\\n- why it should work\\n- what to verify in /admin tomorrow morning"
+        },
+        "incident": {
+          "title": "Template C - Failure response",
+          "body": "Failure class detected: <fill_this>.\\nKeep automation in safe mode and run root-cause fix first.\\nThen execute retry window only and provide:\\n- root cause\\n- fix diff summary\\n- retry result\\n- recurrence prevention checklist"
+        }
+      },
+      "monitoring": {
+        "title": "How to confirm service is improving",
+        "item1": "Match automation run IDs with /admin/runs entries and recent autoloop reports.",
+        "item2": "Track freshAvgQualityScore and freshTopQualityIssues trend in /admin/content-quality.",
+        "item3": "Track queue health via review_required backlog and send_failed count.",
+        "item4": "Review source/subscriber integrity in /admin/news-sources and /admin/subscribers."
+      },
+      "emergency": {
+        "title": "Emergency pause",
+        "item1": "Create the stop-switch file to halt merge-capable runs.",
+        "item2": "Confirm next cycle stops with stopReason in autoloop report.",
+        "item3": "Remove stop-switch only after triage and policy confirmation.",
+        "windowsHint": "Windows (PowerShell):",
+        "windowsCommand": "New-Item -Path reports/autoloop/.automerge-stop -ItemType File -Force",
+        "macHint": "macOS/Linux:",
+        "macCommand": "mkdir -p reports/autoloop && touch reports/autoloop/.automerge-stop"
+      },
+      "actions": {
+        "copy": "Copy",
+        "copied": "Copied"
       }
     },
     "adminPurchaseAllowlist": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -896,6 +896,7 @@
         "runs": "実行履歴",
         "subscribers": "購読者",
         "contentQuality": "コンテンツ品質モニター",
+        "morningOps": "Morning Ops Playbook",
         "waitlist": "ウェイトリスト",
         "purchaseAllowlist": "チェックアウト許可リスト",
         "promptStudioAllowlist": "Prompt Studio ベータ"
@@ -1099,6 +1100,10 @@
         "contentQuality": {
           "title": "コンテンツ品質モニター",
           "desc": "品質シグナル、失敗傾向、改善フォーカスを一か所で追跡します。"
+        },
+        "morningOps": {
+          "title": "Morning Ops Playbook",
+          "desc": "Daily operator guide to review overnight work and issue direction pivots."
         },
         "subscribers": {
           "title": "購読者",
@@ -1409,6 +1414,78 @@
         "publishing": "公開中",
         "published": "公開済み",
         "sendFailed": "送信失敗"
+      }
+    },
+    "adminMorningOps": {
+      "metaTitle": "Morning Ops Playbook",
+      "title": "Morning Ops Playbook",
+      "backToAdmin": "Back to admin",
+      "intro": "Use this page as your daily operator console: review overnight automation, decide go/adjust/stop, and send clear direction templates to the automation agent.",
+      "quickLinks": {
+        "title": "Quick navigation",
+        "runs": "Open runs",
+        "contentQuality": "Open content quality",
+        "contentQueue": "Open content queue",
+        "newsSources": "Open news sources",
+        "subscribers": "Open subscribers"
+      },
+      "morningRoutine": {
+        "title": "10-minute morning routine",
+        "step1": "Check /admin/runs for success/partial-failure/failure and first failure reason.",
+        "step2": "Check /admin/content-quality for freshAvgQualityScore and top recurring issues.",
+        "step3": "Check /admin/content-queue for review_required backlog and low-quality drafts.",
+        "step4": "Choose go, adjust, or stop and issue direction to the automation agent."
+      },
+      "decision": {
+        "title": "Decision matrix",
+        "go": {
+          "title": "Go",
+          "desc": "No critical failures and quality trend is stable or improving."
+        },
+        "adjust": {
+          "title": "Adjust",
+          "desc": "Runs are mostly healthy but quality issues are rising or output is unsatisfying."
+        },
+        "stop": {
+          "title": "Stop",
+          "desc": "Repeated failures, policy violations, or suspicious behavior; pause automation first."
+        }
+      },
+      "templates": {
+        "title": "Direction templates",
+        "newsletter": {
+          "title": "Template A - Newsletter quality improvement",
+          "body": "Based on last night's results, prioritize newsletter quality improvement.\\nGoals:\\n- reduce low_novelty\\n- increase evidence density\\n- improve customer actionability\\n\\nConstraints:\\n- keep low-risk policy\\n- keep auto-merge disabled\\n- make impact visible in /admin/content-quality within 24h\\n\\nExecute:\\n- tune pack/prompt\\n- run one full cycle\\n- report before/after metrics and change summary"
+        },
+        "blogPivot": {
+          "title": "Template B - Blog-first pivot",
+          "body": "Today, pivot toward blog quality and CTA impact over newsletter volume.\\nSuccess criteria:\\n- freshAvgQualityScore up\\n- no regression in freshReviewRequiredCount\\n- reduce body_too_short frequency\\n\\nReturn:\\n- what changed\\n- why it should work\\n- what to verify in /admin tomorrow morning"
+        },
+        "incident": {
+          "title": "Template C - Failure response",
+          "body": "Failure class detected: <fill_this>.\\nKeep automation in safe mode and run root-cause fix first.\\nThen execute retry window only and provide:\\n- root cause\\n- fix diff summary\\n- retry result\\n- recurrence prevention checklist"
+        }
+      },
+      "monitoring": {
+        "title": "How to confirm service is improving",
+        "item1": "Match automation run IDs with /admin/runs entries and recent autoloop reports.",
+        "item2": "Track freshAvgQualityScore and freshTopQualityIssues trend in /admin/content-quality.",
+        "item3": "Track queue health via review_required backlog and send_failed count.",
+        "item4": "Review source/subscriber integrity in /admin/news-sources and /admin/subscribers."
+      },
+      "emergency": {
+        "title": "Emergency pause",
+        "item1": "Create the stop-switch file to halt merge-capable runs.",
+        "item2": "Confirm next cycle stops with stopReason in autoloop report.",
+        "item3": "Remove stop-switch only after triage and policy confirmation.",
+        "windowsHint": "Windows (PowerShell):",
+        "windowsCommand": "New-Item -Path reports/autoloop/.automerge-stop -ItemType File -Force",
+        "macHint": "macOS/Linux:",
+        "macCommand": "mkdir -p reports/autoloop && touch reports/autoloop/.automerge-stop"
+      },
+      "actions": {
+        "copy": "Copy",
+        "copied": "Copied"
       }
     },
     "adminPurchaseAllowlist": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -904,6 +904,7 @@
         "runs": "실행 이력",
         "subscribers": "구독자",
         "contentQuality": "콘텐츠 품질 모니터",
+        "morningOps": "모닝 운영 플레이북",
         "waitlist": "대기명단",
         "purchaseAllowlist": "결제 허용 목록",
         "promptStudioAllowlist": "Prompt Studio 베타"
@@ -1107,6 +1108,10 @@
         "contentQuality": {
           "title": "콘텐츠 품질 모니터",
           "desc": "품질 신호, 실패 추세, 개선 포인트를 한 곳에서 추적합니다."
+        },
+        "morningOps": {
+          "title": "모닝 운영 플레이북",
+          "desc": "밤사이 작업을 점검하고 방향 전환 지시를 내리는 일일 운영 가이드입니다."
         },
         "subscribers": {
           "title": "구독자",
@@ -1417,6 +1422,78 @@
         "publishing": "발행 중",
         "published": "발행 완료",
         "sendFailed": "발송 실패"
+      }
+    },
+    "adminMorningOps": {
+      "metaTitle": "모닝 운영 플레이북",
+      "title": "모닝 운영 플레이북",
+      "backToAdmin": "관리 홈으로",
+      "intro": "이 페이지를 매일 운영 콘솔처럼 사용하세요. 밤사이 자동화 결과를 점검하고, go/adjust/stop 결정을 내린 뒤 에이전트에 방향 지시를 보냅니다.",
+      "quickLinks": {
+        "title": "빠른 이동",
+        "runs": "실행 이력 열기",
+        "contentQuality": "품질 모니터 열기",
+        "contentQueue": "콘텐츠 큐 열기",
+        "newsSources": "뉴스 소스 열기",
+        "subscribers": "구독자 열기"
+      },
+      "morningRoutine": {
+        "title": "출근 후 10분 루틴",
+        "step1": "/admin/runs에서 성공/부분실패/실패와 첫 실패 원인을 확인합니다.",
+        "step2": "/admin/content-quality에서 freshAvgQualityScore와 반복 이슈를 확인합니다.",
+        "step3": "/admin/content-queue에서 review_required 적체와 저품질 초안을 확인합니다.",
+        "step4": "go, adjust, stop 중 하나를 선택하고 자동화 에이전트에 방향을 지시합니다."
+      },
+      "decision": {
+        "title": "판단 매트릭스",
+        "go": {
+          "title": "Go",
+          "desc": "치명적 실패가 없고 품질 추세가 안정적이거나 개선 중입니다."
+        },
+        "adjust": {
+          "title": "Adjust",
+          "desc": "실행은 대체로 정상이나 품질 이슈가 증가하거나 결과가 만족스럽지 않습니다."
+        },
+        "stop": {
+          "title": "Stop",
+          "desc": "반복 실패, 정책 위반, 이상 동작이 의심되면 자동화를 먼저 정지합니다."
+        }
+      },
+      "templates": {
+        "title": "Direction templates",
+        "newsletter": {
+          "title": "템플릿 A - 뉴스레터 품질 개선",
+          "body": "지난 밤 결과 기준으로 뉴스레터 품질 개선을 우선합니다.\\n목표:\\n- low_novelty 감소\\n- 근거 밀도(evidence) 증가\\n- 고객 실행가능성(actionability) 강화\\n\\n제약:\\n- low-risk 정책 유지\\n- 자동머지 비활성 유지\\n- 24시간 내 /admin/content-quality에서 효과 확인\\n\\n실행:\\n- pack/prompt 조정\\n- 1회 사이클 실행\\n- before/after 지표와 변경 요약 보고"
+        },
+        "blogPivot": {
+          "title": "템플릿 B - 블로그 중심 피봇",
+          "body": "오늘은 뉴스레터보다 블로그 품질과 CTA 임팩트를 우선합니다.\\n성공 기준:\\n- freshAvgQualityScore 상승\\n- freshReviewRequiredCount 악화 없음\\n- body_too_short 빈도 감소\\n\\n보고:\\n- 변경한 내용\\n- 기대 효과\\n- 내일 아침 /admin에서 확인할 포인트"
+        },
+        "incident": {
+          "title": "템플릿 C - 장애 대응",
+          "body": "감지된 실패 클래스: <여기에 입력>.\\n자동화는 안전모드로 유지하고 원인 수정부터 수행하세요.\\n이후 retry window만 실행하고 아래를 보고하세요:\\n- 근본 원인\\n- 수정 요약\\n- 재실행 결과\\n- 재발 방지 체크리스트"
+        }
+      },
+      "monitoring": {
+        "title": "서비스 개선 여부 확인법",
+        "item1": "자동화 실행 ID와 /admin/runs, autoloop 리포트를 매칭해 확인합니다.",
+        "item2": "/admin/content-quality의 freshAvgQualityScore, freshTopQualityIssues 추세를 확인합니다.",
+        "item3": "review_required 적체량과 send_failed 수치를 함께 확인합니다.",
+        "item4": "/admin/news-sources, /admin/subscribers에서 입력/대상 이상 유무를 점검합니다."
+      },
+      "emergency": {
+        "title": "긴급 정지",
+        "item1": "merge 가능 실행을 즉시 멈추려면 stop-switch 파일을 생성합니다.",
+        "item2": "다음 사이클이 stopReason과 함께 중단되는지 확인합니다.",
+        "item3": "원인 분석과 정책 확인 후에만 stop-switch를 제거합니다.",
+        "windowsHint": "Windows (PowerShell):",
+        "windowsCommand": "New-Item -Path reports/autoloop/.automerge-stop -ItemType File -Force",
+        "macHint": "macOS/Linux:",
+        "macCommand": "mkdir -p reports/autoloop && touch reports/autoloop/.automerge-stop"
+      },
+      "actions": {
+        "copy": "복사",
+        "copied": "복사됨"
       }
     },
     "adminPurchaseAllowlist": {

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -896,6 +896,7 @@
         "runs": "运行记录",
         "subscribers": "订阅者",
         "contentQuality": "内容质量监控",
+        "morningOps": "Morning Ops Playbook",
         "waitlist": "候补名单",
         "purchaseAllowlist": "结账许可名单",
         "promptStudioAllowlist": "Prompt Studio 测试版"
@@ -1099,6 +1100,10 @@
         "contentQuality": {
           "title": "内容质量监控",
           "desc": "在一个页面追踪质量信号、失败趋势和改进重点。"
+        },
+        "morningOps": {
+          "title": "Morning Ops Playbook",
+          "desc": "Daily operator guide to review overnight work and issue direction pivots."
         },
         "subscribers": {
           "title": "订阅者",
@@ -1409,6 +1414,78 @@
         "publishing": "发布中",
         "published": "已发布",
         "sendFailed": "发送失败"
+      }
+    },
+    "adminMorningOps": {
+      "metaTitle": "Morning Ops Playbook",
+      "title": "Morning Ops Playbook",
+      "backToAdmin": "Back to admin",
+      "intro": "Use this page as your daily operator console: review overnight automation, decide go/adjust/stop, and send clear direction templates to the automation agent.",
+      "quickLinks": {
+        "title": "Quick navigation",
+        "runs": "Open runs",
+        "contentQuality": "Open content quality",
+        "contentQueue": "Open content queue",
+        "newsSources": "Open news sources",
+        "subscribers": "Open subscribers"
+      },
+      "morningRoutine": {
+        "title": "10-minute morning routine",
+        "step1": "Check /admin/runs for success/partial-failure/failure and first failure reason.",
+        "step2": "Check /admin/content-quality for freshAvgQualityScore and top recurring issues.",
+        "step3": "Check /admin/content-queue for review_required backlog and low-quality drafts.",
+        "step4": "Choose go, adjust, or stop and issue direction to the automation agent."
+      },
+      "decision": {
+        "title": "Decision matrix",
+        "go": {
+          "title": "Go",
+          "desc": "No critical failures and quality trend is stable or improving."
+        },
+        "adjust": {
+          "title": "Adjust",
+          "desc": "Runs are mostly healthy but quality issues are rising or output is unsatisfying."
+        },
+        "stop": {
+          "title": "Stop",
+          "desc": "Repeated failures, policy violations, or suspicious behavior; pause automation first."
+        }
+      },
+      "templates": {
+        "title": "Direction templates",
+        "newsletter": {
+          "title": "Template A - Newsletter quality improvement",
+          "body": "Based on last night's results, prioritize newsletter quality improvement.\\nGoals:\\n- reduce low_novelty\\n- increase evidence density\\n- improve customer actionability\\n\\nConstraints:\\n- keep low-risk policy\\n- keep auto-merge disabled\\n- make impact visible in /admin/content-quality within 24h\\n\\nExecute:\\n- tune pack/prompt\\n- run one full cycle\\n- report before/after metrics and change summary"
+        },
+        "blogPivot": {
+          "title": "Template B - Blog-first pivot",
+          "body": "Today, pivot toward blog quality and CTA impact over newsletter volume.\\nSuccess criteria:\\n- freshAvgQualityScore up\\n- no regression in freshReviewRequiredCount\\n- reduce body_too_short frequency\\n\\nReturn:\\n- what changed\\n- why it should work\\n- what to verify in /admin tomorrow morning"
+        },
+        "incident": {
+          "title": "Template C - Failure response",
+          "body": "Failure class detected: <fill_this>.\\nKeep automation in safe mode and run root-cause fix first.\\nThen execute retry window only and provide:\\n- root cause\\n- fix diff summary\\n- retry result\\n- recurrence prevention checklist"
+        }
+      },
+      "monitoring": {
+        "title": "How to confirm service is improving",
+        "item1": "Match automation run IDs with /admin/runs entries and recent autoloop reports.",
+        "item2": "Track freshAvgQualityScore and freshTopQualityIssues trend in /admin/content-quality.",
+        "item3": "Track queue health via review_required backlog and send_failed count.",
+        "item4": "Review source/subscriber integrity in /admin/news-sources and /admin/subscribers."
+      },
+      "emergency": {
+        "title": "Emergency pause",
+        "item1": "Create the stop-switch file to halt merge-capable runs.",
+        "item2": "Confirm next cycle stops with stopReason in autoloop report.",
+        "item3": "Remove stop-switch only after triage and policy confirmation.",
+        "windowsHint": "Windows (PowerShell):",
+        "windowsCommand": "New-Item -Path reports/autoloop/.automerge-stop -ItemType File -Force",
+        "macHint": "macOS/Linux:",
+        "macCommand": "mkdir -p reports/autoloop && touch reports/autoloop/.automerge-stop"
+      },
+      "actions": {
+        "copy": "Copy",
+        "copied": "Copied"
       }
     },
     "adminPurchaseAllowlist": {

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -896,6 +896,7 @@
         "runs": "執行紀錄",
         "subscribers": "訂閱者",
         "contentQuality": "內容品質監控",
+        "morningOps": "Morning Ops Playbook",
         "waitlist": "候補名單",
         "purchaseAllowlist": "結帳許可名單",
         "promptStudioAllowlist": "Prompt Studio 測試版"
@@ -1099,6 +1100,10 @@
         "contentQuality": {
           "title": "內容品質監控",
           "desc": "在單一頁面追蹤品質訊號、失敗趨勢與改善重點。"
+        },
+        "morningOps": {
+          "title": "Morning Ops Playbook",
+          "desc": "Daily operator guide to review overnight work and issue direction pivots."
         },
         "subscribers": {
           "title": "訂閱者",
@@ -1409,6 +1414,78 @@
         "publishing": "發佈中",
         "published": "已發佈",
         "sendFailed": "發送失敗"
+      }
+    },
+    "adminMorningOps": {
+      "metaTitle": "Morning Ops Playbook",
+      "title": "Morning Ops Playbook",
+      "backToAdmin": "Back to admin",
+      "intro": "Use this page as your daily operator console: review overnight automation, decide go/adjust/stop, and send clear direction templates to the automation agent.",
+      "quickLinks": {
+        "title": "Quick navigation",
+        "runs": "Open runs",
+        "contentQuality": "Open content quality",
+        "contentQueue": "Open content queue",
+        "newsSources": "Open news sources",
+        "subscribers": "Open subscribers"
+      },
+      "morningRoutine": {
+        "title": "10-minute morning routine",
+        "step1": "Check /admin/runs for success/partial-failure/failure and first failure reason.",
+        "step2": "Check /admin/content-quality for freshAvgQualityScore and top recurring issues.",
+        "step3": "Check /admin/content-queue for review_required backlog and low-quality drafts.",
+        "step4": "Choose go, adjust, or stop and issue direction to the automation agent."
+      },
+      "decision": {
+        "title": "Decision matrix",
+        "go": {
+          "title": "Go",
+          "desc": "No critical failures and quality trend is stable or improving."
+        },
+        "adjust": {
+          "title": "Adjust",
+          "desc": "Runs are mostly healthy but quality issues are rising or output is unsatisfying."
+        },
+        "stop": {
+          "title": "Stop",
+          "desc": "Repeated failures, policy violations, or suspicious behavior; pause automation first."
+        }
+      },
+      "templates": {
+        "title": "Direction templates",
+        "newsletter": {
+          "title": "Template A - Newsletter quality improvement",
+          "body": "Based on last night's results, prioritize newsletter quality improvement.\\nGoals:\\n- reduce low_novelty\\n- increase evidence density\\n- improve customer actionability\\n\\nConstraints:\\n- keep low-risk policy\\n- keep auto-merge disabled\\n- make impact visible in /admin/content-quality within 24h\\n\\nExecute:\\n- tune pack/prompt\\n- run one full cycle\\n- report before/after metrics and change summary"
+        },
+        "blogPivot": {
+          "title": "Template B - Blog-first pivot",
+          "body": "Today, pivot toward blog quality and CTA impact over newsletter volume.\\nSuccess criteria:\\n- freshAvgQualityScore up\\n- no regression in freshReviewRequiredCount\\n- reduce body_too_short frequency\\n\\nReturn:\\n- what changed\\n- why it should work\\n- what to verify in /admin tomorrow morning"
+        },
+        "incident": {
+          "title": "Template C - Failure response",
+          "body": "Failure class detected: <fill_this>.\\nKeep automation in safe mode and run root-cause fix first.\\nThen execute retry window only and provide:\\n- root cause\\n- fix diff summary\\n- retry result\\n- recurrence prevention checklist"
+        }
+      },
+      "monitoring": {
+        "title": "How to confirm service is improving",
+        "item1": "Match automation run IDs with /admin/runs entries and recent autoloop reports.",
+        "item2": "Track freshAvgQualityScore and freshTopQualityIssues trend in /admin/content-quality.",
+        "item3": "Track queue health via review_required backlog and send_failed count.",
+        "item4": "Review source/subscriber integrity in /admin/news-sources and /admin/subscribers."
+      },
+      "emergency": {
+        "title": "Emergency pause",
+        "item1": "Create the stop-switch file to halt merge-capable runs.",
+        "item2": "Confirm next cycle stops with stopReason in autoloop report.",
+        "item3": "Remove stop-switch only after triage and policy confirmation.",
+        "windowsHint": "Windows (PowerShell):",
+        "windowsCommand": "New-Item -Path reports/autoloop/.automerge-stop -ItemType File -Force",
+        "macHint": "macOS/Linux:",
+        "macCommand": "mkdir -p reports/autoloop && touch reports/autoloop/.automerge-stop"
+      },
+      "actions": {
+        "copy": "Copy",
+        "copied": "Copied"
       }
     },
     "adminPurchaseAllowlist": {

--- a/src/app/(admin)/admin/morning-ops/page.tsx
+++ b/src/app/(admin)/admin/morning-ops/page.tsx
@@ -1,0 +1,139 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { ClipboardList } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import {
+  MorningOpsPlaybookClient,
+  type MorningOpsTemplate,
+} from "@/components/admin/morning-ops-playbook-client";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("Dashboard.adminMorningOps");
+  return { title: t("metaTitle") };
+}
+
+export default async function AdminMorningOpsPage() {
+  const t = await getTranslations("Dashboard.adminMorningOps");
+
+  const quickLinks = [
+    { href: "/admin/runs", label: t("quickLinks.runs") },
+    { href: "/admin/content-quality", label: t("quickLinks.contentQuality") },
+    { href: "/admin/content-queue", label: t("quickLinks.contentQueue") },
+    { href: "/admin/news-sources", label: t("quickLinks.newsSources") },
+    { href: "/admin/subscribers", label: t("quickLinks.subscribers") },
+  ];
+
+  const templates: MorningOpsTemplate[] = [
+    {
+      id: "newsletter",
+      title: t("templates.newsletter.title"),
+      body: t("templates.newsletter.body"),
+    },
+    {
+      id: "blogPivot",
+      title: t("templates.blogPivot.title"),
+      body: t("templates.blogPivot.body"),
+    },
+    {
+      id: "incident",
+      title: t("templates.incident.title"),
+      body: t("templates.incident.body"),
+    },
+  ];
+
+  return (
+    <div className="min-h-screen bg-paper-50">
+      <div className="sticky top-0 z-30 flex h-12 items-center justify-between border-b border-ink-100 bg-paper-50 px-6">
+        <div className="flex min-w-0 items-center gap-2">
+          <ClipboardList className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+          <h1 className="truncate text-sm font-medium text-ink-900">{t("title")}</h1>
+        </div>
+        <Link href="/admin" className="text-xs text-vermilion-600 transition-colors hover:text-vermilion-700">
+          {t("backToAdmin")}
+        </Link>
+      </div>
+
+      <div className="max-w-5xl space-y-5 p-6">
+        <p className="text-sm leading-relaxed text-ink-700">{t("intro")}</p>
+
+        <section className="space-y-3 border border-ink-100 bg-paper-0 p-4">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-ink-700">{t("quickLinks.title")}</h2>
+          <div className="grid gap-2 md:grid-cols-3">
+            {quickLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="border border-ink-100 bg-paper-50 px-3 py-2 text-xs text-ink-800 transition-colors hover:bg-paper-0 hover:text-ink-900"
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-2 border border-ink-100 bg-paper-0 p-4">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-ink-700">{t("morningRoutine.title")}</h2>
+          <ol className="space-y-1 text-xs leading-relaxed text-ink-800">
+            <li>1. {t("morningRoutine.step1")}</li>
+            <li>2. {t("morningRoutine.step2")}</li>
+            <li>3. {t("morningRoutine.step3")}</li>
+            <li>4. {t("morningRoutine.step4")}</li>
+          </ol>
+        </section>
+
+        <section className="space-y-2 border border-ink-100 bg-paper-0 p-4">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-ink-700">{t("decision.title")}</h2>
+          <ul className="space-y-1 text-xs leading-relaxed text-ink-800">
+            <li>
+              <span className="font-medium text-ink-900">{t("decision.go.title")}:</span> {t("decision.go.desc")}
+            </li>
+            <li>
+              <span className="font-medium text-ink-900">{t("decision.adjust.title")}:</span>{" "}
+              {t("decision.adjust.desc")}
+            </li>
+            <li>
+              <span className="font-medium text-ink-900">{t("decision.stop.title")}:</span> {t("decision.stop.desc")}
+            </li>
+          </ul>
+        </section>
+
+        <MorningOpsPlaybookClient
+          heading={t("templates.title")}
+          templates={templates}
+          copyLabel={t("actions.copy")}
+          copiedLabel={t("actions.copied")}
+        />
+
+        <section className="space-y-2 border border-ink-100 bg-paper-0 p-4">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-ink-700">{t("monitoring.title")}</h2>
+          <ul className="space-y-1 text-xs leading-relaxed text-ink-800">
+            <li>- {t("monitoring.item1")}</li>
+            <li>- {t("monitoring.item2")}</li>
+            <li>- {t("monitoring.item3")}</li>
+            <li>- {t("monitoring.item4")}</li>
+          </ul>
+        </section>
+
+        <section className="space-y-2 border border-ink-100 bg-paper-0 p-4">
+          <h2 className="text-xs font-medium uppercase tracking-wide text-ink-700">{t("emergency.title")}</h2>
+          <ul className="space-y-1 text-xs leading-relaxed text-ink-800">
+            <li>- {t("emergency.item1")}</li>
+            <li>- {t("emergency.item2")}</li>
+            <li>- {t("emergency.item3")}</li>
+          </ul>
+          <div className="space-y-2 pt-2">
+            <p className="text-[11px] text-ink-500">{t("emergency.windowsHint")}</p>
+            <pre className="whitespace-pre-wrap border border-ink-100 bg-paper-50 p-2 text-[11px] text-ink-800">
+              {t("emergency.windowsCommand")}
+            </pre>
+            <p className="text-[11px] text-ink-500">{t("emergency.macHint")}</p>
+            <pre className="whitespace-pre-wrap border border-ink-100 bg-paper-50 p-2 text-[11px] text-ink-800">
+              {t("emergency.macCommand")}
+            </pre>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -71,6 +71,12 @@ export default async function ElevateServiceAdminHomePage() {
       icon: Sparkles,
     },
     {
+      href: "/admin/morning-ops",
+      title: t("cards.morningOps.title"),
+      desc: t("cards.morningOps.desc"),
+      icon: ListChecks,
+    },
+    {
       href: "/admin/subscribers",
       title: t("cards.subscribers.title"),
       desc: t("cards.subscribers.desc"),

--- a/src/components/admin/morning-ops-playbook-client.tsx
+++ b/src/components/admin/morning-ops-playbook-client.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+
+export type MorningOpsTemplate = {
+  id: string;
+  title: string;
+  body: string;
+};
+
+export function MorningOpsPlaybookClient({
+  heading,
+  templates,
+  copyLabel,
+  copiedLabel,
+}: {
+  heading: string;
+  templates: MorningOpsTemplate[];
+  copyLabel: string;
+  copiedLabel: string;
+}) {
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  async function onCopy(id: string, text: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedId(id);
+      setTimeout(() => setCopiedId((current) => (current === id ? null : current)), 2000);
+    } catch {
+      setCopiedId(null);
+    }
+  }
+
+  return (
+    <section className="space-y-3 border border-ink-100 bg-paper-0 p-4">
+      <h2 className="text-xs font-medium uppercase tracking-wide text-ink-700">{heading}</h2>
+      <div className="space-y-3">
+        {templates.map((template) => (
+          <article key={template.id} className="space-y-2 border border-ink-100 bg-paper-50 p-3">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="text-xs font-medium text-ink-900">{template.title}</h3>
+              <button
+                type="button"
+                onClick={() => void onCopy(template.id, template.body)}
+                className="rounded-(--radius-1) border border-ink-100 bg-paper-0 px-2 py-1 text-xs text-ink-700 transition-colors hover:bg-paper-50 hover:text-ink-900"
+              >
+                {copiedId === template.id ? copiedLabel : copyLabel}
+              </button>
+            </div>
+            <pre className="whitespace-pre-wrap border border-ink-100 bg-paper-0 p-3 text-[11px] leading-relaxed text-ink-800">
+              {template.body}
+            </pre>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+

--- a/src/components/desk/TOC.tsx
+++ b/src/components/desk/TOC.tsx
@@ -115,6 +115,10 @@ export function TOC({
               label: tx("admin.contentQuality", "Content quality monitor"),
             },
             {
+              href: "/admin/morning-ops",
+              label: tx("admin.morningOps", "Morning Ops Playbook"),
+            },
+            {
               href: "/admin/purchase-allowlist",
               label: tx("admin.purchaseAllowlist", "Checkout allowlist"),
             },
@@ -221,6 +225,7 @@ export function TOC({
       "/admin/runs": CircleHelp,
       "/admin/subscribers": Users,
       "/admin/content-quality": Sparkles,
+      "/admin/morning-ops": ListChecks,
       "/admin/purchase-allowlist": Shield,
       "/admin/prompt-studio-allowlist": Sparkles,
     };


### PR DESCRIPTION
## Summary
- add a new `/admin/morning-ops` playbook page for daily operator workflow (go/adjust/stop), quick links, monitoring checks, emergency stop guidance, and copyable agent direction templates
- add a reusable client component for copying direction templates from the UI
- wire the new page into admin home cards and admin TOC navigation
- add localization keys for all supported locales (`en`, `ko`, `ja`, `zh-CN`, `zh-TW`)

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:i18n`

## Operator impact
- admins can now start each day from `/admin/morning-ops` and issue consistent guidance to automation agents without leaving the admin interface

Made with [Cursor](https://cursor.com)