### PR TITLE
docs: P1 prep — cursor rules audit + verify gate (§2b)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ When creating blog content, use **`docs/templates/blog-authoring-templates.md`**
 | **INIT** | Ask / short Agent | Declared **L1–L4**, touched paths, SoT refs [`memory-bank/tasks.md`](memory-bank/tasks.md), [`memory-bank/activeContext.md`](memory-bank/activeContext.md) |
 | **PLAN** | **Plan** | Plan + risks + verification idea (in chat or linked notes); align with [`memory-bank/tasks.md`](memory-bank/tasks.md) |
 | **CREATIVE** | **Plan** | Decision logged [`memory-bank/creative-*.md`](memory-bank/), ADR, or `docs/features/…` as appropriate |
-| **BUILD** | **Agent** | Code + **`pnpm verify`** whenever the repo changes materially |
+| **BUILD** | **Agent** | Code + **`pnpm verify`** when material changes apply — gate: [`docs/AI_ORCHESTRATION.md`](docs/AI_ORCHESTRATION.md) **§2b** |
 | **REFLECT** | Ask / **Debug** | What shipped, gaps, follow-ups → [`memory-bank/progress.md`](memory-bank/progress.md) / `tasks.md` |
 | **ARCHIVE** | Agent | Durable summaries → [`memory-bank/archive/`](memory-bank/archive/) per `.cursor/rules/archive-and-cleanup.mdc` |
 

--- a/docs/AI_ORCHESTRATION.md
+++ b/docs/AI_ORCHESTRATION.md
@@ -30,6 +30,16 @@
 | PR 전 품질·리그레션 | **`/review`**; 브라우저 검증은 **`/qa`** 또는 **`/browse`** (설치 시) |
 | 출하 파이프라인 | **`/ship`** — 단, **이 저장소는 `pnpm verify`·커밋 규칙을 반드시 지킨다** (gstack 기본과 다를 수 있음) |
 
+### 2b. verify 게이트 (BUILD → REFLECT)
+
+**If** 아래 중 하나라도 해당하면 **then** “BUILD 완료”·REFLECT 시작·PR ready 선언 전에 **`pnpm verify`**를 통과시킨다(또는 팀이 합의한 **동등한 최소** 하위 집합: 예 lint+typecheck+관련 테스트만).
+
+- `src/**`, `tests/**`, `e2e/**`, `scripts/**`에서의 실행 코드·테스트·스냅샷 변경  
+- `package.json`, `pnpm-lock.yaml`, `next.config.*`, `vitest.config.*`, `tsconfig*.json`, `eslint.config.*`, CI 워크플로(`.github/**`) 변경  
+- **예외:** 순수 문서(`docs/**`만)·메모리뱅크 서술만·이 PR 가이드처럼 런타임에 영향 없는 마크다운만 바뀐 경우 — 그래도 팀이 요구하면 verify 유지.
+
+gstack **`/ship`** 등은 이 저장소의 **`pnpm verify`·훅을 대체하지 않는다.** 상세 표는 [`AGENTS.md`](../AGENTS.md) § Operating model.
+
 ---
 
 ## 3. 프롬프트 엔지니어링 계약 (에이전트에게 줄 맥락)
@@ -89,6 +99,7 @@
 | [`AI_USAGE.md`](./AI_USAGE.md) | 짧은 진입점 |
 | [`MEMORY_BANK_SKILL_GUIDE.md`](./MEMORY_BANK_SKILL_GUIDE.md) | `elevate-memory-bank-bootstrap` 스킬로 세션 시작 (팀 가이드) |
 | [`features/PLAN-ai-native-workflow-evolution-2026-05.md`](./features/PLAN-ai-native-workflow-evolution-2026-05.md) | 업계·커뮤니티·벤더 리서치 대비 갭·BUILD 백로그 (PLAN) |
+| [`CURSOR_RULES_AUDIT.md`](./CURSOR_RULES_AUDIT.md) | `.cursor/rules` 줄 수·alwaysApply·globs 스냅샷 + 분할 후보 (P1) |
 | [`GSTACK.md`](./GSTACK.md) | vendored gstack 설치 |
 | [`DEVELOPMENT.md`](./DEVELOPMENT.md) | 스크립트·CI·대시보드 접근 env |
 | [`design/SYSTEM.md`](./design/SYSTEM.md) | 디자인 토큰·마케팅/앱 셸 |

--- a/docs/AI_USAGE.md
+++ b/docs/AI_USAGE.md
@@ -13,7 +13,9 @@
 6. **PostHog 퍼널 (UI에서 구성)** — [`POSTHOG_FUNNELS.md`](./POSTHOG_FUNNELS.md)  
 7. **원격 이슈·PR 큐** — [`DEV_PROCESS_GITHUB.md`](./DEV_PROCESS_GITHUB.md) · `pnpm issues:studio`
 8. **Slack 없는 운영 자동화** — [`AUTOMATIONS_NO_SLACK_OPS.md`](./AUTOMATIONS_NO_SLACK_OPS.md)
-9. **전문가 의사결정·복붙 프롬프트** — [`AI_EXPERT_PROMPTS.md`](./AI_EXPERT_PROMPTS.md)
+9. **전문가 의사결정·복붙 프롬프트** — [`AI_EXPERT_PROMPTS.md`](./AI_EXPERT_PROMPTS.md)  
+10. **업계 대비 워크플로 PLAN (2026-05)** — [`features/PLAN-ai-native-workflow-evolution-2026-05.md`](./features/PLAN-ai-native-workflow-evolution-2026-05.md)  
+11. **Cursor 규칙 감사 (P1)** — [`CURSOR_RULES_AUDIT.md`](./CURSOR_RULES_AUDIT.md) · verify 게이트 [`AI_ORCHESTRATION.md`](./AI_ORCHESTRATION.md) §2b
 
 **자동**: 구현·버그·기능 요청은 `.cursor/rules/ai-session-bootstrap.mdc`가 위 컨텍스트를 로드한다.  
 **권장 입력 형식**: [`AI_USER_TEMPLATES.md`](./AI_USER_TEMPLATES.md) · **전문가 세션**: [`AI_EXPERT_PROMPTS.md`](./AI_EXPERT_PROMPTS.md) · **타 프로젝트 이식**: [`AI_WORKFLOW_PORTABILITY.md`](./AI_WORKFLOW_PORTABILITY.md).

--- a/docs/CURSOR_RULES_AUDIT.md
+++ b/docs/CURSOR_RULES_AUDIT.md
@@ -1,0 +1,57 @@
+# `.cursor/rules` 감사 표 (baseline)
+
+**목적:** [PLAN §4 P1 — AI-native workflow](features/PLAN-ai-native-workflow-evolution-2026-05.md) 항목 1. 토큰·중복 로드를 줄이기 위한 **스냅샷**. 분할·축소는 팀 판단 후 후속 PR로 진행한다.
+
+**갱신 방법:** 아래 표의 줄 수는 `wc -l .cursor/rules/*`로 재생성할 수 있다. `alwaysApply` / `globs`는 각 파일 YAML **첫 블록** 기준.
+
+## 규칙 파일 개요
+
+| 파일 | 줄 수 | alwaysApply | globs (요약) | 비고 |
+|------|------:|---------------|--------------|------|
+| [commit-verification.mdc](../.cursor/rules/commit-verification.mdc) | 12 | true | (비어 있음) | 커밋 게이트 — 유지 |
+| [posthog-integration.mdc](../.cursor/rules/posthog-integration.mdc) | 29 | true | (키만 있고 패턴 없음) | YAML `globs:` 값 없음 — 필요 시 `[]` 명시 권장 |
+| [completion-and-commit.mdc](../.cursor/rules/completion-and-commit.mdc) | 32 | false | (키만 있고 값 없음) | Agent-requested 성격 — YAML 정리 후보 |
+| [ai-session-bootstrap.mdc](../.cursor/rules/ai-session-bootstrap.mdc) | 43 | true | `[]` | 매 세션 부트스트랩 — 유지 |
+| [cursor-ai-context.mdc](../.cursor/rules/cursor-ai-context.mdc) | 48 | false | `[]` | 진입 링크 — 유지 |
+| [archive-and-cleanup.mdc](../.cursor/rules/archive-and-cleanup.mdc) | 58 | false | memory-bank, archive | 유지 |
+| [memory-bank-guide.mdc](../.cursor/rules/memory-bank-guide.mdc) | 61 | false | memory-bank | 유지 |
+| [sentry-logs.md](../.cursor/rules/sentry-logs.md) | 71 | — | (프론트매터 없음) | `.md` — glob/적용 방식은 Cursor 설정에 따름 |
+| [rust-first-architecture.mdc](../.cursor/rules/rust-first-architecture.mdc) | 97 | — | (프론트매터 없음) | 레거시 형식 — `alwaysApply`/`globs` 추가 검토 |
+| [debugging-commit-failures.md](../.cursor/rules/debugging-commit-failures.md) | 111 | — | (프론트매터 없음) | 수동 `@` 규칙으로 쓰는 패턴 가정 |
+| [auto-workflow.mdc](../.cursor/rules/auto-workflow.mdc) | 118 | true | `[]` | [workflow-modes.mdc](../.cursor/rules/workflow-modes.mdc)와 **역할 중복** 가능 — 축소·통합 후보 |
+| [rust-api-conventions.mdc](../.cursor/rules/rust-api-conventions.mdc) | 164 | — | (프론트매터 없음) | Rust 작업 시에만 — `.mdc` YAML 정리 후보 |
+| [dead-code-removal-guide.md](../.cursor/rules/dead-code-removal-guide.md) | 168 | — | — | 긴 가이드 — `@` 수동 |
+| [workflow-modes.mdc](../.cursor/rules/workflow-modes.mdc) | 169 | true | `[]` | MB 워크플로 SoT — 유지 |
+| [refactoring-guide.md](../.cursor/rules/refactoring-guide.md) | 319 | — | — | 분할 또는 에이전트 요청 전용 `.mdc` 전환 후보 |
+| [clean-architecture-tdd.md](../.cursor/rules/clean-architecture-tdd.md) | 510 | — | — | 대형 — `@` 또는 glob `tests/**` 부착 검토 |
+| [prd-adr-integration.mdc](../.cursor/rules/prd-adr-integration.mdc) | 786 | false | docs, memory-bank | **최대 용량** — 섹션별 파일 분할 또는 `description` 기반 로드만 강화 후보 |
+
+**합계(대략):** 약 2,800줄(마크다운 본문 포함). `alwaysApply: true`가 **동시에** 켜지는 파일: `commit-verification`, `posthog-integration`, `ai-session-bootstrap`, `auto-workflow`, `workflow-modes` (5개) — [Cursor agent best practices](https://cursor.com/blog/agent-best-practices)에 맞춰 **주기적으로** “정말 매 턴 필요한가”를 검토한다.
+
+## 분할·축소 후보 (우선순위)
+
+1. **prd-adr-integration.mdc** — IMPLEMENT/ADR 전용 섹션을 `docs/` 내 링크 타깃으로 쪼개고, 규칙 파일에는 목차+링크만 남기기.
+2. **auto-workflow.mdc vs workflow-modes.mdc** — 한쪽으로 통합하거나 `auto-workflow`를 `alwaysApply: false` + 강한 `description`으로 전환해 토큰 절약.
+3. **clean-architecture-tdd.md / refactoring-guide.md** — glob 부착 또는 수동 규칙으로 전환.
+4. **rust-*.mdc** — `apps/api/**` glob + 짧은 frontmatter 추가로 “Rust 터치할 때만” 자동 부착.
+
+## nested `AGENTS.md` (PLAN P1 항목 3)
+
+**상태:** 팀 합의 전 **스킵**. 도입 시 루트 [`AGENTS.md`](../AGENTS.md)에서 하위 파일로만 링크하고, 각 파일 **40줄 이하** 권장([Cursor nested AGENTS.md](https://cursor.com/docs/context/rules)).
+
+---
+
+## P1 에이전트/본인용 복붙 (다음 작업)
+
+아래를 새 채팅 맨 위에 붙여 P1 잔여를 이어간다.
+
+```text
+Elevate — P1 잔여 (PLAN §4 P1)
+
+main에 P0 머지 완료. 다음을 수행:
+1) docs/CURSOR_RULES_AUDIT.md의 분할·축소 후보를 검토하고, 승인된 항목만 PR로 반영한다.
+2) AI_ORCHESTRATION §2b verify 게이트가 팀 플로우와 맞는지 확인하고, 필요 시 AGENTS 표현만 다듬는다.
+3) nested AGENTS.md는 합의 후에만 추가한다.
+
+SoT: docs/features/PLAN-ai-native-workflow-evolution-2026-05.md §4 P1
+```

--- a/docs/features/PLAN-ai-native-workflow-evolution-2026-05.md
+++ b/docs/features/PLAN-ai-native-workflow-evolution-2026-05.md
@@ -102,6 +102,8 @@
 
 ### P1 — 정책·구조 (1~3 PR)
 
+**진행:** 베이스라인 감사 표 [`docs/CURSOR_RULES_AUDIT.md`](../CURSOR_RULES_AUDIT.md) · verify if/then은 [`docs/AI_ORCHESTRATION.md`](../AI_ORCHESTRATION.md) **§2b** + [`AGENTS.md`](../../AGENTS.md) BUILD 행.
+
 3. **`.cursor/rules` 감사 표**: 파일별 `alwaysApply` / glob / 줄 수 개요를 `docs/` 또는 `memory-bank/`에 **한 페이지**로 두고, **분할·축소 후보** 표시 ([Cursor agent best practices](https://cursor.com/blog/agent-best-practices)).
 4. **REFLECT 게이트 문구 표준화** (OpenAI OSS 패턴 차용):  
    `AGENTS.md` 또는 `AI_ORCHESTRATION.md`에 **“코드·테스트·예제·빌드 터치 시 REFLECT 전 `pnpm verify`”** if/then을 더 명시적 문자열로 (이미 있으면 **중복 제거**만).

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -20,7 +20,7 @@
 
 ## PLAN — AI-native workflow evolution (2026-05-03)
 
-- **Epic (process, not product):** [`docs/features/PLAN-ai-native-workflow-evolution-2026-05.md`](../docs/features/PLAN-ai-native-workflow-evolution-2026-05.md) — 업계·SO·벤더·국내 MCP 사례 리서치 → Elevate 갭 → **P0–P2 BUILD 백로그**. **P0 문서 반영 완료(저장소). 다음: P1** — PLAN §4 P1(`.cursor/rules` 감사 표, REFLECT·verify if/then 정리, nested AGENTS 선택).
+- **Epic (process, not product):** [`docs/features/PLAN-ai-native-workflow-evolution-2026-05.md`](../docs/features/PLAN-ai-native-workflow-evolution-2026-05.md) — **P0 main 머지 완료.** **P1 준비:** [`docs/CURSOR_RULES_AUDIT.md`](../docs/CURSOR_RULES_AUDIT.md) · verify 게이트 [`docs/AI_ORCHESTRATION.md`](../docs/AI_ORCHESTRATION.md) §2b · 잔여는 감사 표 하단 **복붙 블록** 또는 PLAN §4 P1.
 
 ## PLAN backlog — first slice (order TBD in PLAN session)
 


### PR DESCRIPTION
## Summary

Follow-up after P0 merge ([`docs/features/PLAN-ai-native-workflow-evolution-2026-05.md`](docs/features/PLAN-ai-native-workflow-evolution-2026-05.md) §4 P1).

1. **`.cursor/rules` audit:** [`docs/CURSOR_RULES_AUDIT.md`](docs/CURSOR_RULES_AUDIT.md) — line counts, `alwaysApply`, globs, shrink candidates, **P1 paste block** for next session.
2. **verify if/then:** [`docs/AI_ORCHESTRATION.md`](docs/AI_ORCHESTRATION.md) **§2b** (material changes → `pnpm verify` before REFLECT/ready). [`AGENTS.md`](AGENTS.md) BUILD row links here (dedupe narrative).
3. **nested AGENTS:** deferred in audit (team consensus).

## Verify

- `pnpm verify` passed locally.

Refs: PLAN-ai-native-workflow-evolution-2026-05.md §4 P1

Made with [Cursor](https://cursor.com)