### PR TITLE
chore(content-ops): gate51 trend check and close helper

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -356,6 +356,16 @@ Result:
   - `pnpm run typecheck` (pass)
   - `pnpm exec vitest run tests/unit/content-ops-queue-triage.test.ts tests/unit/content-ops-config-stop-policy.test.ts` (pass)
   - `pnpm run content-ops:gate-check` (pass, latest gate output recorded)
+- `#51` closeout routine update:
+  - Added script: `scripts/content-ops-gate51-trend-check.ts`
+  - Added command: `pnpm run content-ops:gate51-trend-check`
+  - Latest output (2026-05-02):
+    - `status=PENDING`
+    - `decisionReason=insufficient multi-day trend buckets`
+    - available bucket: `2026-05-01` only
+  - Closure is deferred until at least 2 day buckets exist and latest day improves for both:
+    - `lowNoveltyRatio`
+    - `blogReviewRequiredRatio`
 
 ## Gate Close Protocol (Deterministic)
 

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -43,17 +43,17 @@ Goal: execute stabilization backlog from remote issues after INIT foundation del
   - Order: `3` (starts after #49/#50 publish-path stabilization)
   - Status: `operational_gate_pending_multiday_trend_required`
   - Acceptance: one full cycle after change shows lower `low_novelty` share and better blog review-required trend.
-  - Verify: quality monitor + `content_items` low_novelty/review_required SQL.
-- [ ] #52 `[STAB][P1] strategy-scoreboard-activation-quality`
-  - Status: `operational_gate_passed`
+  - Verify: `pnpm run content-ops:gate51-trend-check` + quality monitor + `content_items` low_novelty/review_required SQL.
+- [x] #52 `[STAB][P1] strategy-scoreboard-activation-quality`
+  - Status: `operational_gate_passed` (GitHub closed 2026-05-03)
   - Acceptance: strategy scoreboard sample non-zero and winner selection meaningful.
   - Verify: snapshot output + `/admin/content-quality` scoreboard state.
-- [ ] #53 `[STAB][P1] citation-coverage-enablement`
-  - Status: `operational_gate_passed_initial_trend`
+- [x] #53 `[STAB][P1] citation-coverage-enablement`
+  - Status: `operational_gate_passed_initial_trend` (GitHub closed 2026-05-03)
   - Acceptance: `citationCoverage7dAvg` becomes non-zero and trendable.
   - Verify: quality monitor 24h/7d citation cards + reason distribution.
-- [ ] #54 `[STAB][P1] escalation-action-loop-hardening`
-  - Status: `operational_gate_passed_simulated_e2e`
+- [x] #54 `[STAB][P1] escalation-action-loop-hardening`
+  - Status: `operational_gate_passed_simulated_e2e` (GitHub closed 2026-05-03)
   - Acceptance: regression alert path includes owner-assigned next-action loop.
   - Verify: `content_runs.metadata.alert` payload usability + `/admin/morning-ops` action flow.
 
@@ -109,6 +109,7 @@ Goal: execute stabilization backlog from remote issues after INIT foundation del
 - [x] Bring publication fail ratio under `<20%` and keep retry waste low over consecutive daily windows.
   - Gate-check result (2026-05-02 latest): `gate50=PASS` (`failRatio24=0`, `retryExhausted24=0`).
 - [ ] Capture second-day novelty trend to confirm `low_novelty` and blog review_required movement.
+  - Latest check (2026-05-03): `PENDING` (`pnpm run content-ops:gate51-trend-check` — multi-day bucket insufficient; only `2026-05-01` bucket present).
 - [ ] Resolve runtime-source alignment (`cursor` vs `vercel-cron`) and confirm first `scheduled` run is persisted in `content_runs.trigger_type`.
   - Evidence: first `scheduled` rows persisted (`source=cursor` success + `source=vercel-cron` mismatch failure) on 2026-05-02.
 - [x] Lock executor strategy before `#53`: Cursor Cloud Agent first, Vercel cron emergency fallback only.
@@ -131,5 +132,5 @@ Goal: execute stabilization backlog from remote issues after INIT foundation del
 
 - [x] All INIT issues (#38-#47) are closed with explicit rationale.
 - [ ] P0 stabilization issues (#49-#51) complete with verified metric movement.
-- [ ] P1 stabilization issues (#52-#54) complete with operational action loop.
+- [x] P1 stabilization issues (#52-#54) complete with operational action loop.
 - [ ] Re-audit report after one business-day cycle is recorded.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "content-ops:quality:monitor": "pnpm tsx scripts/content-ops-quality-monitor.ts",
     "content-ops:daily-snapshot": "pnpm tsx scripts/content-ops-daily-snapshot.ts",
     "content-ops:gate-check": "pnpm tsx scripts/content-ops-gate-check.ts",
+    "content-ops:gate51-trend-check": "pnpm tsx scripts/content-ops-gate51-trend-check.ts",
     "pr:automerge:safe": "pnpm tsx scripts/pr-automerge-safe.ts",
     "autoloop:poc": "pnpm tsx scripts/continuous-improvement-loop.ts",
     "autoloop:rehearsal": "pnpm autoloop:poc --mode=rehearsal --allow-dirty-tree --max-cycles=3 --max-hours=1 --interval-minutes=5",

--- a/scripts/close-gate51-if-pass.sh
+++ b/scripts/close-gate51-if-pass.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# One-click gate close helper for issue #51.
+# - Runs gate51 multi-day trend check
+# - Runs global gate check
+# - Closes GitHub issue #51 when both checks report PASS
+# - Otherwise posts a PENDING status comment and keeps the issue open
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: GitHub CLI (gh) is required." >&2
+  exit 1
+fi
+
+echo "→ running #51 trend check"
+TREND_OUT="$(pnpm run content-ops:gate51-trend-check)"
+echo "$TREND_OUT" > /tmp/gate51-trend-check.out
+
+echo "→ running global gate check"
+GATE_OUT="$(pnpm run content-ops:gate-check)"
+echo "$GATE_OUT" > /tmp/gate-check.out
+
+TREND_PASS=false
+GATE51_PASS=false
+
+if echo "$TREND_OUT" | grep -q '"status": "PASS"'; then
+  TREND_PASS=true
+fi
+
+if echo "$GATE_OUT" | grep -A8 '"gate51"' | grep -q '"status": "PASS"'; then
+  GATE51_PASS=true
+fi
+
+if [[ "$TREND_PASS" == "true" && "$GATE51_PASS" == "true" ]]; then
+  echo "→ #51 PASS detected, closing issue"
+  gh issue close 51 --comment "$(cat <<'EOF'
+#51 gate close (multi-day trend) — PASS
+
+- Command: `pnpm run content-ops:gate51-trend-check`
+- Command: `pnpm run content-ops:gate-check`
+- Result: `gate51=PASS`
+
+Evidence files:
+- `/tmp/gate51-trend-check.out`
+- `/tmp/gate-check.out`
+
+Closure rationale:
+- Multi-day trend confirmation satisfied.
+- Novelty recovery signal is stable enough for operational closure.
+EOF
+)"
+  echo "✓ #51 closed"
+  exit 0
+fi
+
+echo "→ #51 is still pending, posting status comment"
+gh issue comment 51 --body "$(cat <<'EOF'
+#51 gate recheck — PENDING
+
+- Command: `pnpm run content-ops:gate51-trend-check`
+- Command: `pnpm run content-ops:gate-check`
+- Result: `gate51=PENDING`
+
+Blocker:
+- Multi-day trend condition is not yet fully satisfied.
+
+Next action:
+- Re-run the same checks in the next daily window.
+EOF
+)"
+
+echo "⏸ #51 kept open (pending)."

--- a/scripts/content-ops-gate51-trend-check.ts
+++ b/scripts/content-ops-gate51-trend-check.ts
@@ -1,0 +1,115 @@
+import dotenv from "dotenv";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+dotenv.config({ path: ".env.local" });
+
+const MIN_DAY_BUCKETS = Number.parseInt(
+  process.env.CONTENT_OPS_GATE51_MIN_DAY_BUCKETS ?? "2",
+  10,
+);
+const LOOKBACK_DAYS = Number.parseInt(
+  process.env.CONTENT_OPS_GATE51_LOOKBACK_DAYS ?? "7",
+  10,
+);
+
+type DayBucket = {
+  total: number;
+  lowNovelty: number;
+  blogTotal: number;
+  blogReviewRequired: number;
+};
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function extractReviewReasons(metadata: unknown): string[] {
+  const root = asObject(metadata);
+  const latest =
+    asObject(asObject(root?.review_gate)?.latest) ??
+    asObject(asObject(root?.reviewGate)?.latest);
+  const reasons = latest?.reasons;
+  if (!Array.isArray(reasons)) return [];
+  return reasons.filter((entry): entry is string => typeof entry === "string");
+}
+
+async function main() {
+  const admin = createAdminClient();
+  const sinceIso = new Date(Date.now() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const { data, error } = await admin
+    .from("content_items")
+    .select("type,status,created_at,metadata")
+    .gte("created_at", sinceIso)
+    .order("created_at", { ascending: true });
+
+  if (error) throw new Error(`content_items_query_failed:${error.message}`);
+
+  const byDay = new Map<string, DayBucket>();
+  for (const row of data ?? []) {
+    const day = new Date(row.created_at).toISOString().slice(0, 10);
+    const cur = byDay.get(day) ?? {
+      total: 0,
+      lowNovelty: 0,
+      blogTotal: 0,
+      blogReviewRequired: 0,
+    };
+    cur.total += 1;
+    if (extractReviewReasons(row.metadata).includes("low_novelty")) {
+      cur.lowNovelty += 1;
+    }
+    if (row.type === "blog") {
+      cur.blogTotal += 1;
+      if (row.status === "review_required") cur.blogReviewRequired += 1;
+    }
+    byDay.set(day, cur);
+  }
+
+  const trend = Array.from(byDay.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([day, bucket]) => ({
+      day,
+      total: bucket.total,
+      lowNovelty: bucket.lowNovelty,
+      lowNoveltyRatio: bucket.total > 0 ? Number((bucket.lowNovelty / bucket.total).toFixed(4)) : 0,
+      blogTotal: bucket.blogTotal,
+      blogReviewRequired: bucket.blogReviewRequired,
+      blogReviewRequiredRatio:
+        bucket.blogTotal > 0
+          ? Number((bucket.blogReviewRequired / bucket.blogTotal).toFixed(4))
+          : 0,
+    }));
+
+  let status: "PASS" | "PENDING" = "PENDING";
+  let decisionReason = "insufficient multi-day trend buckets";
+  if (trend.length >= MIN_DAY_BUCKETS) {
+    const prev = trend[trend.length - 2];
+    const latest = trend[trend.length - 1];
+    const lowNoveltyImproved = latest.lowNoveltyRatio <= prev.lowNoveltyRatio;
+    const blogReviewImproved = latest.blogReviewRequiredRatio <= prev.blogReviewRequiredRatio;
+    status = lowNoveltyImproved && blogReviewImproved ? "PASS" : "PENDING";
+    decisionReason = lowNoveltyImproved && blogReviewImproved
+      ? "latest daily trend improved for low_novelty and blog review_required ratio"
+      : "latest daily trend does not show simultaneous improvement";
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        lookbackDays: LOOKBACK_DAYS,
+        minDayBuckets: MIN_DAY_BUCKETS,
+        status,
+        decisionReason,
+        trend,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  console.error("[content-ops-gate51-trend-check] failed:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds operational tooling for STAB gate **#51** (novelty multi-day trend) and syncs Memory Bank with GitHub issue state.

## Changes

- `scripts/content-ops-gate51-trend-check.ts` — daily bucket trend for `low_novelty` and blog `review_required` ratios
- `pnpm run content-ops:gate51-trend-check` in `package.json`
- `scripts/close-gate51-if-pass.sh` — runs trend + global gate check; closes #51 or posts PENDING (requires `gh`, `.env.local` for Supabase admin)
- `memory-bank/tasks.md` / `progress.md` — mark P1 STAB #52–#54 closed; refresh #51 pending note

## Verification

- `pnpm run typecheck` (local)

## Notes

- Scripts are operator-only; not added to `pnpm verify`.

Made with [Cursor](https://cursor.com)