### PR TITLE
docs: P0 AI-native workflow (session reset + MCP-first external APIs)

### DIFF
--- a/docs/AI_EXPERT_PROMPTS.md
+++ b/docs/AI_EXPERT_PROMPTS.md
@@ -17,6 +17,10 @@
 5. **검증 일원화** — 이 저장소는 변경 후 **`pnpm verify`**(또는 작업에 맞는 최소 하위 집합)로 맞춘다. ([`AGENTS.md`](../AGENTS.md) · 커밋 규칙 우선.)
 6. **비밀 금지** — 키·토큰·`.env.local` 내용을 프롬프트나 PR 본문에 넣지 않는다.
 
+### 1b. 긴 디버그·세션 리셋
+
+같은 스레드에서 디버그가 **길어지면**(가이드: 사용자 메시지 **약 20턴** 초과) 컨텍스트 오염 위험이 커진다. **새 채팅**을 열고, `memory-bank/tasks.md`·`activeContext.md`에서 **목표·범위만** 인용한 뒤 **블록 A**를 맨 위에 다시 붙여 세션을 재고정한다. 단계별 설명·근거 링크는 [`MEMORY_BANK_SKILL_GUIDE.md`](./MEMORY_BANK_SKILL_GUIDE.md) **§ 긴 디버그·세션 리셋**에 둔다(여기서는 중복하지 않음).
+
 제안만 하고 끝내지 말고, 사용자가 **다음 세션에 그대로 재사용**할 수 있도록 아래 **블록 A~C** 중 하나를 함께 넘긴다. (저장소 에이전트 규약: **`AGENTS.md`** § Session handoff · **`CLAUDE.md`** § AI orchestration · `.cursor/rules/ai-session-bootstrap.mdc` §4.)
 
 ---

--- a/docs/AI_ORCHESTRATION.md
+++ b/docs/AI_ORCHESTRATION.md
@@ -44,6 +44,8 @@
 
 불필요한 전체 붙여넣기 대신 **파일 경로를 주고 읽게 한다** — 컨텍스트 비용과 드리프트를 줄인다.
 
+**결제·외부 API·PII**가 걸리는 작업에서는, 채팅에 스펙 요약만 던지고 끝내지 말고 **공식 문서 MCP**(또는 저장소에 이미 연결된 동등한 도구)로 최신 스펙·플로우를 가져오게 한다. 문서만으로 생성할 때 흔한 **SDK 경로 오류·결제 플로우 위반·시크릿의 클라이언트 노출**을 줄이려는 실무 패턴이다([토스페이먼츠 MCP 서버 구현기](https://toss.tech/article/37777)). 세부 비밀·금지 사항은 아래 **§6**과 동일하다. 관련 PLAN: [`features/PLAN-ai-native-workflow-evolution-2026-05.md`](./features/PLAN-ai-native-workflow-evolution-2026-05.md) §4 P0.
+
 **제안·로드맵·“다음 작업” 응답 시:** 한 가지 **최선안**을 먼저 제시하고, [`AI_EXPERT_PROMPTS.md`](./AI_EXPERT_PROMPTS.md) §1 의사결정 바를 따른다. 가능하면 사용자가 다음 탭에 붙여 넣을 **블록 B/C 형태의 완성 프롬프트**를 함께 출력한다.
 
 ---
@@ -85,6 +87,8 @@
 | 문서 | 용도 |
 |------|------|
 | [`AI_USAGE.md`](./AI_USAGE.md) | 짧은 진입점 |
+| [`MEMORY_BANK_SKILL_GUIDE.md`](./MEMORY_BANK_SKILL_GUIDE.md) | `elevate-memory-bank-bootstrap` 스킬로 세션 시작 (팀 가이드) |
+| [`features/PLAN-ai-native-workflow-evolution-2026-05.md`](./features/PLAN-ai-native-workflow-evolution-2026-05.md) | 업계·커뮤니티·벤더 리서치 대비 갭·BUILD 백로그 (PLAN) |
 | [`GSTACK.md`](./GSTACK.md) | vendored gstack 설치 |
 | [`DEVELOPMENT.md`](./DEVELOPMENT.md) | 스크립트·CI·대시보드 접근 env |
 | [`design/SYSTEM.md`](./design/SYSTEM.md) | 디자인 토큰·마케팅/앱 셸 |
@@ -99,6 +103,7 @@
 ## 8. 자동화 (버그·기능 요청도 동일 동작)
 
 - **Cursor**: `.cursor/rules/ai-session-bootstrap.mdc` (`alwaysApply: true`) — 구현·버그·기능 요청 시 **`memory-bank/tasks.md`·`activeContext.md`**를 도구로 읽고, **`docs/AI_ORCHESTRATION.md`** 레이어를 확인한 뒤 진행. 사용자가 템플릿을 쓰지 않아도 동작한다.
+- **명시 세션 시작 (선택)**: 프로젝트 스킬 **`.cursor/skills/elevate-memory-bank-bootstrap`** — “INIT 모드에서…” 장문 대신 스킬 지명으로 **INIT 산출 형식·L1–L4·다음 모드**를 한 턴에 고정. 팀 가이드: [`MEMORY_BANK_SKILL_GUIDE.md`](./MEMORY_BANK_SKILL_GUIDE.md).
 - **사용자 권장 형식** (재현·범위 명확화): [`AI_USER_TEMPLATES.md`](./AI_USER_TEMPLATES.md).
 - **전문가 기준·복붙 세션**: [`AI_EXPERT_PROMPTS.md`](./AI_EXPERT_PROMPTS.md).
 

--- a/docs/MEMORY_BANK_SKILL_GUIDE.md
+++ b/docs/MEMORY_BANK_SKILL_GUIDE.md
@@ -1,0 +1,73 @@
+# Memory Bank 부트스트랩 스킬 — 팀 가이드
+
+Elevate에서는 **같은 모델**을 써도 산출이 갈리는 이유를 **컨텍스트·세이프가드·하네스**로 줄이기 위해, Memory Bank와 Cursor 규칙을 표준으로 쌓아 두었다.  
+여기서는 **“INIT 모드에서 ~~해줘” 한 줄 프롬프트 대신**, 프로젝트 스킬 **`elevate-memory-bank-bootstrap`**으로 세션을 여는 방법을 정리한다.
+
+## 무엇이 바뀌나
+
+| 이전 습관 | 권장 |
+|-----------|------|
+| 매번 “INIT 모드에서 tasks 읽고…” 길게 적기 | 채팅에서 스킬을 **지명**해 한 번에 부트스트랩 |
+| 로그·환경값 통째로 붙여넣기 | **파일 경로**와 짧은 목표만 주고, 에이전트가 도구로 읽기 |
+| PLAN 없이 큰 기능 바로 구현 | `AGENTS.md` **L2+** 에서는 PLAN 생략 금지 (사용자 fast path 명시 시만 예외) |
+
+**자동 부트스트랩** (`.cursor/rules/ai-session-bootstrap.mdc`)은 구현·버그·기능 요청 시에도 `tasks` / `activeContext`를 읽는다. **이 스킬**은 그 위에 **INIT 산출물 형식·복잡도·다음 모드·영상에서 말하는 비용/훅 습관**을 한 블록으로 고정한다.
+
+## 스킬 호출 방법 (Cursor)
+
+1. 채팅 입력창에서 **Skills / @** 로 프로젝트 스킬 목록을 연다.  
+2. **`elevate-memory-bank-bootstrap`** (또는 표시 이름이 같으면 그걸) 선택한다.  
+3. 같은 메시지에 **목표 한 줄** + (있다면) **이슈 번호·브랜치·범위**만 덧붙인다.
+
+트리거 예시 (에이전트가 스킬을 고르기 쉬운 문구):
+
+- “`elevate-memory-bank-bootstrap` 켜고 오늘 할 일 시작”
+- “MB 시작 — #62 사이드바만”
+- “메모리뱅크 세션 부트스트랩 후 PLAN까지”
+
+스킬 메타데이터에 `disable-model-invocation: true`가 있어 **이름을 부르지 않으면** 자동으로 끼워 넣지 않는다. **의도적으로 켤 때** 쓰는 하네스다.
+
+## 에이전트가 하는 일 (요약)
+
+1. `memory-bank/tasks.md` → `activeContext.md` 순으로 읽는다.  
+2. INIT(VAN): 범위·파일 수·설계·DB 여부로 **L1–L4**를 선언한다.  
+3. `workflow-modes.mdc`에 있는 **INIT 완료** 블록 형식으로 답한다.  
+4. **다음 단계** (PLAN / BUILD 등)와 권장 Cursor 모드를 한 줄 제안한다.  
+5. 작업이 끝난 턴에는 `docs/AI_EXPERT_PROMPTS.md` **블록 A + B/C/D**를 규칙대로 붙인다.
+
+## 긴 디버그·세션 리셋
+
+같은 채팅 스레드에서 **디버그·재시도·부분 수정**이 길어지면, 이전 턴의 가설·거절된 패치·중복 로그가 컨텍스트에 남아 **판단이 흔들리기 쉽다**. 커뮤니티에서는 **사용자 메시지 기준 약 20턴**을 넘기면 새 스레드를 여는 것을 권장하는 경우가 많다([cursor-ai-tips](https://github.com/murataslan1/cursor-ai-tips) 등 큐레이션).
+
+**권장 절차:** (1) **새 채팅**을 연다. (2) `memory-bank/tasks.md`와 `activeContext.md`에서 **지금 목표·범위·다음 앵커만** 짧게 인용한다(전체 파일 붙여넣기 금지). (3) 맨 위에 [`docs/AI_EXPERT_PROMPTS.md`](./AI_EXPERT_PROMPTS.md) **블록 A**를 다시 넣어 역할·필수 읽기 파일을 고정한다. (4) 남은 작업은 **블록 B** 형태로 이어간다.
+
+이 패턴은 장기 에이전트 하네스에서 말하는 **세션 간 깨끗한 handoff·증분 진행**과 같은 축이다([Anthropic — Effective harnesses for long-running agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)).
+
+이 웨이브의 문서 SoT: [`docs/features/PLAN-ai-native-workflow-evolution-2026-05.md`](./features/PLAN-ai-native-workflow-evolution-2026-05.md) §4 P0.
+
+## 영상에서 말하는 것과의 연결 (학습 맥락)
+
+- **4단계 (AI-Aware → AI-Native)** — 우리 쪽에서는 “규칙·Memory Bank·verify를 **매번** 쓰는가”로 대응한다.  
+- **비용 패턴 (컨텍스트 비대, 거대 툴 출력 등)** — `docs/AI_ORCHESTRATION.md` §3: **경로로 읽기**, 불필요한 전문 붙여넣기 금지.  
+- **Hooks / 사고 예방** — 저장소 훅 + CI + **`pnpm verify`**; 키는 채팅에 넣지 않는다 (`AI_ORCHESTRATION.md` §6).  
+- **Codex 앱의 스킬·MCP·병렬** — Elevate는 **Cursor 스킬** + **MCP** + **Task 서브에이전트** + (선택) **gstack**으로 같은 축을 담는다.
+
+참고 링크 (팀 공유용):
+
+- [같은 Claude인데 5배 산출량 — 4단계·컨텍스트·훅](https://www.youtube.com/watch?v=ahGgv9lsWlU)  
+- [Codex 앱 입문 — 스킬·MCP·워크트리·관제탑](https://www.youtube.com/watch?v=ZkD6nE3JopY)
+
+## 관련 문서
+
+| 문서 | 용도 |
+|------|------|
+| [`AI_ORCHESTRATION.md`](./AI_ORCHESTRATION.md) | 레이어·프롬프트 계약·금지 사항 |
+| [`AI_USAGE.md`](./AI_USAGE.md) | 30초 체크리스트 |
+| [`AGENTS.md`](../AGENTS.md) | Operating model · L1–L4 · gstack 1~2개 규칙 |
+| [`.cursor/rules/workflow-modes.mdc`](../.cursor/rules/workflow-modes.mdc) | INIT 출력 형식·모드 전환 |
+| [`.cursor/skills/elevate-memory-bank-bootstrap/SKILL.md`](../.cursor/skills/elevate-memory-bank-bootstrap/SKILL.md) | 스킬 본문 (에이전트용) |
+
+## 유지보수
+
+- **워크플로 표나 INIT 형식을 바꿀 때**는 `workflow-modes.mdc` / `AGENTS.md`를 먼저 고치고, 스킬은 **중복 서술을 늘리지 말고** 링크만 맞춘다.  
+- 스킬의 `description`에 **트리거 문구**를 넣어 두면 Cursor가 스킬 선택을 잘한다.

--- a/docs/features/PLAN-ai-native-workflow-evolution-2026-05.md
+++ b/docs/features/PLAN-ai-native-workflow-evolution-2026-05.md
@@ -1,0 +1,165 @@
+# PLAN — AI-native 업무 방식 진화 (리서치 기준일: 2026-05-03)
+
+**목적:** 업계·커뮤니티·벤더 기술 블로그에서 확인되는 **2026년 초 기준** AI-assisted / agentic 개발 관행을 정리하고, Elevate의 **Memory Bank + Cursor + gstack** 스택과 비교해 **합리적·효율적인** 개선안을 **구현 준비(PLAN)** 수준으로 고정한다.  
+**범위:** 문서·규칙·스킬·훅·CI·팀 루틴. 코드베이스 대규모 리팩터는 포함하지 않는다.  
+**다음 단계:** 이 PLAN 승인 후 **BUILD**에서 우선순위(P0→P2)대로 이슈/PR로 쪼갠다.
+
+---
+
+## 1. 리서치 요약 (출처별)
+
+### 1.1 Anthropic — 하네스·장기 에이전트
+
+- [Effective harnesses for long-running agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents): **initializer vs coding** 역할 분리, 세션 간 **구조화된 산출물**(진행 로그, JSON 상태 등), **한 번에 한 기능** incremental, 끝날 때 **머지 가능한 깨끗한 상태**·커밋·요약.
+- [Harness design for long-running application development](https://www.anthropic.com/engineering/harness-design-long-running-apps): planner / generator / **evaluator**(MCP로 실제 클릭·검증), **스프린트 계약**(무엇이 done인지 합의) 등 고신뢰 하네스.
+- [Scaling Managed Agents](https://www.anthropic.com/engineering/managed-agents): **brain / hands / session** 분리, 세션 로그를 컨텍스트 밖 저장소로 — “메타 하네스” 관점.
+
+**Elevate 매핑:** `elevate-memory-bank-bootstrap` + `tasks`/`activeContext`/`progress` = initializer·handoff에 가깝다. **Evaluator** 축은 gstack `/qa`·`/browse`·`pnpm verify`·CI로 부분 충족.
+
+### 1.2 OpenAI Codex — 커스터마이징·스킬·OSS 사례
+
+- [Customization](https://developers.openai.com/codex/concepts/customization): **AGENTS.md**(작게) + **Skills**(반복 워크플로) + **MCP**(외부) + **서브에이전트** — 상호보완.
+- [Agent Skills](https://developers.openai.com/codex/skills): 메타데이터 우선 로드, **progressive disclosure**, 설명에 트리거·경계, repo는 **`.agents/skills`** 스캔 등.
+- [Using skills to accelerate OSS maintenance](https://developers.openai.com/blog/skills-agents-sdk): **if/then 필수 스킬**(`$implementation-strategy`, `$code-change-verification`, …), **Docs MCP**로 할루시네이션 감소, **Codex GitHub Action**으로 CI에 동일 하네스 이식.
+
+**Elevate 매핑:** 루트 `AGENTS.md` + `.cursor/rules` + gstack `.agents/skills` + 이미 추가한 **`.cursor/skills/elevate-memory-bank-bootstrap`**. **필수 스킬 라우팅 if/then**은 아직 Codex 수준으로 엄밀하진 않음 → **§4 P1**.
+
+### 1.3 Cursor — 규칙·스킬·에이전트 모범 사례
+
+- [Rules (AGENTS.md, .cursor/rules)](https://cursor.com/docs/context/rules): **Team → Project → User** 우선순위, **nested `AGENTS.md`**, glob·description으로 토큰 절약.
+- [Best practices for coding with agents](https://cursor.com/blog/agent-best-practices): Rules는 **짧게·핵심만**, 내용 **복붙보다 파일 참조**; Skills는 **동적** 워크플로; **`.cursor/plans/`**에 플랜 저장 팀 공유; **명시적 프롬프트**가 수용률↑; 룰은 **반복 실수 날 때만** 추가.
+
+**Elevate 매핑:** 이미 강한 규칙 세트·오케스트레이션 허브 존재. **리스크:** `alwaysApply: true` 룰이 많으면 상한에 근접할 수 있음 → **§4 P1 감사**.
+
+### 1.4 Stack Overflow — 설문(2025) 커뮤니티 현실
+
+- [AI 섹션 (2025 Developer Survey)](https://survey.stackoverflow.co/2025/ai/): 도구 도입은 넓으나 **정확도 신뢰 하락**, “거의 맞는데 아님” **좌절**, **에이전트는 아직 주류 아님**(단순 보조 모드 비중).
+- [SO Blog 요약 (2025-07)](https://stackoverflow.blog/2025/07/29/developers-remain-willing-but-reluctant-to-use-ai-the-2025-developer-survey-results-are-here/): 신뢰·검증·인간 전문성 강조.
+
+**시사:** 자동 생성물에 대한 **리뷰·검증 하네스**를 제품에 박는 것이 경쟁 우위. Elevate의 **`pnpm verify` + REFLECT + `/review`** 방향과 정합.
+
+### 1.5 보조: 업계 서베·커뮤니티 큐레이션 (비공식/3자 포함)
+
+- [Digital Applied — AI Coding Tool Adoption 2026 (Q1 2026 필드워크 주장)](https://www.digitalapplied.com/blog/ai-coding-tool-adoption-2026-developer-survey): “**리뷰**가 **작성**보다 주당 시간을 앞선다”는 등 **에이전트·비동기 PR** 확산 가설 — *제3자 자기보고이므로 수치는 참고용*.
+- Reddit·포럼 논의는 [murataslan1/cursor-ai-tips](https://github.com/murataslan1/cursor-ai-tips) 등 **큐레이션 저장소**에 집약: **긴 디버그는 새 채팅**, **Agent 전 방어적 커밋**, **한 대화에서 모델 혼선 금지**, **Research → Plan → Execute** 루프, **Context7 MCP** 등.
+
+**Elevate 매핑:** “새 채팅 + 요약”은 `AI_EXPERT_PROMPTS` handoff와 결합 가능. Context7은 이미 MCP 생태와 맞음 — **선택 P2**.
+
+### 1.6 국내 — 토스·앱인토스
+
+- [토스페이먼츠 MCP 서버 구현기](https://toss.tech/article/37777): 문서만 주면 **시크릿 키 클라이언트 노출·플로우 오류**; **MCP + Cursor**에서 **정확도·안전** 개선.
+- [앱인토스 AI 개발 가이드](https://developers-apps-in-toss.toss.im/development/llms.html): `llms.txt` / **MCP** / **@docs** 명시.
+
+**Elevate 매핑:** 결제·외부 API 작업 시 **공식 MCP·문서 도구** 우선 호출을 규칙에 한 줄 더 박기(§4 P1). (이미 PostHog 등 MCP 사용 중인 패턴 확장.)
+
+---
+
+## 2. Elevate 현황 (강점)
+
+| 축 | 상태 |
+|----|------|
+| 단일 오케스트레이션 허브 | [`docs/AI_ORCHESTRATION.md`](../AI_ORCHESTRATION.md), [`AGENTS.md`](../../AGENTS.md) Operating model |
+| 페이즈·복잡도 | `workflow-modes.mdc`, L1–L4, INIT→ARCHIVE |
+| 상태 SoT | `memory-bank/tasks.md`, `activeContext.md`, `progress.md` |
+| 세이프가드 | Husky, `commit-verification`, `pnpm verify`, CI, PostHog 규칙 |
+| 스킬 | gstack vendored + `elevate-memory-bank-bootstrap` + UI 스킬 |
+| 세션 부트스트랩 | `ai-session-bootstrap.mdc` (자동) + [MEMORY_BANK_SKILL_GUIDE.md](../MEMORY_BANK_SKILL_GUIDE.md) (명시) |
+
+---
+
+## 3. 갭 분석 (우리 vs “프런티어” 관행)
+
+| 관행 (외부) | 갭 | 비고 |
+|-------------|-----|------|
+| if/then **필수** 스킬 게이트 | 부분적 | gstack은 “권장”; Codex OSS처럼 **저장소 강제 문구**는 미약 |
+| **Evaluator** 루프 | 부분적 | `/qa`·브라우저는 선택; **모든 L2+ PR에 브라우저 스모크**는 비용 큼 |
+| **Nested AGENTS.md** | 없음 | 모노리포 수준은 아니나 `src/app` vs `src/components/marketing` 분리 시 이점 |
+| **장기 세션 오염** 대응 | 암묵적 | “20턴 이상 디버그 → 새 채팅” 문서화 부족 |
+| **Hooks (IDE)** | 미정 | Cursor Hooks로 **Agent 전 커밋 알림** 등 — Amazon 사고급은 아니나 **실수 방지**에 기여 가능 |
+| **플랜 아티팩트 공유** | 부분적 | Cursor `.cursor/plans/` 권장과 **팀 내 위치** 정렬 여지 |
+| **토큰 예산 (룰 팽창)** | 리스크 | alwaysApply 룰 **감사** 필요 |
+
+---
+
+## 4. 구현·수정 백로그 (BUILD 준비)
+
+우선순위는 **비용 대비 효과**와 **이미 스택과의 정합** 기준.
+
+### P0 — 문서·루틴만으로 즉시 (1 PR 이내)
+
+1. **`docs/MEMORY_BANK_SKILL_GUIDE.md`** 또는 **`docs/AI_EXPERT_PROMPTS.md`**에 **짧은 절** 추가:  
+   - 긴 디버그(예: **~20 메시지** 초과) 시 **새 채팅 + `tasks`/`activeContext` 인용 한 블록 요약** 후 계속.  
+   - 출처: 커뮤니티 큐레이션([cursor-ai-tips](https://github.com/murataslan1/cursor-ai-tips)) + Anthropic “깨끗한 handoff” 정신.
+2. **`docs/AI_ORCHESTRATION.md`** §3 옆에 **한 문단**: 외부 API·결제·PII 구역은 **MCP/공식 문서 도구 우선**(토스 사례).
+
+**수용 기준:** 위 두 곳 중 최소 한 곳에 반영, 링크로 이 PLAN 참조.
+
+**P0 구현 체크 (저장소, 문서 PR):**
+
+- [x] [`docs/MEMORY_BANK_SKILL_GUIDE.md`](../MEMORY_BANK_SKILL_GUIDE.md) — § 긴 디버그·세션 리셋
+- [x] [`docs/AI_EXPERT_PROMPTS.md`](../AI_EXPERT_PROMPTS.md) — §1b + MEMORY_BANK_SKILL_GUIDE 링크
+- [x] [`docs/AI_ORCHESTRATION.md`](../AI_ORCHESTRATION.md) — §3 외부 API·결제·MCP 우선 문단
+
+### P1 — 정책·구조 (1~3 PR)
+
+3. **`.cursor/rules` 감사 표**: 파일별 `alwaysApply` / glob / 줄 수 개요를 `docs/` 또는 `memory-bank/`에 **한 페이지**로 두고, **분할·축소 후보** 표시 ([Cursor agent best practices](https://cursor.com/blog/agent-best-practices)).
+4. **REFLECT 게이트 문구 표준화** (OpenAI OSS 패턴 차용):  
+   `AGENTS.md` 또는 `AI_ORCHESTRATION.md`에 **“코드·테스트·예제·빌드 터치 시 REFLECT 전 `pnpm verify`”** if/then을 더 명시적 문자열로 (이미 있으면 **중복 제거**만).
+5. **선택: nested `AGENTS.md` 파일 1~2개**  
+   예: `src/app/(dashboard)/AGENTS.md`, `src/app/[locale]/(marketing)/AGENTS.md` — **각 40줄 이하**, 루트 `AGENTS.md`로 링크만.
+
+**수용 기준:** 감사 문서 merge; verify 문구 중복 없이 강화; nested 파일은 팀 합의 후 추가(없으면 P2로 미룸).
+
+### P2 — 도구·자동화 (별도 이슈)
+
+6. **Cursor Hooks** ([create-hook 스킬](https://github.com/cursor) 경로는 로컬) — 예: Agent 시작 전 “working tree clean 또는 의도된 WIP” 알림. **보안·정책** 검토 후 적용.  
+7. **Context7 또는 공식 Docs MCP** — 새 외부 SDK 도입 시만 켜는 **문서 스킬** (토큰 비용 고려).  
+8. **Codex GitHub Action** 수준의 **CI 이중 하네스**는 비용·유지보수 큼 → **gstack + 기존 CI**로 충분한지 분기 판단 후 결정.
+
+---
+
+## 5. 성공 지표 (3개월 스냅샷 제안)
+
+- **리뷰/검증:** L2+ 기능 PR에 **REFLECT 증거**(리뷰 요약 또는 QA 로그 링크) 비율.
+- **회귀:** `main`에서 `pnpm verify` 실패 건수(주간).
+- **컨텍스트:** 에이전트 턴당 **불필요한 전문 로그 붙여넣기** 감소(정성 + 온콜 피드백).
+- **온보딩:** 신규 기여자가 **MEMORY_BANK_SKILL_GUIDE + 한 번의 스킬 호출**로 첫 PR까지 도달하는지 시간 측정(선택).
+
+---
+
+## 6. 리스크·주의
+
+- **서베·블로그 수치**는 자기보고·마케팅이 섞일 수 있음 — **저장소 내 측정**(CI, PR 템플릿, 시간)을 우선.
+- **룰·스킬 과다**는 오히려 라우팅 실패·토큰 낭비 — “추가 시 삭제 대상도 정한다”는 **정리 규칙**을 `archive-and-cleanup` 철학과 맞출 것.
+- **Reddit 단일 스레드**는 노이즈 큼 — **공식 문서 + SO 설문 + 벤더 엔지니어링 블로그**를 1차, 커뮤니티는 **검증된 큐레이션**만 2차로 사용한다(본 PLAN 방식).
+
+---
+
+## 7. 참고 링크 모음
+
+| 출처 | URL |
+|------|-----|
+| Anthropic long-running harness | https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents |
+| Anthropic harness design (evaluator 등) | https://www.anthropic.com/engineering/harness-design-long-running-apps |
+| Anthropic Managed Agents | https://www.anthropic.com/engineering/managed-agents |
+| OpenAI Codex customization | https://developers.openai.com/codex/concepts/customization |
+| OpenAI Codex skills | https://developers.openai.com/codex/skills |
+| OpenAI OSS + skills blog | https://developers.openai.com/blog/skills-agents-sdk |
+| Cursor rules | https://cursor.com/docs/context/rules |
+| Cursor agent best practices | https://cursor.com/blog/agent-best-practices |
+| Stack Overflow 2025 AI | https://survey.stackoverflow.co/2025/ai/ |
+| SO blog 2025-07 | https://stackoverflow.blog/2025/07/29/developers-remain-willing-but-reluctant-to-use-ai-the-2025-developer-survey-results-are-here/ |
+| Third-party 2026 adoption survey (참고) | https://www.digitalapplied.com/blog/ai-coding-tool-adoption-2026-developer-survey |
+| Reddit 큐레이션 (GitHub) | https://github.com/murataslan1/cursor-ai-tips |
+| 토스 MCP 구현기 | https://toss.tech/article/37777 |
+| 앱인토스 AI 가이드 | https://developers-apps-in-toss.toss.im/development/llms.html |
+
+---
+
+## 8. PLAN 승인 후 BUILD 순서 (권장)
+
+1. **P0** 문서 PR (가이드 + 오케스트레이션 소폭).  
+2. **P1** 룰 감사 표 + `AGENTS.md`/`AI_ORCHESTRATION` 정리 PR.  
+3. **P2** Hooks / Docs MCP / CI Codex — 별도 RFC 이슈.
+
+**PLAN 완료 정의:** 위 백로그가 이슈/PR로 쪼개졌고, `memory-bank/tasks.md`에 **에픽 한 줄**(선택)이 반영되면 된다.

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -18,6 +18,10 @@
 
 **Expert decision — `CONTENT_OPS_AUTOMATION_RUNTIME` missing in Vercel:** Unset env **equals `cursor`** in code (`automation-config.ts`). Vercel “no results” for the name is **implicit default**, not a different runtime. **P0 ops (no deploy code required):** add **`CONTENT_OPS_AUTOMATION_RUNTIME=cursor`** in Vercel Production so dashboards match RUNBOOK preflight and on-call mental model. **While `cursor`:** `vercel.json` crons that use `source=vercel-cron` **will skip** (`runtime_secret_mismatch`) — intentional cursor-first policy; PLAN may choose to trim cron noise or keep as dormant fallback.
 
+## PLAN — AI-native workflow evolution (2026-05-03)
+
+- **Epic (process, not product):** [`docs/features/PLAN-ai-native-workflow-evolution-2026-05.md`](../docs/features/PLAN-ai-native-workflow-evolution-2026-05.md) — 업계·SO·벤더·국내 MCP 사례 리서치 → Elevate 갭 → **P0–P2 BUILD 백로그**. **P0 문서 반영 완료(저장소). 다음: P1** — PLAN §4 P1(`.cursor/rules` 감사 표, REFLECT·verify if/then 정리, nested AGENTS 선택).
+
 ## PLAN backlog — first slice (order TBD in PLAN session)
 
 1. **Ops:** Vercel explicit `CONTENT_OPS_AUTOMATION_RUNTIME=cursor` + redeploy note in RUNBOOK (done in repo doc / `.env.local.example`; operator applies in dashboard).


### PR DESCRIPTION
## Summary

Implements PLAN §4 P0 from [`docs/features/PLAN-ai-native-workflow-evolution-2026-05.md`](docs/features/PLAN-ai-native-workflow-evolution-2026-05.md):

- **Long debug / session reset:** `docs/MEMORY_BANK_SKILL_GUIDE.md` + `docs/AI_EXPERT_PROMPTS.md` §1b (~20-turn guideline, new chat + Block A).
- **External API / payment / PII:** `docs/AI_ORCHESTRATION.md` §3 — prefer official docs MCP (Toss case study link).
- PLAN P0 implementation checklist; `memory-bank/tasks.md` epic points to P1 next.

## Verify

- `pnpm verify` (local) passed on branch.

Refs: docs/features/PLAN-ai-native-workflow-evolution-2026-05.md §4 P0

Made with [Cursor](https://cursor.com)