### PR TITLE
[BUG] 메인 ROI 섹션 부제에 디자인 메타 카피("Pretext") 노출

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -74,7 +74,7 @@
     "subhead": "Choose a target model, get structured analysis, and turn rough prompts into review-ready changes. Join the waitlist for Prompt Studio beta—then explore guides and templates in the catalog as we ship.",
     "pretextLine1": "ROI you can",
     "pretextLine2": "show in a meeting.",
-    "pretextSub": "Headlines stay balanced on every screen size—resize the window to see smooth reflow (Pretext).",
+    "pretextSub": "Answer 'What have we done with AI?' in 5 minutes—ready to show your team.",
     "ctaEbooks": "Browse catalog",
     "ctaWaitlist": "Join the waitlist",
     "ctaWaitlistB": "Join the launch waitlist",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -66,7 +66,7 @@
     "subhead": "対象モデルを選び、構造化された分析でラフなプロンプトをレビュー可能な状態へ。Prompt Studio ベータはウェイトリストから。リリースに合わせてカタログのガイドやテンプレートもご覧ください。",
     "pretextLine1": "ROI you can",
     "pretextLine2": "show in a meeting.",
-    "pretextSub": "画面サイズごとに見出しのバランスが保たれます。ウィンドウを変えてスムーズなリフローを試してください（Pretext）。",
+    "pretextSub": "「AIで何をしましたか？」という質問に5分で答えられる資料。",
     "ctaEbooks": "カタログを見る",
     "ctaWaitlist": "ウェイトリストに登録",
     "ctaWaitlistB": "Join the launch waitlist",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -74,7 +74,7 @@
     "subhead": "대상 모델을 고르고 구조화된 분석으로, 거친 프롬프트를 검토 가능한 수준까지 끌어올립니다. 프롬프트 스튜디오 베타는 대기 명단으로 받습니다. 출시에 맞춰 카탈로그의 가이드·템플릿도 함께 둘러보세요.",
     "pretextLine1": "회의실에서",
     "pretextLine2": "보여줄 수 있는 ROI.",
-    "pretextSub": "화면 크기마다 헤드라인 균형이 유지됩니다. 창 크기를 바꿔 부드러운 리플로우를 확인해 보세요(Pretext).",
+    "pretextSub": "회사 안에서 'AI로 뭘 했냐'는 질문에 5분 안에 답이 되는 자료.",
     "ctaEbooks": "카탈로그 보기",
     "ctaWaitlist": "대기 명단 등록",
     "ctaWaitlistB": "Join the launch waitlist",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -66,7 +66,7 @@
     "subhead": "选择目标模型，获得结构化分析，把粗糙提示打磨到可评审。Prompt Studio 测试版通过等候名单；随着发布可在目录中浏览指南与模板。",
     "pretextLine1": "ROI you can",
     "pretextLine2": "show in a meeting.",
-    "pretextSub": "5分钟内回答"我们用AI做了什么"——随时可向团队展示的资料。",
+    "pretextSub": "5分钟内回答\"我们用AI做了什么\"——随时可向团队展示的资料。",
     "ctaEbooks": "浏览目录",
     "ctaWaitlist": "加入等候名单",
     "ctaWaitlistB": "Join the launch waitlist",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -66,7 +66,7 @@
     "subhead": "选择目标模型，获得结构化分析，把粗糙提示打磨到可评审。Prompt Studio 测试版通过等候名单；随着发布可在目录中浏览指南与模板。",
     "pretextLine1": "ROI you can",
     "pretextLine2": "show in a meeting.",
-    "pretextSub": "不同屏幕尺寸下标题仍保持平衡。拖动窗口即可看到顺滑重排（Pretext）。",
+    "pretextSub": "5分钟内回答"我们用AI做了什么"——随时可向团队展示的资料。",
     "ctaEbooks": "浏览目录",
     "ctaWaitlist": "加入等候名单",
     "ctaWaitlistB": "Join the launch waitlist",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -66,7 +66,7 @@
     "subhead": "選擇目標模型，獲得結構化分析，把粗糙提示打磨到可審查。Prompt Studio 測試版透過等候名單；隨著發布可在目錄瀏覽指南與範本。",
     "pretextLine1": "ROI you can",
     "pretextLine2": "show in a meeting.",
-    "pretextSub": "不同螢幕尺寸下標題仍保持平衡。拖曳視窗即可看到順暢重排（Pretext）。",
+    "pretextSub": "5分鐘內回答「我們用AI做了什麼」——隨時可向團隊展示的資料。",
     "ctaEbooks": "瀏覽目錄",
     "ctaWaitlist": "加入等候名單",
     "ctaWaitlistB": "Join the launch waitlist",

--- a/tests/unit/messages-meta-vocabulary-guard.test.ts
+++ b/tests/unit/messages-meta-vocabulary-guard.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const messagesDir = join(__dirname, "../../messages");
+
+/**
+ * Design system meta vocabulary that should never appear in user-facing copy.
+ * These terms are for builders/designers, not end users.
+ */
+const FORBIDDEN_META_VOCABULARY = [
+  // Design system references
+  "Pretext",
+  "pretext",
+  "(Pretext)",
+  "（Pretext）",
+  
+  // Technical design terms
+  "Headlines stay balanced",
+  "見出しのバランスが保たれ",
+  "헤드라인 균형이 유지",
+  "标题仍保持平衡",
+  "標題仍保持平衡",
+  
+  // Reflow/resize instructions
+  "smooth reflow",
+  "スムーズなリフロー",
+  "부드러운 리플로우",
+  "顺滑重排",
+  "順暢重排",
+  "resize the window",
+  "ウィンドウを変えて",
+  "창 크기를 바꿔",
+  "拖动窗口",
+  "拖曳視窗",
+] as const;
+
+function loadJson(name: string): unknown {
+  const raw = readFileSync(join(messagesDir, name), "utf8");
+  return JSON.parse(raw) as unknown;
+}
+
+/** Recursively collect all string values from a nested object */
+function collectAllStrings(value: unknown): string[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (value === null || typeof value !== "object") {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap(collectAllStrings);
+  }
+  return Object.values(value as Record<string, unknown>).flatMap(collectAllStrings);
+}
+
+describe("messages meta vocabulary guard (no builder jargon in user copy)", () => {
+  const locales = ["en.json", "ko.json", "ja.json", "zh-CN.json", "zh-TW.json"] as const;
+
+  it.each(locales)(
+    "%s does not contain forbidden design meta vocabulary",
+    (file) => {
+      const data = loadJson(file) as Record<string, unknown>;
+      const allStrings = collectAllStrings(data);
+      const fullText = allStrings.join("\n");
+
+      const violations: Array<{ term: string; found: string }> = [];
+
+      for (const term of FORBIDDEN_META_VOCABULARY) {
+        if (fullText.includes(term)) {
+          // Find which string(s) contain this term
+          const matches = allStrings.filter((s) => s.includes(term));
+          matches.forEach((match) => {
+            violations.push({ term, found: match });
+          });
+        }
+      }
+
+      if (violations.length > 0) {
+        const report = violations
+          .map(({ term, found }) => `  - Term: "${term}"\n    Found in: "${found}"`)
+          .join("\n");
+        throw new Error(
+          `Found ${violations.length} forbidden meta vocabulary term(s) in ${file}:\n${report}`,
+        );
+      }
+
+      expect(violations).toHaveLength(0);
+    },
+  );
+
+  it("guard list is not empty", () => {
+    expect(FORBIDDEN_META_VOCABULARY.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixed design system meta text leaking into user-facing copy on the homepage ROI section. Replaced builder memo text with actionable user value copy across all locales.

## Issue Context

**Closes #57**

**Audit Source:** This PR resolves findings from `reports/2026-05-02-claude-audit.md` §0 TL;DR #2, §2.1

### Problem
The subtitle under the "ROI you can show in a meeting." headline was exposing design system demo text instead of user-facing value proposition:
- **Before:** `"Headlines stay balanced on every screen size—resize the window to see smooth reflow (Pretext)."`
- **After:** User-focused copy addressing real pain points

## Changes Made

### Copy Strategy Decision
**Selected Option 2 (Content tone)** from issue candidates:
- ✅ **Option 2:** "Answer 'What have we done with AI?' in 5 minutes—ready to show your team."
- ❌ Option 1: Product-focused tone
- ❌ Option 3: Substack-style tone

**Rationale for Option 2:**
- Directly addresses the common executive question: "AI로 뭘 했냐?" (What have we done with AI?)
- Aligns with R님's intent: AI 활용 꿀팁 + 학습 없이 따라할 수 있는 프로세스
- Emphasizes quick, actionable answers (5 minutes)
- More practical and relatable than abstract product features
- Fits the "show in a meeting" context perfectly

### Localized Copy Updates

| Locale | New Copy |
|--------|----------|
| 🇺🇸 en | Answer 'What have we done with AI?' in 5 minutes—ready to show your team. |
| 🇰🇷 ko | 회사 안에서 'AI로 뭘 했냐'는 질문에 5분 안에 답이 되는 자료. |
| 🇯🇵 ja | 「AIで何をしましたか？」という質問に5分で答えられる資料。 |
| 🇨🇳 zh-CN | 5分钟内回答"我们用AI做了什么"——随时可向团队展示的资料。 |
| 🇹🇼 zh-TW | 5分鐘內回答「我們用AI做了什麼」——隨時可向團隊展示的資料。 |

### Files Changed
- `messages/en.json` - English copy update
- `messages/ko.json` - Korean copy update
- `messages/ja.json` - Japanese copy update
- `messages/zh-CN.json` - Simplified Chinese copy update
- `messages/zh-TW.json` - Traditional Chinese copy update
- `tests/unit/messages-meta-vocabulary-guard.test.ts` - **NEW:** Regression test

### Meta Text Removal Verification
Confirmed zero occurrences of design meta vocabulary in user-facing content:
- ✅ `"Headlines stay balanced"` - 0 occurrences
- ✅ `"smooth reflow"` - 0 occurrences
- ✅ `"(Pretext)"` / `"（Pretext）"` - 0 occurrences (only in archive docs)

### Regression Guard (NEW)
Added `tests/unit/messages-meta-vocabulary-guard.test.ts`:
- Vitest test that fails if forbidden meta vocabulary appears in any locale's messages
- Guards against 15+ meta terms across all 5 languages
- Prevents future accidental leaks of builder jargon into user copy
- Runs as part of `pnpm test` and `pnpm verify`

**Forbidden terms list includes:**
- "Pretext", "(Pretext)", "（Pretext）"
- "Headlines stay balanced" (+ all locale variants)
- "smooth reflow" (+ all locale variants)
- "resize the window" (+ all locale variants)

## DoD Status

- [x] ROI section subtitle replaced with Option 2 copy across all locales
- [x] Zero design meta vocabulary in user-facing text confirmed
- [x] All 5 locales updated: en, ko, ja, zh-CN, zh-TW
- [x] **Regression guard test added** (`messages-meta-vocabulary-guard.test.ts`)
- [ ] `pnpm verify` check (requires Node.js environment setup - see note below)

## Environment Note

⚠️ **Node.js environment not configured in this cloud agent instance.** The changes are:
1. Content/copy updates in JSON files (no logic changes)
2. New Vitest test file (TypeScript)

Both are safe and follow project patterns. However, `pnpm verify` (lint + typecheck + test + build) should be run before merge:

```bash
pnpm verify
```

The new test will automatically run as part of `pnpm test` and will fail the build if any forbidden meta vocabulary appears in user-facing messages in the future.

If the repository requires systematic environment setup across cloud agents, consider running an env setup agent at [cursor.com/onboard](https://cursor.com/onboard).

## Review Checklist

- [x] Copy decision documented with rationale
- [x] All locale files updated consistently
- [x] Meta text removal verified via grep
- [x] Regression test added and committed
- [x] Commit messages follow Conventional Commits
- [x] PR links to issue and audit report
- [ ] Manual verification on staging/preview (recommended)
- [ ] Human approval for copy quality and tone

---

**Related Issues:**
- Similar meta leak pattern: #4 (photo credit in blog content)

**Testing:**
To verify the fix locally or in preview:
1. Navigate to homepage: `https://elevate.ai.kr/` (or preview URL)
2. Locate "ROI you can show in a meeting." section
3. Confirm subtitle shows user value copy, not design meta text
4. Test locale switcher to verify all translations

To verify the regression guard:
```bash
pnpm test tests/unit/messages-meta-vocabulary-guard.test.ts
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6af41bf5-6089-4339-aba4-dfcad39d3807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6af41bf5-6089-4339-aba4-dfcad39d3807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

