### PR TITLE
[CONTENT] Remove MICE legacy 'event communications' from blog tagline

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -227,7 +227,7 @@
   "Blog": {
     "metaTitle": "Blog",
     "title": "Blog",
-    "description": "Practical ideas on prompt improvement and event communications—plus product news from the Elevate team.",
+    "description": "Weekly AI workflow guides your company can use right away—no training required. Product updates from the Elevate team.",
     "empty": "No posts yet.",
     "published": "Published {date}",
     "readMore": "Read article",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -219,7 +219,7 @@
   "Blog": {
     "metaTitle": "ブログ",
     "title": "ブログ",
-    "description": "プロンプト改善とイベント・現場コミュニケーションに役立つヒント、そして Elevate チームからの製品ニュースをお届けします。",
+    "description": "毎週配信、すぐに使える AI 運用マニュアル—学習不要。Elevate チームの製品情報も。",
     "empty": "まだ記事がありません。",
     "published": "公開日 {date}",
     "readMore": "記事を読む",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -227,7 +227,7 @@
   "Blog": {
     "metaTitle": "블로그",
     "title": "블로그",
-    "description": "프롬프트 개선과 행사·현장 커뮤니케이션에 바로 쓸 만한 인사이트, 그리고 Elevate 팀의 제품 소식을 모았습니다.",
+    "description": "매주 한 통, 회사가 그대로 쓸 수 있는 AI 운영 매뉴얼. Elevate 팀의 제품 소식도 함께.",
     "empty": "아직 게시물이 없습니다.",
     "published": "게시 {date}",
     "readMore": "글 읽기",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -219,7 +219,7 @@
   "Blog": {
     "metaTitle": "博客",
     "title": "博客",
-    "description": "分享提示词改进与活动／现场沟通的实用观点，以及 Elevate 团队的产品动态。",
+    "description": "每周一份，公司可直接使用的 AI 运营手册—无需培训。Elevate 团队产品动态。",
     "empty": "暂无文章。",
     "published": "发布 {date}",
     "readMore": "阅读全文",

--- a/messages/zh-TW.json
+++ b/messages/zh-TW.json
@@ -219,7 +219,7 @@
   "Blog": {
     "metaTitle": "部落格",
     "title": "部落格",
-    "description": "分享提示詞改進與活動／現場溝通的實用觀點，以及 Elevate 團隊的產品消息。",
+    "description": "每週一份，公司可直接使用的 AI 運營手冊—無需培訓。Elevate 團隊產品消息。",
     "empty": "尚無文章。",
     "published": "發布 {date}",
     "readMore": "閱讀全文",

--- a/tests/unit/blog-mice-legacy-guard.test.ts
+++ b/tests/unit/blog-mice-legacy-guard.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const messagesDir = join(__dirname, "../../messages");
+
+/** MICE legacy terms that must not appear in user-facing blog content */
+const MICE_LEGACY_PATTERNS = [
+  /event communications?/i,
+  /events and sessions/i,
+  /meetings,?\s*events/i,
+  /イベント[・･]現場コミュニケーション/i,
+  /活動[／/]現場溝通/i,
+  /행사[·・･]현장\s*커뮤니케이션/i,
+] as const;
+
+function loadLocaleMessages(locale: string): Record<string, unknown> {
+  const raw = readFileSync(join(messagesDir, `${locale}.json`), "utf8");
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+describe("Blog tagline MICE legacy guard", () => {
+  const locales = ["en", "ko", "ja", "zh-CN", "zh-TW"] as const;
+
+  it.each(locales)(
+    "%s blog tagline must not contain MICE legacy terms",
+    (locale) => {
+      const messages = loadLocaleMessages(locale);
+      const blogSection = (messages as { Blog?: { description?: string } }).Blog;
+
+      expect(
+        blogSection,
+        `Blog section missing in ${locale}.json`,
+      ).toBeDefined();
+      expect(
+        blogSection?.description,
+        `Blog.description missing in ${locale}.json`,
+      ).toBeDefined();
+
+      const description = blogSection?.description ?? "";
+
+      for (const pattern of MICE_LEGACY_PATTERNS) {
+        expect(
+          description,
+          `${locale}.json Blog.description contains MICE legacy term matching ${pattern}`,
+        ).not.toMatch(pattern);
+      }
+    },
+  );
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes MICE legacy positioning ("event communications") from blog index tagline across all 5 locales. Replaces with AI workflow platform copy aligned with README positioning: "AI adoption and workflow platform (pivot in progress)".

## Changes

### Content Updates (5 locales)
- **en**: `"Weekly AI workflow guides your company can use right away—no training required. Product updates from the Elevate team."`
- **ko**: `"매주 한 통, 회사가 그대로 쓸 수 있는 AI 운영 매뉴얼. Elevate 팀의 제품 소식도 함께."`
- **ja**: `"毎週配信、すぐに使える AI 運用マニュアル—学習不要。Elevate チームの製品情報も。"`
- **zh-CN**: `"每周一份,公司可直接使用的 AI 运营手册—无需培训。Elevate 团队产品动态。"`
- **zh-TW**: `"每週一份,公司可直接使用的 AI 運營手冊—無需培訓。Elevate 團隊產品消息。"`

**Copy selection rationale**: Selected option 2 from issue (weekly AI workflow guides, no training required) as best match for R's stated intent: "AI 활용 꿀팁 + 학습 없이 따라할 수 있는 프로세스".

### Regression Guard
- Added `tests/unit/blog-mice-legacy-guard.test.ts` with pattern matching for all MICE legacy terms across all locales
- Test fails if any Blog.description contains: `event communications`, `events and sessions`, `meetings, events`, or CJK equivalents

## Verification

✅ **Zero instances of MICE legacy terms** (grep verified):
- `event communications` — 0 matches
- `events and sessions` — 0 matches  
- `meetings, events` — 0 matches
- CJK equivalents — 0 matches

✅ **All content tests pass**:
- `messages-locale-parity.test.ts` — 8/8 pass (all locales have matching keys)
- `blog-mice-legacy-guard.test.ts` — 5/5 pass (all locales free of MICE terms)

⚠️ **Pre-existing test failures** (confirmed on main branch before changes):
- `blog-subscription.test.ts` (Polar checkout URL format change)
- `posthog-public.test.ts` (PostHog config logic)

## Impact

- **User-facing**: Blog index tagline at `/blog` (all locales)
- **SEO/OG**: `Blog.description` used in `page.tsx` for `meta.description`, `og:description`, `twitter:description`
- **RSS**: Feed uses separate hardcoded `FEED_SUBTITLE` (unchanged, already pivot-aligned)
- **Sitemap**: Uses dynamic page metadata (now updated via this change)

## Audit References

Closes #58

This PR addresses the following sections from `reports/2026-05-02-claude-audit.md`:
- **§0 TL;DR #3**: "Blog index tagline still says 'event communications'—contradicts README pivot statement"
- **§2.2**: "Blog tagline mismatch—'event communications' vs AI platform positioning"
- **§3.3**: "MICE vocabulary leakage in user-facing copy"

## Related

- Source batch: `reports/github-issues-batch-2026-05-02.md`
- Previous MICE cleanup: PR #64 (blog post sample leak)
- North Star: `memory-bank/creative-elevate-ai-pivot.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3444c90b-6d96-449b-bc72-fd77449a6b6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3444c90b-6d96-449b-bc72-fd77449a6b6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

